### PR TITLE
Split pending nic-os changes by scope

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -109,11 +109,34 @@
           ({ inputs, ... }: {
             nixpkgs.overlays = [
               # uv 0.9.26 from release-25.11 fails to build on aarch64-linux; use nixpkgs-unstable
-              (final: prev: {
-                uv = (import inputs.nixpkgs-unstable {
+              (final: prev: rec {
+                unstablePkgs = import inputs.nixpkgs-unstable {
                   system = prev.stdenv.hostPlatform.system;
                   config.allowUnfree = true;
-                }).uv;
+                };
+                uv =
+                  unstablePkgs.uv;
+                # Keep Ghostfolio current to pick up Yahoo upstream fixes.
+                # Temporary pin to 2.247.0 until nixpkgs ships this version.
+                ghostfolio = unstablePkgs.ghostfolio.overrideAttrs (old: rec {
+                  version = "2.247.0";
+                  src = prev.fetchFromGitHub {
+                    owner = "ghostfolio";
+                    repo = "ghostfolio";
+                    tag = version;
+                    hash = "sha256-pUFrbPNyHis18Ta/p8DNfM0dz7R7ucGd981gleCFQyw=";
+                    leaveDotGit = true;
+                    postFetch = ''
+                      date -u -d "@$(git -C $out log -1 --pretty=%ct)" +%s%3N > $out/SOURCE_DATE_EPOCH
+                      find "$out" -name .git -print0 | xargs -0 rm -rf
+                    '';
+                  };
+                  npmDepsHash = "sha256-eDzoCT28gRhmHxRHKUXl2Gm0Rpso/R5SKaxCuFkZjS8=";
+                  npmDeps = prev.fetchNpmDeps {
+                    inherit src;
+                    hash = npmDepsHash;
+                  };
+                });
               })
               inputs.nix-openclaw.overlays.default
               # Redis cluster tests are flaky in the Nix sandbox

--- a/home/dotfiles/tmux.conf
+++ b/home/dotfiles/tmux.conf
@@ -9,6 +9,7 @@ bind-key C-k resize-pane -U
 bind-key C-h resize-pane -L
 bind-key C-l resize-pane -R
 
-# Fig Tmux Integration: Enabled
-source-file ~/.fig/tmux
-# End of Fig Tmux Integration
+# Pane borders
+set -g pane-border-lines heavy
+set -g pane-border-style fg=colour240
+set -g pane-active-border-style fg=colour39

--- a/home/packages.nix
+++ b/home/packages.nix
@@ -1,6 +1,7 @@
 {
   pkgs,
   masterpkgs,
+  unstablePkgs,
   lib,
   devSetup ? false,
   ...
@@ -19,7 +20,7 @@
       btop
       coreutils-full
       curl
-      claude-code
+      unstablePkgs.claude-code
       codex
       masterpkgs.cursor-cli
       ctop

--- a/macos/configuration.nix
+++ b/macos/configuration.nix
@@ -86,6 +86,10 @@
         system = "aarch64-darwin";
         config.allowUnfree = true;
       };
+      unstablePkgs = import inputs.nixpkgs-unstable {
+        system = "aarch64-darwin";
+        config.allowUnfree = true;
+      };
     };
     users.${username} = {
       imports = [

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -614,6 +614,10 @@ in
         system = "x86_64-linux";
         config.allowUnfree = true;
       };
+      unstablePkgs = import inputs.nixpkgs-unstable {
+        system = "x86_64-linux";
+        config.allowUnfree = true;
+      };
     };
     users.${username} = {
       imports = [

--- a/rpi5/blocky.nix
+++ b/rpi5/blocky.nix
@@ -49,6 +49,32 @@
           ];
         };
 
+        allowlists = {
+          # Keep Yahoo Finance provider reachable for Ghostfolio.
+          # These must be in active clientGroupsBlock groups so they
+          # override matching denylist entries.
+          ads = [
+            ''
+              fc.yahoo.com
+              finance.yahoo.com
+              query1.finance.yahoo.com
+              query2.finance.yahoo.com
+              guce.yahoo.com
+              consent.yahoo.com
+            ''
+          ];
+          threats = [
+            ''
+              fc.yahoo.com
+              finance.yahoo.com
+              query1.finance.yahoo.com
+              query2.finance.yahoo.com
+              guce.yahoo.com
+              consent.yahoo.com
+            ''
+          ];
+        };
+
         # Apply all denylist groups to every client on the network
         clientGroupsBlock = {
           default = [ "ads" "threats" ];

--- a/rpi5/configuration.nix
+++ b/rpi5/configuration.nix
@@ -258,7 +258,7 @@ in
         openclawSource
         ;
       devSetup = false;
-      unstablepkgs = import inputs.nixpkgs-unstable {
+      unstablePkgs = import inputs.nixpkgs-unstable {
         inherit system;
         config.allowUnfree = true;
       };

--- a/rpi5/ghostfolio.nix
+++ b/rpi5/ghostfolio.nix
@@ -59,6 +59,8 @@ in
         PORT = toString cfg.port;
         DATABASE_URL = "postgresql://ghostfolio@localhost/ghostfolio?host=/run/postgresql";
         # Ghostfolio-specific env vars
+        # Reduce Yahoo Finance request pressure to avoid 429 throttling.
+        CACHE_QUOTES_TTL = "900000"; # 15 minutes in milliseconds
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1";
       };
 

--- a/rpi5/openclaw/openclaw.nix
+++ b/rpi5/openclaw/openclaw.nix
@@ -114,6 +114,11 @@ in
               end = "23:00";
               timezone = "Europe/Paris";
             };
+            # Explicit Telegram delivery target for visible heartbeat reports.
+            target = "telegram";
+            to = "82389391";
+            accountId = "default";
+            directPolicy = "allow";
           };
         };
 


### PR DESCRIPTION
## Summary
- standardize  wiring and switch  to unstable package
- improve Ghostfolio Yahoo reliability (Blocky allowlist + Ghostfolio pin/cache TTL)
- set explicit OpenClaw heartbeat Telegram delivery target
- update tmux local config (remove Fig integration, add pane borders)

## Notes
-  intentionally excluded (local permissions file).