### PR TITLE
openclaw: copy bundled plugins to validated runtime path

### DIFF
--- a/rpi5/openclaw/openclaw.nix
+++ b/rpi5/openclaw/openclaw.nix
@@ -24,11 +24,30 @@ in
   systemd.user.services.openclaw-gateway.Service.ExecStartPre = [
     "${pkgs.coreutils}/bin/mkdir -p ${bundledExtensionsDir}"
     "${pkgs.coreutils}/bin/mkdir -p ${customAcpxDir}"
-    "${pkgs.bash}/bin/bash -eu -c 'if [ -d \"${bundledExtensionsSource}\" ]; then ${pkgs.rsync}/bin/rsync -a --delete \"${bundledExtensionsSource}/\" \"${bundledExtensionsDir}/\"; fi'"
+    "${pkgs.bash}/bin/bash -c '${pkgs.coreutils}/bin/chmod -R u+w \"${bundledExtensionsDir}\" 2>/dev/null || true'"
+    "${pkgs.coreutils}/bin/rm -rf ${bundledExtensionsDir}/acpx"
+    "${pkgs.bash}/bin/bash -eu -c 'if [ -d \"${bundledExtensionsSource}\" ]; then ${pkgs.rsync}/bin/rsync -aL --delete --chmod=Du+rwx,Dgo+rx,Fu+rw,Fgo+r --exclude \"acpx/\" \"${bundledExtensionsSource}/\" \"${bundledExtensionsDir}/\"; fi'"
     "${pkgs.bash}/bin/bash -eu -c 'if [ -d \"${customAcpxSource}\" ]; then ${pkgs.rsync}/bin/rsync -a --delete --chmod=Du+rwx,Dgo+rx,Fu+rw,Fgo+r \"${customAcpxSource}/\" \"${customAcpxDir}/\"; fi'"
     "${pkgs.coreutils}/bin/ln -sfn ${bundledNodeModulesSource} ${bundledNodeModulesLink}"
   ];
   systemd.user.services.openclaw-gateway.Install.WantedBy = [ "default.target" ];
+  home.sessionVariables = {
+    OPENCLAW_BUNDLED_PLUGINS_DIR = bundledExtensionsDir;
+  };
+  programs.zsh.sessionVariables = {
+    OPENCLAW_BUNDLED_PLUGINS_DIR = bundledExtensionsDir;
+  };
+  programs.zsh.envExtra = ''
+    export OPENCLAW_BUNDLED_PLUGINS_DIR="${bundledExtensionsDir}"
+  '';
+  home.activation.copyOpenClawBundledPlugins = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    ${pkgs.coreutils}/bin/mkdir -p ${bundledExtensionsDir}
+    ${pkgs.bash}/bin/bash -c '${pkgs.coreutils}/bin/chmod -R u+w "${bundledExtensionsDir}" 2>/dev/null || true'
+    ${pkgs.coreutils}/bin/rm -rf ${bundledExtensionsDir}/acpx || true
+    if [ -d "${bundledExtensionsSource}" ]; then
+      ${pkgs.rsync}/bin/rsync -aL --delete --chmod=Du+rwx,Dgo+rx,Fu+rw,Fgo+r --exclude "acpx/" "${bundledExtensionsSource}/" "${bundledExtensionsDir}/"
+    fi
+  '';
 
   programs.openclaw = {
     documents = ./documents;


### PR DESCRIPTION
## Summary
- Copy bundled OpenClaw plugins into `~/.openclaw/bundled-runtime/extensions` with symlinks dereferenced (`rsync -aL`) so plugin manifests are no longer loaded from `/nix/store` paths.
- Exclude bundled `acpx` and keep the runtime plugin tree writable/cleaned across service starts and Home Manager activation to avoid stale duplicate-plugin artifacts.
- Export `OPENCLAW_BUNDLED_PLUGINS_DIR` via Home Manager session vars so CLI commands can resolve the same runtime plugin directory as the gateway.

## Test plan
- [x] `sudo nixos-rebuild switch --flake 'path:.#rpi5' --impure`
- [x] `openclaw doctor` (default shell still showed old env until session vars are reloaded)
- [x] `unset __HM_SESS_VARS_SOURCED && . /etc/profiles/per-user/nsimon/etc/profile.d/hm-session-vars.sh && OPENCLAW_BUNDLED_PLUGINS_DIR="$OPENCLAW_BUNDLED_PLUGINS_DIR" openclaw doctor`

Made with [Cursor](https://cursor.com)