### PR TITLE
chore(security): remove default password + tighten Tailscale serve exposure

### DIFF
--- a/rpi5/configuration.nix
+++ b/rpi5/configuration.nix
@@ -58,7 +58,6 @@ in
 
   users.users.${username} = {
     isNormalUser = true;
-    initialPassword = "changeme";
     extraGroups = [
       "wheel"
       "video"
@@ -209,8 +208,7 @@ in
     let
       serveServices = [
         { port = 443; name = "openclaw"; localPort = 18789; }
-        { port = 8443; name = "blocky"; localPort = 4000; }
-        { port = 8444; name = "ghostfolio"; localPort = 3333; }
+        { port = 3333; name = "ghostfolio"; localPort = 3333; }
       ];
       
       serveCommands = lib.concatMapStringsSep "\n    " (service:


### PR DESCRIPTION
## Summary
This PR applies requested hardening changes on rpi5:

1. Removes `initialPassword = "changeme";` from `users.users.${username}`
2. Removes Blocky tailnet exposure (`8443 -> 4000`) from Tailscale Serve
3. Moves Ghostfolio serve endpoint from `8444` to base port `3333`

## Rationale
- Avoids keeping a known bootstrap password in versioned config
- Reduces exposed services on tailnet
- Aligns Ghostfolio external port with service base port

## Scope
- Config-only change in `rpi5/configuration.nix`
- No rebuild performed in this PR