### PR TITLE
Configure OpenClaw explicit heartbeat (30m, 6 AM - 11 PM)

### DIFF
--- a/rpi5/openclaw.nix
+++ b/rpi5/openclaw.nix
@@ -72,10 +72,10 @@
           };
           # Explicit heartbeat configuration (replaces OpenClaw's internal default)
           heartbeat = {
-            every = "30m";  # Every 30 minutes (current observed default)
+            every = "1h";   # Every 1 hour
             activeHours = {
-              start = "06:00";
-              end = "23:59";
+              start = "09:00";
+              end = "23:00";
               timezone = "Europe/Paris";
             };
             suppressToolErrorWarnings = true;

--- a/rpi5/openclaw.nix
+++ b/rpi5/openclaw.nix
@@ -70,6 +70,16 @@
               alias = "codex";
             };
           };
+          # Explicit heartbeat configuration (replaces OpenClaw's internal default)
+          heartbeat = {
+            every = "30m";  # Every 30 minutes (current observed default)
+            activeHours = {
+              start = "06:00";
+              end = "23:59";
+              timezone = "Europe/Paris";
+            };
+            suppressToolErrorWarnings = true;
+          };
         };
 
         channels.telegram = {

--- a/rpi5/openclaw.nix
+++ b/rpi5/openclaw.nix
@@ -70,15 +70,13 @@
               alias = "codex";
             };
           };
-          # Explicit heartbeat configuration (replaces OpenClaw's internal default)
           heartbeat = {
-            every = "1h";   # Every 1 hour
+            every = "1h";
             activeHours = {
               start = "09:00";
               end = "23:00";
               timezone = "Europe/Paris";
             };
-            suppressToolErrorWarnings = true;
           };
         };
 


### PR DESCRIPTION
## Changes

- Add explicit heartbeat configuration to replace OpenClaw internal defaults
- Interval: Every 30 minutes (matches current hardcoded behavior, now transparent)
- Active hours: 06:00-23:59 Paris timezone (no heartbeats during night hours)
- Suppress tool error warnings for cleaner heartbeat logs

## Why

Makes heartbeat behavior declarative in Nix instead of relying on OpenClaw's internal hardcoded defaults. Also prevents unnecessary health checks overnight.

## Testing

- Heartbeat config validated in openclaw.json
- Service restarted successfully
- Heartbeat check respects active hours