### PR TITLE
Add realtime OpenAPI documentation reference to Firefly III skill

### DIFF
--- a/rpi5/openclaw/skills/firefly-iii/SKILL.md
+++ b/rpi5/openclaw/skills/firefly-iii/SKILL.md
@@ -20,6 +20,23 @@ curl -s "$BASE/endpoint" \
   -H "Content-Type: application/json"
 ```
 
+## Realtime API Documentation (always check first)
+
+Before using less-common endpoints or fields, fetch and inspect the current OpenAPI spec:
+
+```bash
+DOC_URL="https://api-docs.firefly-iii.org/firefly-iii-6.5.1-v1.yaml"
+DOC_CACHE="/tmp/firefly-iii-openapi.yaml"
+
+curl -fsSL "$DOC_URL" -o "$DOC_CACHE"
+
+# Quick checks
+grep -n "^openapi:\|^info:\|^  version:" "$DOC_CACHE" | head -n 5
+grep -n "^  /transactions:\|^  /rules:\|^  /accounts:" "$DOC_CACHE"
+```
+
+When in doubt, prefer fields/endpoints confirmed in this spec over memory/examples.
+
 ## Core Endpoints
 
 ### Accounts


### PR DESCRIPTION
## Summary\nUpdates Firefly III skill to include direct reference to the live OpenAPI specification.\n\n## Changes\n- Added **Realtime API Documentation** section in SKILL.md\n- Provides direct link to OpenAPI v1 YAML spec\n- Includes quick-check commands to fetch and inspect the spec locally\n- Recommends checking spec first for less-common endpoints/fields\n\n## Benefits\n- Always up-to-date with latest Firefly III API\n- Reduces reliance on stale memory/examples\n- Enables self-service documentation lookup