### PR TITLE
rpi5: package blogwatcher declaratively with Nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -115,9 +115,6 @@
                   config.allowUnfree = true;
                 }).uv;
               })
-              (final: prev: {
-                blogwatcher = prev.callPackage ./shared/pkgs/blogwatcher.nix { };
-              })
               inputs.nix-openclaw.overlays.default
               # Redis cluster tests are flaky in the Nix sandbox
               (final: prev: {

--- a/flake.nix
+++ b/flake.nix
@@ -115,6 +115,9 @@
                   config.allowUnfree = true;
                 }).uv;
               })
+              (final: prev: {
+                blogwatcher = prev.callPackage ./shared/pkgs/blogwatcher.nix { };
+              })
               inputs.nix-openclaw.overlays.default
               # Redis cluster tests are flaky in the Nix sandbox
               (final: prev: {

--- a/rpi5/configuration.nix
+++ b/rpi5/configuration.nix
@@ -12,6 +12,7 @@
 }:
 let
   system = "aarch64-linux";
+  blogwatcherPkg = pkgs.callPackage ../shared/pkgs/blogwatcher.nix { };
 in
 {
   # Workaround for nixpkgs 25.11 rename.nix <-> nixos-raspberrypi conflict
@@ -118,7 +119,7 @@ in
     ethtool
     wakeonlan
     sqlite  # SQL database for structured data storage
-    blogwatcher
+    blogwatcherPkg
   ];
 
   virtualisation.docker.enable = true;

--- a/rpi5/configuration.nix
+++ b/rpi5/configuration.nix
@@ -118,8 +118,7 @@ in
     ethtool
     wakeonlan
     sqlite  # SQL database for structured data storage
-    go      # required for blogwatcher install/build
-    gcc     # required for Go cgo builds (blogwatcher)
+    blogwatcher
   ];
 
   virtualisation.docker.enable = true;

--- a/rpi5/openclaw/skills/blogwatcher/SKILL.md
+++ b/rpi5/openclaw/skills/blogwatcher/SKILL.md
@@ -2,15 +2,12 @@
 name: blogwatcher
 description: Monitor blogs and RSS/Atom feeds for updates using the blogwatcher CLI.
 homepage: https://github.com/Hyaxia/blogwatcher
-metadata: {"clawdbot":{"emoji":"📰","requires":{"bins":["blogwatcher"]},"install":[{"id":"go","kind":"go","module":"github.com/Hyaxia/blogwatcher/cmd/blogwatcher@latest","bins":["blogwatcher"],"label":"Install blogwatcher (go)"}]}}
+metadata: {"clawdbot":{"emoji":"📰","requires":{"bins":["blogwatcher"]}}}
 ---
 
 # blogwatcher
 
 Track blog and RSS/Atom feed updates with the `blogwatcher` CLI.
-
-Install
-- Go: `go install github.com/Hyaxia/blogwatcher/cmd/blogwatcher@latest`
 
 Quick start
 - `blogwatcher --help`

--- a/shared/pkgs/blogwatcher.nix
+++ b/shared/pkgs/blogwatcher.nix
@@ -1,0 +1,31 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "blogwatcher";
+  version = "0.0.2";
+
+  src = fetchFromGitHub {
+    owner = "Hyaxia";
+    repo = "blogwatcher";
+    rev = "v${version}";
+    hash = "sha256-O9CAEJoSr6fWeznKewvEIHqW6BZiz5LI7gIp6w2SnBc=";
+  };
+
+  subPackages = [ "cmd/blogwatcher" ];
+
+  vendorHash = "sha256-TfcMKlr/mdElYLf2zw9iNLJgGVJzMVg97jJm015ClTQ=";
+
+  ldflags = [
+    "-s"
+    "-w"
+    "-X main.version=${version}"
+  ];
+
+  meta = with lib; {
+    description = "Terminal-based RSS and Atom feed tracker";
+    homepage = "https://github.com/Hyaxia/blogwatcher";
+    license = licenses.mit;
+    maintainers = [ ];
+    mainProgram = "blogwatcher";
+  };
+}


### PR DESCRIPTION
## Summary
- add a reusable `shared/pkgs/blogwatcher.nix` package using `buildGoModule`
- expose package through the rpi5 nixpkgs overlay
- install `blogwatcher` via `environment.systemPackages` instead of manual Go toolchain install
- remove Go installer metadata from the OpenClaw blogwatcher skill docs

## Verification
- `nix build .#nixosConfigurations.rpi5.config.system.build.toplevel --no-link --impure`
- `nix build .#nixosConfigurations.rpi5.pkgs.blogwatcher --no-link --impure`

No `nixos-rebuild switch` was run.
