### PR TITLE
ci: enforce conventional commit messages with commitlint

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+set -eu
+
+if ! command -v pnpm >/dev/null 2>&1; then
+  echo "pnpm is required to run commitlint (install Node.js + pnpm)." >&2
+  exit 1
+fi
+
+pnpm dlx --quiet @commitlint/cli --config commitlint.config.cjs --edit "$1"

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,17 @@
+name: Commitlint
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+  push:
+    branches:
+      - main
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Lint commits
+        uses: wagoid/commitlint-github-action@v6
+        with:
+          configFile: commitlint.config.cjs

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -11,6 +11,9 @@ jobs:
   commitlint:
     runs-on: ubuntu-latest
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
       - name: Lint commits
         uses: wagoid/commitlint-github-action@v6
         with:

--- a/README.md
+++ b/README.md
@@ -114,6 +114,30 @@ Boot the Pi from the SD card, connect via SSH, then:
 sudo nixos-rebuild switch --flake 'path:.#rpi5'
 ```
 
+## Commit message linting
+
+This repository uses [commitlint](https://commitlint.js.org/) to enforce Conventional Commits.
+
+### One-time local setup (git hook)
+
+```sh
+git config core.hooksPath .githooks
+```
+
+### Run commitlint locally
+
+Validate a commit message file:
+
+```sh
+pnpm dlx @commitlint/cli --config commitlint.config.cjs --edit .git/COMMIT_EDITMSG
+```
+
+Validate the latest commit message:
+
+```sh
+git log -1 --pretty=%B | pnpm dlx @commitlint/cli --config commitlint.config.cjs
+```
+
 ## Apply updates
 
 Home Manager is integrated as a NixOS/Darwin module on all machines, so each command below deploys both system and user config in one step.

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,0 +1,12 @@
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'type-enum': [
+      2,
+      'always',
+      ['feat', 'fix', 'docs', 'refactor', 'chore', 'ci', 'test', 'perf', 'build', 'revert'],
+    ],
+    'subject-empty': [2, 'never'],
+    'header-max-length': [2, 'always', 100],
+  },
+};

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,11 +1,11 @@
 module.exports = {
-  extends: ['@commitlint/config-conventional'],
   rules: {
     'type-enum': [
       2,
       'always',
       ['feat', 'fix', 'docs', 'refactor', 'chore', 'ci', 'test', 'perf', 'build', 'revert'],
     ],
+    'type-empty': [2, 'never'],
     'subject-empty': [2, 'never'],
     'header-max-length': [2, 'always', 100],
   },


### PR DESCRIPTION
## Summary
- add  with conventional commit rules and header length limit
- add repo-managed  to lint local commit messages
- add GitHub Actions workflow to lint commits on pull requests and pushes to 
- document local hook setup and local commitlint usage in 

## Scope
Implements only plan items 1, 2, and 3.