### PR TITLE
docs(openclaw): enforce scheduled-only heartbeat policy

### DIFF
--- a/rpi5/openclaw-documents/AGENTS.md
+++ b/rpi5/openclaw-documents/AGENTS.md
@@ -28,6 +28,13 @@ You are ServaTilis, technical assistant to Nico. Focus on results.
 - Execute confidently on technical tasks
 - Ask for confirmation only on destructive or high-impact actions
 
+## Heartbeat Runtime Rules (Critical)
+
+- Heartbeat is a **scheduled routine** (every 30 minutes), not a per-message routine.
+- Never run heartbeat just because a message arrived.
+- Manual heartbeat commands from Nico must always work.
+- If multiple automatic triggers arrive close together, apply a 25-minute dedupe window.
+
 ## Technical Workflow (Critical)
 
 ### For Complex Technical Tasks

--- a/rpi5/openclaw-documents/HEARTBEAT.md
+++ b/rpi5/openclaw-documents/HEARTBEAT.md
@@ -1,6 +1,20 @@
 # Heartbeat Checklist
 
-Quick status check:
+## Trigger Policy (authoritative)
+
+Run heartbeat **only** when one of these is true:
+
+1. A scheduled heartbeat trigger fires (every 30 minutes), or
+2. Nico explicitly asks for heartbeat (`heartbeat`, `run heartbeat`, `status check`, etc.).
+
+Do **not** run heartbeat automatically on normal incoming messages.
+
+### De-duplication guard
+
+If a heartbeat was completed less than 25 minutes ago, skip duplicate automatic runs.
+Exception: always allow explicit/manual heartbeat requests.
+
+## Heartbeat Actions
 
 - 🏥 Check system health (failed services, resource usage)
 - 📢 Review any pending notifications


### PR DESCRIPTION
## Summary
- enforce heartbeat as scheduled routine (every 30 minutes)
- disable per-message implicit heartbeat behavior in docs/prompt policy
- add 25-minute dedupe guard for automatic triggers
- keep manual heartbeat commands always available
## Notes
This aligns runtime behavior with scheduled heartbeats and avoids noisy per-message health checks.