### PR TITLE
OpenClaw: enable classic subagent runtime alongside ACP

### DIFF
--- a/rpi5/openclaw/openclaw.nix
+++ b/rpi5/openclaw/openclaw.nix
@@ -98,6 +98,14 @@ in
           };
         };
 
+        # Enable classic subagent runtime alongside ACP runtime.
+        agents.list = [
+          {
+            id = "main";
+            default = true;
+          }
+        ];
+
         channels.telegram = {
           enabled = true;
           tokenFile = "/home/nsimon/.secrets/telegram-bot-token";
@@ -110,6 +118,7 @@ in
         tools.agentToAgent.enabled = true;
 
         acp = {
+          dispatch.enabled = true;
           defaultAgent = "cursor-agent";
           allowedAgents = [ "cursor-agent" "codex" ];
         };


### PR DESCRIPTION
## Summary
- keep ACP enabled ()
- add classic subagent runtime agent definitions ()
- allow  to spawn  and  via 

## Why
This restores old  behavior while keeping ACP available.

## Notes
- No secrets changed
- NixOS rebuild will be run after PR creation