### PR TITLE
fix: enable --impure flag for nixos-upgrade service

### DIFF
--- a/rpi5/configuration.nix
+++ b/rpi5/configuration.nix
@@ -103,6 +103,8 @@ in
   system.autoUpgrade = {
     enable = true;
     flake = "github:nSimonFR/nic-os#rpi5";
+    # Required because flake outputs reference a local path source for OpenClaw skills.
+    flags = [ "--impure" ];
     dates = "04:00";
     randomizedDelaySec = "30min";
     allowReboot = true;


### PR DESCRIPTION
**Problem:**
The automatic NixOS upgrade service was consistently failing with:
```
error: cannot call 'getFlake' on unlocked flake reference 'path:/home/nsimon/nic-os'
```

**Root Cause:**
The flake outputs reference a local path source (`nClawSkillsSource = "path:/home/nsimon/nic-os"`) for OpenClaw skills. When `nixos-upgrade.service` runs, it builds the configuration from the remote GitHub URL in pure evaluation mode. Pure mode cannot resolve local path references.

**Solution:**
Add the `--impure` flag to `system.autoUpgrade.flags` to allow the upgrade to resolve local paths during evaluation.

**Testing:**
✅ Service now runs successfully with impure evaluation enabled
✅ Flake evaluates and builds correctly with local path sources