### PR TITLE
Feature(Scrutiny): disk health monitoring with Telegram notifications

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -635,11 +635,11 @@
     },
     "nixpkgs-master": {
       "locked": {
-        "lastModified": 1774180670,
-        "narHash": "sha256-IEyLS7UnVaVDUWhXTMAA9jgYJ/fKF5fLIy7mzY9/De4=",
+        "lastModified": 1774192030,
+        "narHash": "sha256-YjbupgcKJZ7lmaZe22Rn68jmKz+dZLYieoAIPbsAkmI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ef3f92866e2372ad5015cc6219531ea8c3cb5194",
+        "rev": "8a70e5ad159e2e2a16f0ad1f23aa57d99772326d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -110,7 +110,7 @@
 
       nixosConfigurations.${rpiconfig} = inputs.nixos-raspberrypi.lib.nixosSystem {
         specialArgs = {
-          inherit inputs outputs username;
+          inherit inputs outputs username telegramChatId;
           hostname = rpiconfig;
           nixos-raspberrypi = inputs.nixos-raspberrypi;
         };

--- a/rpi5/configuration.nix
+++ b/rpi5/configuration.nix
@@ -113,6 +113,7 @@ in
     ./tailscale-serve.nix
     ./blocky.nix
     ./ghostfolio.nix
+    ./scrutiny.nix
     # Tailscale with server features (subnet routing, SSH, exit node)
     (import ../shared/tailscale.nix {
       role = "server";

--- a/rpi5/scrutiny.nix
+++ b/rpi5/scrutiny.nix
@@ -3,7 +3,7 @@
 {
   services.scrutiny = {
     enable = true;
-    influxdb.enable = true;
+    influxdb.enable = false; # v0.8.1 uses SQLite for metrics; InfluxDB is legacy
 
     settings = {
       web.listen = {

--- a/rpi5/scrutiny.nix
+++ b/rpi5/scrutiny.nix
@@ -3,7 +3,7 @@
 {
   services.scrutiny = {
     enable = true;
-    influxdb.enable = false; # v0.8.1 uses SQLite for metrics; InfluxDB is legacy
+    influxdb.enable = true;
 
     settings = {
       web.listen = {

--- a/rpi5/scrutiny.nix
+++ b/rpi5/scrutiny.nix
@@ -1,0 +1,41 @@
+{ config, lib, pkgs, telegramChatId, ... }:
+
+{
+  services.scrutiny = {
+    enable = true;
+    influxdb.enable = true;
+
+    settings = {
+      web.listen = {
+        port = 9090;
+        host = "127.0.0.1";
+      };
+
+      # Telegram notification URL assembled at runtime; see ExecStartPre below.
+      notify.urls = [
+        { _secret = "/run/scrutiny/telegram-url"; }
+      ];
+    };
+
+    collector = {
+      enable = true;
+      # Collect SMART data once per day; timer is persistent (catches missed runs).
+      schedule = "daily";
+    };
+  };
+
+  # Compose the Telegram notification URL at runtime from the existing bot token secret
+  # and the inline chat ID (not sensitive). This privileged ExecStartPre (+) runs as root
+  # before the module's own preStart (which processes _secret substitutions), so the
+  # telegram-url file is ready when genJqSecretsReplacementSnippet reads it.
+  systemd.services.scrutiny.serviceConfig.ExecStartPre = lib.mkBefore [
+    ("+${pkgs.writeShellScript "scrutiny-compose-telegram-url" ''
+      token=$(< ${config.age.secrets.telegram-bot-token.path})
+      printf 'telegram://%s@telegram?channels=${toString telegramChatId}\n' "$token" \
+        > /run/scrutiny/telegram-url
+      # 644 is safe: /run/scrutiny/ is mode 0700 owned by the DynamicUser,
+      # so no other unprivileged process can traverse into it.
+      chmod 644 /run/scrutiny/telegram-url
+    ''}")
+  ];
+}

--- a/rpi5/tailscale-serve.nix
+++ b/rpi5/tailscale-serve.nix
@@ -6,6 +6,7 @@ let
     { port = 8080;  backend = "http://127.0.0.1:8080";  } # nginx portal (firefly)
     { port = 8123;  backend = "http://127.0.0.1:8123";  } # home-assistant
     { port = 13333; backend = "http://127.0.0.1:13333"; } # ghostfolio
+    { port = 9090;  backend = "http://127.0.0.1:9090";  } # scrutiny (disk health)
   ];
 
   # Publicly-accessible services (tailscale funnel).


### PR DESCRIPTION
## Summary

- Adds `rpi5/scrutiny.nix`: Scrutiny SMART monitoring on `127.0.0.1:9090` with bundled InfluxDB, daily collector, and Telegram alerts
- Exposes the UI via Tailscale Serve (port 9090) in `tailscale-serve.nix`
- Telegram notification URL composed at runtime: privileged `ExecStartPre` reads the existing `telegram-bot-token` agenix secret and injects `telegramChatId` from `specialArgs` — no secrets or IDs hardcoded
- Adds `telegramChatId` to the rpi5 NixOS `specialArgs` in `flake.nix`
- Bumps `nixpkgs-master` to fix a narHash mismatch under Nix 2.31.2

## Test plan

- [x] `services.scrutiny.enable` evaluates cleanly
- [x] `scrutiny.service`, `influxdb2.service`, `scrutiny-collector.timer`, `smartd.service` all start
- [x] `POST /api/health/notify` returns `{"success":true}` and Telegram message received
- [x] `GET /api/summary` returns disk data (HP SSD EX900 250GB, 35°C, status healthy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)