### PR TITLE
feat(Tobii): native Linux Eye Tracker 5 support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -76,6 +76,22 @@
       }
     },
     "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_3": {
       "locked": {
         "lastModified": 1767039857,
         "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
@@ -134,11 +150,11 @@
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
-        "lastModified": 1769996383,
-        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
+        "lastModified": 1772408722,
+        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
+        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
         "type": "github"
       },
       "original": {
@@ -182,6 +198,51 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nix-gaming",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1772893680,
+        "narHash": "sha256-JDqZMgxUTCq85ObSaFw0HhE+lvdOre1lx9iI6vYyOEs=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "8baab586afc9c9b57645a734c820e4ac0a604af9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-gaming",
+          "git-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
         "type": "github"
       }
     },
@@ -253,7 +314,9 @@
     "nix-citizen": {
       "inputs": {
         "flake-parts": "flake-parts_2",
-        "nix-gaming": "nix-gaming",
+        "nix-gaming": [
+          "nix-gaming"
+        ],
         "nix-github-actions": "nix-github-actions",
         "nixpkgs": [
           "nixpkgs-unstable"
@@ -278,17 +341,15 @@
     "nix-gaming": {
       "inputs": {
         "flake-parts": "flake-parts_3",
-        "nixpkgs": [
-          "nix-citizen",
-          "nixpkgs"
-        ]
+        "git-hooks": "git-hooks",
+        "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1772073295,
-        "narHash": "sha256-0FrC4ioaSDfhk9t8BcUBRTOyvOYpuZXGgqEBAKeyGIs=",
+        "lastModified": 1773196297,
+        "narHash": "sha256-3cTCid9mn1VwqZwxoIjh7NKlUhnsNZUuEn++AAjaWsk=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "e461a786602af544bd3e872faf5296b34011d2c9",
+        "rev": "283b7757411109bec421885dca788984c423d4af",
         "type": "github"
       },
       "original": {
@@ -343,7 +404,7 @@
     },
     "nix-steipete-tools": {
       "inputs": {
-        "nixpkgs": "nixpkgs_5"
+        "nixpkgs": "nixpkgs_6"
       },
       "locked": {
         "lastModified": 1772109967,
@@ -388,7 +449,7 @@
     "nixos-raspberrypi": {
       "inputs": {
         "argononed": "argononed",
-        "flake-compat": "flake-compat_2",
+        "flake-compat": "flake-compat_3",
         "nixos-images": "nixos-images",
         "nixpkgs": [
           "nixpkgs"
@@ -442,11 +503,11 @@
     },
     "nixpkgs-lib_2": {
       "locked": {
-        "lastModified": 1769909678,
-        "narHash": "sha256-cBEymOf4/o3FD5AZnzC3J9hLbiZ+QDT/KDuyHXVJOpM=",
+        "lastModified": 1772328832,
+        "narHash": "sha256-e+/T/pmEkLP6BHhYjx6GmwP5ivonQQn0bJdH9YrRB+Q=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "72716169fe93074c333e8d0173151350670b824c",
+        "rev": "c185c7a5e5dd8f9add5b2f8ebeff00888b070742",
         "type": "github"
       },
       "original": {
@@ -537,6 +598,22 @@
     },
     "nixpkgs_5": {
       "locked": {
+        "lastModified": 1772736753,
+        "narHash": "sha256-au/m3+EuBLoSzWUCb64a/MZq6QUtOV8oC0D9tY2scPQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "917fec990948658ef1ccd07cef2a1ef060786846",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_6": {
+      "locked": {
         "lastModified": 1767364772,
         "narHash": "sha256-fFUnEYMla8b7UKjijLnMe+oVFOz6HjijGGNS1l7dYaQ=",
         "owner": "NixOS",
@@ -551,7 +628,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_6": {
+    "nixpkgs_7": {
       "locked": {
         "lastModified": 1772808134,
         "narHash": "sha256-o0b3WQZ5S8Vy7JFXC0sl13bogdMawrTfFQtH0GxLZ5M=",
@@ -589,9 +666,10 @@
         "home-manager": "home-manager",
         "mac-app-util": "mac-app-util",
         "nix-citizen": "nix-citizen",
+        "nix-gaming": "nix-gaming",
         "nix-openclaw": "nix-openclaw",
         "nixos-raspberrypi": "nixos-raspberrypi",
-        "nixpkgs": "nixpkgs_6",
+        "nixpkgs": "nixpkgs_7",
         "nixpkgs-master": "nixpkgs-master",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "openclaw-source": "openclaw-source",

--- a/flake.nix
+++ b/flake.nix
@@ -27,9 +27,12 @@
       inputs.home-manager.follows = "home-manager";
     };
 
+    nix-gaming.url = "github:fufexan/nix-gaming";
+
     nix-citizen = {
       url = "github:LovingMelody/nix-citizen";
       inputs.nixpkgs.follows = "nixpkgs-unstable";
+      inputs.nix-gaming.follows = "nix-gaming";
     };
 
     nix-openclaw = {

--- a/home/dotfiles/gitconfig
+++ b/home/dotfiles/gitconfig
@@ -1,7 +1,7 @@
 [include]
   path = ~/.config/git/config-shared
 [user]
-  email = nsimon+ai@pm.me
+  email = 13413730+nSimonFR@users.noreply.github.com
   name = nSimonFR-ai
 [core]
   sshCommand = ssh -i ~/.ssh/ai_id_ed25519 -o IdentityAgent=none

--- a/home/dotfiles/zsh/evals.zsh
+++ b/home/dotfiles/zsh/evals.zsh
@@ -1,2 +1,8 @@
 (( $+commands[atuin] )) && eval "$(atuin init zsh)"
-(( $+commands[zoxide] )) && eval "$(zoxide init zsh)" && alias cd="z"
+# Initialize zoxide but only alias cd in truly interactive shells
+# This prevents errors in Claude Code and other non-interactive contexts
+if (( $+commands[zoxide] )); then
+  eval "$(zoxide init zsh)"
+  # Only alias cd to z in interactive shells with a tty
+  [[ -o interactive ]] && [[ -t 0 ]] && alias cd="z"
+fi

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -31,6 +31,7 @@ in
     ./hyperion-openrgb.nix # Hyperion with OpenRGB support
     ./hyperion-openrgb-bridge.nix # Bridge between Hyperion and OpenRGB
     ./piper-autoprofile.nix
+    ./tobii-native.nix # Tobii Eye Tracker 5 native Linux (experimental)
     # Tailscale client configuration
     (import ../shared/tailscale.nix { role = "client"; enableSSH = true; })
   ];
@@ -497,7 +498,7 @@ in
       SUBSYSTEM=="usb", ATTRS{idVendor}=="0b05", TAG+="uaccess"
       SUBSYSTEM=="usb", ATTRS{idVendor}=="046d", TAG+="uaccess"
 
-      # Tobii Eye Tracker 5 - VM USB passthrough with autosuspend disabled
+      # Tobii Eye Tracker 5 - Native Linux + VM passthrough with autosuspend disabled
       # Disable power management to ensure stable passthrough and adequate power delivery
       ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="2104", ATTR{idProduct}=="0313", ATTR{power/control}="on", ATTR{power/autosuspend}="-1", MODE="0666", TAG+="uaccess"
     '';

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -30,6 +30,7 @@ in
     ./openrgb-lg.nix # OpenRGB with LG monitor support
     ./hyperion-openrgb.nix # Hyperion with OpenRGB support
     ./hyperion-openrgb-bridge.nix # Bridge between Hyperion and OpenRGB
+    ./piper-autoprofile.nix
     # Tailscale client configuration
     (import ../shared/tailscale.nix { role = "client"; enableSSH = true; })
   ];
@@ -153,6 +154,8 @@ in
     libvirt # virsh CLI for VM management
     ntfs3g
     opentrack # Head tracking for Tobii VM passthrough
+    piper # GUI for Logitech G502 configuration (DPI, buttons, RGB)
+    input-remapper # Remap keys/mouse buttons for games
     usbutils
     ethtool # verify WoL status: ethtool eno1 | grep Wake
     vim
@@ -590,6 +593,9 @@ in
 
   hardware.bluetooth.enable = true;
   services.blueman.enable = true;
+
+  # Required for Piper (mouse configuration GUI)
+  services.ratbagd.enable = true;
 
   system.stateVersion = "25.11"; # DO NOT UPDATE UNLESS YOU KNOW WHAT YOU'RE DOING
 

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -11,33 +11,6 @@ let
   # Toggle between LightDM (true) and ReGreet (false)
   useLightdm = false;
 
-  hyprlandWrapper = pkgs.writeShellScriptBin "hyprland-nvidia" ''
-    # NVIDIA-specific environment variables for Wayland
-    export LIBVA_DRIVER_NAME=nvidia
-    export GBM_BACKEND=nvidia-drm
-    export __GLX_VENDOR_LIBRARY_NAME=nvidia
-    export WLR_NO_HARDWARE_CURSORS=1
-
-    # Additional NVIDIA Wayland fixes
-    export __GL_GSYNC_ALLOWED=1
-    export __GL_VRR_ALLOWED=1
-
-    # Run Hyprland
-    exec ${pkgs.hyprland}/bin/Hyprland "$@"
-  '';
-
-  hyprlandSession =
-    (pkgs.writeTextDir "share/wayland-sessions/hyprland.desktop" ''
-      [Desktop Entry]
-      Name=Hyprland
-      Description=A dynamic tiling Wayland compositor
-      Exec=${hyprlandWrapper}/bin/hyprland-nvidia
-      Type=Application
-    '').overrideAttrs
-      (old: {
-        passthru.providedSessions = [ "hyprland" ];
-      });
-
   i3Session =
     (pkgs.writeTextDir "share/xsessions/i3.desktop" ''
       [Desktop Entry]
@@ -75,6 +48,8 @@ in
       "mem_sleep_default=s2idle"
       "nvidia.NVreg_PreserveVideoMemoryAllocations=0"
       "nvidia.NVreg_EnableGpuSuspend=1"
+      "nvidia.NVreg_RegistryDwords=RMGpuTdr=0x7FFFFFFF" # Disable GPU TDR timeout (Star Citizen pipeline rebuild)
+      "nvidia.NVreg_EnableGpuFirmware=0" # Disable GSP firmware (fixes Vulkan pipeline compile timeouts)
       "nvidia-drm.modeset=1" # CRITICAL: Required for NVIDIA on Wayland/Xwayland
       "nvidia-drm.fbdev=1" # Enable framebuffer device support
       "acpi_enforce_resources=lax" # Fix OpenRGB I2C/SMBus detection bug (GitLab issue #5059)
@@ -151,6 +126,8 @@ in
       "input"
       "seat" # Required for Wayland seat management
       "i2c" # Required for OpenRGB monitor control
+      "libvirtd" # VM management
+      "kvm" # KVM acceleration
     ];
     home = "/home/${username}";
 
@@ -173,7 +150,9 @@ in
     i3status
     kdePackages.kwallet
     kdePackages.kwalletmanager
+    libvirt # virsh CLI for VM management
     ntfs3g
+    opentrack # Head tracking for Tobii VM passthrough
     usbutils
     ethtool # verify WoL status: ethtool eno1 | grep Wake
     vim
@@ -204,6 +183,8 @@ in
 
   services.flatpak.enable = true;
   
+  programs.hyprland.enable = true;
+
   xdg.portal = {
     enable = true;
     extraPortals = [
@@ -250,8 +231,8 @@ in
   };
 
   hardware.nvidia = {
-    open = true;
-    package = config.boot.kernelPackages.nvidiaPackages.latest;
+    open = false; # Proprietary modules: open modules have Vulkan pipeline compilation timeout bug (Xid 109)
+    package = config.boot.kernelPackages.nvidiaPackages.production; # 580.119.02 — 590.x has Vulkan pipeline timeout
 
     modesetting.enable = true;
     nvidiaSettings = true;
@@ -351,7 +332,6 @@ in
   };
 
   services.displayManager.sessionPackages = [
-    hyprlandSession
     i3Session
   ];
 
@@ -499,6 +479,10 @@ in
       SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", TAG+="uaccess"
       SUBSYSTEM=="usb", ATTRS{idVendor}=="0b05", TAG+="uaccess"
       SUBSYSTEM=="usb", ATTRS{idVendor}=="046d", TAG+="uaccess"
+
+      # Tobii Eye Tracker 5 - VM USB passthrough with autosuspend disabled
+      # Disable power management to ensure stable passthrough and adequate power delivery
+      ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="2104", ATTR{idProduct}=="0313", ATTR{power/control}="on", ATTR{power/autosuspend}="-1", MODE="0666", TAG+="uaccess"
     '';
 
     packages = [ pkgs.game-devices-udev-rules ];
@@ -514,16 +498,23 @@ in
       }
     ];
     allowedUDPPortRanges = allowedTCPPortRanges;
+    allowedUDPPorts = [ 4242 ]; # opentrack UDP from Tobii VM
   };
 
   virtualisation.docker = {
     enable = true;
-    autoPrune = {
-      enable = true;
-      dates = "weekly";
-      flags = [ "--all" ];
+  };
+
+  # Libvirt/QEMU for Tobii Eye Tracker VM passthrough
+  virtualisation.libvirtd = {
+    enable = true;
+    qemu = {
+      swtpm.enable = true; # TPM emulation for Windows 11
+      vhostUserPackages = [ pkgs.virtiofsd ]; # Required for virtiofs
     };
   };
+  virtualisation.spiceUSBRedirection.enable = true;
+  programs.virt-manager.enable = true;
 
   # Ollama - local LLM inference with CUDA (RTX 3080 Ti)
   # services.ollama = {

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -441,6 +441,20 @@ in
     ];
   };
 
+  fileSystems."/mnt/media" = {
+    device = "/dev/disk/by-label/Media\\x20HDD";
+    fsType = "ntfs3";
+    options = [
+      "uid=1000"
+      "gid=100"
+      "umask=0000"
+      "force"
+      "nofail"
+      "x-systemd.automount"
+      "noauto"
+    ];
+  };
+
   # Disk swap disabled - using zram only for better performance
   swapDevices = [ ];
 

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -221,6 +221,11 @@ in
         return polkit.Result.AUTH_SELF_KEEP;
       }
     });
+    polkit.addRule(function(action, subject) {
+      if (action.id.indexOf("com.feralinteractive.GameMode") === 0 && subject.isInGroup("users")) {
+        return polkit.Result.YES;
+      }
+    });
   '';
 
   # 1Password GUI with proper polkit integration
@@ -390,6 +395,14 @@ in
     settings = {
       general = {
         renice = 10;
+        desiredgov = "performance";
+        softrealtime = "auto";
+        ioprio = 0;
+      };
+      gpu = {
+        apply_gpu_optimisations = "accept-responsibility";
+        gpu_device = 1;
+        nv_powermizer_mode = 1;
       };
       custom = {
         start = "${pkgs.libnotify}/bin/notify-send 'GameMode started'";

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -78,11 +78,18 @@ in
       "nvidia-drm.modeset=1" # CRITICAL: Required for NVIDIA on Wayland/Xwayland
       "nvidia-drm.fbdev=1" # Enable framebuffer device support
       "acpi_enforce_resources=lax" # Fix OpenRGB I2C/SMBus detection bug (GitLab issue #5059)
+      "zswap.enabled=0" # Disable zswap when using zram (Star Citizen optimization)
     ];
 
     kernel.sysctl = {
       "vm.max_map_count" = 16777216;
       "fs.file-max" = 524288;
+      "vm.swappiness" = 100; # Use zram more aggressively
+      "vm.dirty_ratio" = 5; # Cap dirty pages at ~1.6GB (was 6.4GB) to avoid write bursts on DRAM-less NVMe
+      "vm.dirty_background_ratio" = 2; # Start flushing at ~640MB (was 3.2GB)
+      "vm.dirty_expire_centisecs" = 1500; # Flush dirty pages after 15s (was 30s)
+      "vm.dirty_writeback_centisecs" = 300; # Check for dirty pages every 3s (was 5s)
+      "vm.min_free_kbytes" = 262144; # Keep 256MB free to prevent emergency reclaim I/O storms
     };
 
     kernelModules = [
@@ -172,6 +179,8 @@ in
     vim
     vulkan-tools
     vulkan-loader
+    vulkan-validation-layers
+    dxvk
     wayland
     wayland-protocols
     wget
@@ -206,7 +215,17 @@ in
       "gtk"
     ];
   };
-  programs.nix-ld.enable = true;
+  programs.nix-ld = {
+    enable = true;
+    # Enable 32-bit support for pressure-vessel/Steam runtime
+    libraries = with pkgs; [
+      # 32-bit libraries for Steam/Proton/pressure-vessel
+      pkgsi686Linux.glibc
+    ];
+  };
+
+  # Symlink 32-bit dynamic linker for pressure-vessel compatibility
+  environment.etc."ld-linux.so.2".source = "${pkgs.pkgsi686Linux.glibc}/lib/ld-linux.so.2";
 
   security.polkit.enable = true;
 
@@ -433,26 +452,19 @@ in
     device = "/dev/disk/by-label/Games-Linux";
     fsType = "ext4";
     options = [
-      "uid=1000"
-      "gid=100"
-      "umask=0000"
-      "force"
       "nofail"
       "x-systemd.automount"
       "noauto"
     ];
   };
 
-  swapDevices = [
-    {
-      device = "/var/lib/swapfile";
-      size = 8 * 1024; # 8 GB Swap
-    }
-  ];
+  # Disk swap disabled - using zram only for better performance
+  swapDevices = [ ];
 
   zramSwap = {
     enable = true;
-    memoryMax = 16 * 1024 * 1024 * 1024; # 16 GB ZRAM
+    memoryPercent = 100; # 32GB zram = ~64-96GB effective with compression
+    algorithm = "zstd"; # Best compression ratio for Star Citizen
   };
 
   services.udev = {
@@ -464,6 +476,10 @@ in
 
       # DualSense controller
       KERNEL=="hidraw*", ATTRS{idVendor}=="054c", ATTRS{idProduct}=="0ce6", MODE="0666", TAG+="uaccess"
+
+      # VKB devices for Star Citizen
+      # Covers all VKB-Sim devices (Gladiator EVO L SEM, Gladiator EVO R, etc.)
+      KERNEL=="hidraw*", ATTRS{idVendor}=="231d", ATTRS{idProduct}=="*", MODE="0660", TAG+="uaccess"
 
       # OpenRGB USB HID device access for RGB keyboards/mice/devices
       # Drevo Calibur RGB Keyboard
@@ -608,7 +624,7 @@ in
   nix.gc = {
     automatic = true;
     dates = "weekly";
-    options = "--delete-older-than 5d";
+    options = "--delete-older-than 30d";
   };
 
   # Limit journal size to 200MB

--- a/nixos/piper-autoprofile.nix
+++ b/nixos/piper-autoprofile.nix
@@ -1,0 +1,59 @@
+{ pkgs, lib, ... }:
+
+let
+  # ============================================
+  # CONFIGURE HERE
+  # ============================================
+  device = "bellowing-paca";  # ratbagctl device name
+
+  defaultProfile = 1;
+
+  # Window class pattern -> profile number
+  profiles = {
+    "starcitizen" = 2;
+  };
+  # ============================================
+
+  # Generate bash case patterns from the profiles attrset
+  profilePatterns = lib.concatStringsSep "\n" (
+    lib.mapAttrsToList (pattern: profile: ''
+      *"${pattern}"*) ${pkgs.libratbag}/bin/ratbagctl "${device}" profile active set ${toString profile} ;;'')
+    profiles
+  );
+
+  # Generate grep patterns for checking if any game is running
+  checkPatterns = lib.concatStringsSep " -e " (lib.attrNames profiles);
+
+  script = pkgs.writeShellScript "piper-autoprofile" ''
+    switch_if_needed() {
+      ${pkgs.hyprland}/bin/hyprctl clients -j | ${pkgs.gnugrep}/bin/grep -qi -e ${checkPatterns} && return
+      ${pkgs.libratbag}/bin/ratbagctl "${device}" profile active set ${toString defaultProfile}
+    }
+
+    ${pkgs.socat}/bin/socat -U - UNIX-CONNECT:$XDG_RUNTIME_DIR/hypr/$HYPRLAND_INSTANCE_SIGNATURE/.socket2.sock | while read -r line; do
+      case $line in
+        openwindow*)
+          case $line in
+            ${profilePatterns}
+          esac
+          ;;
+        closewindow*)
+          switch_if_needed
+          ;;
+      esac
+    done
+  '';
+
+in
+{
+  systemd.user.services.piper-autoprofile = {
+    description = "Auto-switch Piper mouse profiles for games";
+    wantedBy = [ "hyprland-session.target" ];
+    after = [ "hyprland-session.target" ];
+    serviceConfig = {
+      ExecStart = script;
+      Restart = "on-failure";
+      RestartSec = 5;
+    };
+  };
+}

--- a/nixos/tobii-native.nix
+++ b/nixos/tobii-native.nix
@@ -1,0 +1,223 @@
+# Tobii Eye Tracker 5 — Native Linux support
+# Experimental: head pose (pitch/yaw) doesn't work yet, only gaze position.
+# Repackaged from Arch packages at https://github.com/megagtrwrath/tobii_eye_tracker_linux_installer
+# VM passthrough config is kept alongside in configuration.nix.
+{ pkgs, lib, ... }:
+
+let
+  # ── tobii-stream-engine ──────────────────────────────────────────────
+  # Shared library + headers for the Tobii Stream Engine API
+  tobii-stream-engine = pkgs.stdenv.mkDerivation {
+    pname = "tobii-stream-engine";
+    version = "4.24.0";
+
+    src = pkgs.fetchurl {
+      url = "https://raw.githubusercontent.com/megagtrwrath/tobii_eye_tracker_linux_installer/master/tobii-stream-engine-4.24.0-linux-x86_64.tar.gz";
+      hash = "sha256-dItQCNLAkau14zL/dvpifynWrNc8HIVRM0O4+oFY6zA=";
+    };
+
+    nativeBuildInputs = [ pkgs.autoPatchelfHook ];
+    buildInputs = [
+      pkgs.stdenv.cc.cc.lib
+      pkgs.avahi # libavahi-client, libavahi-common
+    ];
+
+    sourceRoot = "tobii-stream-engine-4.24.0";
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/lib $out/include/tobii
+      cp lib/libtobii_stream_engine.so $out/lib/
+      cp include/tobii/*.h $out/include/tobii/
+      runHook postInstall
+    '';
+  };
+
+  # ── tobii-engine ─────────────────────────────────────────────────────
+  # Main Tobii Engine daemon (face tracking, calibration, firmware)
+  tobii-engine = pkgs.stdenv.mkDerivation {
+    pname = "tobii-engine";
+    version = "0.1.6.193rc";
+
+    src = pkgs.fetchurl {
+      url = "https://github.com/megagtrwrath/tobii_eye_tracker_linux_installer/releases/download/v1/tobii_engine_linux-0.1.6.193rc-1-x86_64.pkg.tar.zst";
+      hash = "sha256-duCqFXZk7grNIsRK/4vu4EAkCZAmkYtcUrk8pKh9QcE=";
+    };
+
+    nativeBuildInputs = [ pkgs.autoPatchelfHook pkgs.zstd ];
+    buildInputs = [
+      pkgs.stdenv.cc.cc.lib # libstdc++
+      pkgs.zlib             # libz
+      pkgs.sqlcipher        # libsqlcipher
+      pkgs.libgcc           # libgomp (via libseeta)
+    ];
+
+    unpackPhase = ''
+      tar xf $src
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/share
+      cp -r usr/share/tobii_engine $out/share/tobii_engine
+
+      # Add bundled libs to rpath so self-referential deps resolve
+      addAutoPatchelfSearchPath $out/share/tobii_engine/lib
+      addAutoPatchelfSearchPath $out/share/tobii_engine/platform_modules
+      runHook postInstall
+    '';
+  };
+
+  # ── tobii-usb-service ────────────────────────────────────────────────
+  # USB communication daemon for Tobii hardware
+  tobii-usb-service = pkgs.stdenv.mkDerivation {
+    pname = "tobii-usb-service";
+    version = "2.1.5";
+
+    src = pkgs.fetchurl {
+      url = "https://github.com/megagtrwrath/tobii_eye_tracker_linux_installer/releases/download/v1/tobiiusbservice-2.1.5-1-x86_64.pkg.tar.zst";
+      hash = "sha256-+QLdjfJ7oLCAU66R49KHHU/drhXRUlBYRmjLpCYlmnk=";
+    };
+
+    nativeBuildInputs = [ pkgs.autoPatchelfHook pkgs.zstd ];
+    buildInputs = [
+      pkgs.systemd # libudev
+    ];
+
+    unpackPhase = ''
+      tar xf $src
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/bin $out/lib
+      cp usr/bin/tobiiusbserviced $out/bin/
+      cp usr/local/lib/tobiiusb/*.so $out/lib/
+
+      # Bundled libs reference each other
+      addAutoPatchelfSearchPath $out/lib
+      runHook postInstall
+    '';
+  };
+
+  # ── tobii-pro-eye-tracker-manager ────────────────────────────────────
+  # Electron calibration/configuration app
+  tobii-pro-eye-tracker-manager = pkgs.stdenv.mkDerivation {
+    pname = "tobii-pro-eye-tracker-manager";
+    version = "2.6.1";
+
+    src = pkgs.fetchurl {
+      url = "https://github.com/megagtrwrath/tobii_eye_tracker_linux_installer/releases/download/v1/tobiiproeyetrackermanager-2.6.1-1-x86_64.pkg.tar.zst";
+      hash = "sha256-IiDsq1GFKEQQCmwev9I0sJgRvqgJm5M1oNvG1dIU7ys=";
+    };
+
+    nativeBuildInputs = [
+      pkgs.autoPatchelfHook
+      pkgs.makeWrapper
+      pkgs.zstd
+    ];
+
+    buildInputs = with pkgs; [
+      alsa-lib
+      at-spi2-atk
+      cairo
+      cups
+      dbus
+      expat
+      gdk-pixbuf
+      glib
+      gtk3
+      libdrm
+      libxkbcommon
+      mesa
+      nspr
+      nss
+      pango
+      systemd        # libudev
+      xorg.libX11
+      xorg.libXcomposite
+      xorg.libXdamage
+      xorg.libXext
+      xorg.libXfixes
+      xorg.libXrandr
+      xorg.libxcb
+    ];
+
+    runtimeDependencies = [
+      pkgs.systemd   # libudev at runtime
+    ];
+
+    unpackPhase = ''
+      tar xf $src
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/opt $out/bin $out/share
+
+      cp -r opt/TobiiProEyeTrackerManager $out/opt/TobiiProEyeTrackerManager
+
+      # Desktop file and icon
+      if [ -d usr/share/applications ]; then
+        cp -r usr/share/applications $out/share/
+      fi
+      if [ -d usr/share/icons ]; then
+        cp -r usr/share/icons $out/share/
+      fi
+
+      # Wrapper with --no-sandbox (required for Electron without suid chrome-sandbox)
+      makeWrapper $out/opt/TobiiProEyeTrackerManager/tobiiproeyetrackermanager $out/bin/tobii-pro-eye-tracker-manager \
+        --add-flags "--no-sandbox"
+
+      runHook postInstall
+    '';
+  };
+
+  # ── opentrack-tobii ──────────────────────────────────────────────────
+  # OpenTrack AppImage build with Tobii input plugin
+  opentrack-tobii = pkgs.appimageTools.wrapType2 {
+    pname = "opentrack-tobii";
+    version = "2026.1.0";
+
+    src = pkgs.fetchurl {
+      url = "https://github.com/megagtrwrath/opentrack-appimage-ci/releases/download/opentrack-2026.1.0-20260312-072213Z/OpenTrack-TOBII-2026.1.0-x86_64.AppImage";
+      hash = "sha256-1h/W3NMMrNiBHD3dlebIdjfFf3tALsCexIAlB6E7mK8=";
+    };
+  };
+
+in
+{
+  # Make packages available
+  environment.systemPackages = [
+    tobii-stream-engine
+    tobii-pro-eye-tracker-manager
+    opentrack-tobii
+  ];
+
+  # ── Systemd services ────────────────────────────────────────────────
+  systemd.services.tobii-engine = {
+    description = "Tobii Engine Service";
+    after = [ "network.target" ];
+    wantedBy = [ "graphical.target" ];
+
+    serviceConfig = {
+      Type = "simple";
+      ExecStart = "${tobii-engine}/share/tobii_engine/tobii_engine --daemonize";
+      Restart = "on-abort";
+    };
+  };
+
+  systemd.services.tobii-usb = {
+    description = "Tobii USB Service";
+    requires = [ "tobii-engine.service" ];
+    after = [ "tobii-engine.service" ];
+    wantedBy = [ "graphical.target" ];
+
+    serviceConfig = {
+      Type = "forking";
+      ExecStartPre = "${pkgs.coreutils}/bin/mkdir -p /var/run/tobiiusb";
+      ExecStart = "${tobii-usb-service}/bin/tobiiusbserviced";
+      Restart = "on-failure";
+    };
+  };
+}

--- a/nixos/tobii-native.nix
+++ b/nixos/tobii-native.nix
@@ -174,7 +174,7 @@ let
   };
 
   # ── opentrack-tobii ──────────────────────────────────────────────────
-  # OpenTrack AppImage build with Tobii input plugin
+  # OpenTrack AppImage with Tobii input plugin (for Tobii → UDP relay)
   opentrack-tobii = pkgs.appimageTools.wrapType2 {
     pname = "opentrack-tobii";
     version = "2026.1.0";
@@ -185,13 +185,73 @@ let
     };
   };
 
+  # ── opentrack-sc ─────────────────────────────────────────────────────
+  # Star Citizen fork of opentrack with UMU/Proton Wine prefix fixes
+  # https://github.com/Priton-CE/opentrack-StarCitizen (wine-extended-proton branch)
+  opentrack-sc = let
+    aruco = pkgs.callPackage
+      "${pkgs.path}/pkgs/by-name/op/opentrack/aruco.nix" {};
+    xplaneSdk = pkgs.fetchzip {
+      url = "https://developer.x-plane.com/wp-content/plugins/code-sample-generation/sdk_zip_files/XPSDK411.zip";
+      hash = "sha256-zay5QrHJctllVFl+JhlyTDzH68h5UoxncEt+TpW3UgI=";
+    };
+  in pkgs.stdenv.mkDerivation {
+    pname = "opentrack-sc";
+    version = "2024.1.1-sc";
+
+    src = pkgs.fetchFromGitHub {
+      owner = "Priton-CE";
+      repo = "opentrack-StarCitizen";
+      rev = "4dd97af0f139f3ddc8f34a24ee961a1046015d3f";
+      hash = "sha256-xN4Z1Cpmj8ktqWCQYPZTfqznHrYe28qlKkPoQxHRPJ8=";
+    };
+
+    strictDeps = true;
+
+    nativeBuildInputs = [
+      pkgs.cmake
+      pkgs.ninja
+      pkgs.pkg-config
+      pkgs.libsForQt5.wrapQtAppsHook
+      pkgs.wineWowPackages.stable
+    ];
+
+    buildInputs = [
+      aruco
+      pkgs.eigen
+      pkgs.xorg.libXdmcp
+      pkgs.libevdev
+      pkgs.onnxruntime
+      pkgs.opencv4
+      pkgs.procps
+      pkgs.libsForQt5.qtbase
+      pkgs.libsForQt5.qttools
+    ];
+
+    cmakeFlags = [
+      (lib.cmakeBool "SDK_WINE" true)
+      (lib.cmakeFeature "SDK_ARUCO_LIBPATH" "${aruco}/lib/libaruco.a")
+      (lib.cmakeFeature "SDK_XPLANE" xplaneSdk.outPath)
+    ];
+
+    postInstall = ''
+      install -Dt $out/share/icons/hicolor/256x256 $src/gui/images/opentrack.png
+    '';
+
+    dontWrapQtApps = true;
+    preFixup = ''
+      wrapQtApp $out/bin/opentrack
+    '';
+  };
+
 in
 {
   # Make packages available
   environment.systemPackages = [
     tobii-stream-engine
     tobii-pro-eye-tracker-manager
-    opentrack-tobii
+    opentrack-tobii  # Tobii input → UDP relay
+    opentrack-sc     # UDP input → Wine/Proton output to SC
   ];
 
   # ── Systemd services ────────────────────────────────────────────────

--- a/nixos/tobii-native.nix
+++ b/nixos/tobii-native.nix
@@ -202,7 +202,25 @@ in
 
     serviceConfig = {
       Type = "simple";
-      ExecStart = "${tobii-engine}/share/tobii_engine/tobii_engine --daemonize";
+      StateDirectory = "tobii_engine";
+      ExecStartPre = pkgs.writeShellScript "tobii-engine-setup" ''
+        # Copy engine files to writable state dir so config.db can be written
+        src="${tobii-engine}/share/tobii_engine"
+        dst="/var/lib/tobii_engine"
+        # Only copy if not already populated (preserve calibration data)
+        if [ ! -f "$dst/tobii_engine" ]; then
+          ${pkgs.coreutils}/bin/cp -r "$src"/* "$dst"/
+          ${pkgs.coreutils}/bin/chmod -R u+w "$dst"
+        else
+          # Always update binary + libs from store (new derivation version)
+          ${pkgs.coreutils}/bin/cp -f "$src/tobii_engine" "$dst/"
+          ${pkgs.coreutils}/bin/cp -rf "$src/lib" "$dst/"
+          ${pkgs.coreutils}/bin/cp -rf "$src/platform_modules" "$dst/"
+          ${pkgs.coreutils}/bin/chmod -R u+w "$dst"
+        fi
+      '';
+      ExecStart = "/var/lib/tobii_engine/tobii_engine --daemonize";
+      WorkingDirectory = "/var/lib/tobii_engine";
       Restart = "on-abort";
     };
   };


### PR DESCRIPTION
## Summary
- Add `nixos/tobii-native.nix` with 5 repackaged Arch derivations (tobii-stream-engine, tobii-engine, tobii-usb-service, tobii-pro-eye-tracker-manager, opentrack-tobii AppImage)
- Add 2 systemd services (tobii-engine, tobii-usb) for the Tobii daemon stack
- Fix git agent email to use GitHub noreply (GH007 privacy protection)
- Fix zoxide cd alias to only apply in interactive shells with a tty

Experimental: head pose (pitch/yaw) doesn't work yet — only gaze position — but this sets up the infrastructure. Existing VM passthrough config kept alongside.

## Test plan
- [x] `nixos-rebuild build` succeeds
- [ ] `nixos-rebuild switch` — deploy and verify services start
- [ ] `systemctl status tobii-engine tobii-usb`
- [ ] `tobii-pro-eye-tracker-manager` — calibration UI launches
- [ ] `opentrack-tobii` — AppImage launches with Tobii input option

🤖 Generated with [Claude Code](https://claude.com/claude-code)