### PR TITLE
feat: enable Claude Code in ACP allowedAgents policy

### DIFF
--- a/rpi5/openclaw/openclaw.nix
+++ b/rpi5/openclaw/openclaw.nix
@@ -144,7 +144,7 @@ in
         acp = {
           dispatch.enabled = true;
           defaultAgent = "cursor-agent";
-          allowedAgents = [ "cursor-agent" "codex" ];
+          allowedAgents = [ "cursor-agent" "codex" "claude" ];
         };
 
         plugins.load.paths = [ customAcpxDir ];


### PR DESCRIPTION
**What:**
Adds 'claude' to the ACP allowedAgents configuration, enabling Claude Code to be used through the OpenClaw ACP (Agent Control Protocol) harness.

**Why:**
Previously only cursor-agent and codex were in the allowlist. This change extends ACP support to include Claude Code as an available coding harness option.

**Related:**
- OpenClaw ACP routing via SKILL.md (acp-router)
- ACP harness: `claude-agent-acp`

**Testing:**
After merge and rebuild, Claude Code should be available as an allowed ACP agent in openclaw-gateway policy.