### PR TITLE
Feat(RPI5): add Immich self-hosted photo server

### DIFF
--- a/rpi5/configuration.nix
+++ b/rpi5/configuration.nix
@@ -117,6 +117,7 @@ in
     ./monitoring
     ./storj.nix
     ./filebrowser.nix
+    ./immich.nix
     # Tailscale with server features (subnet routing, SSH, exit node)
     (import ../shared/tailscale.nix {
       role = "server";

--- a/rpi5/immich.nix
+++ b/rpi5/immich.nix
@@ -5,9 +5,7 @@
     port          = 2283;
     # host defaults to 127.0.0.1 — Tailscale Serve owns TLS termination
     mediaLocation = "/var/lib/immich";
-    settings = {
-      machineLearning.enabled = false;  # saves ~3-7 GB RAM
-    };
+    machine-learning.enable = false;  # disable the systemd unit, not just the runtime config flag
   };
 
   # Ensure Immich starts after /mnt/cloud is loop-mounted (external library path)

--- a/rpi5/immich.nix
+++ b/rpi5/immich.nix
@@ -1,4 +1,4 @@
-{ ... }:
+{ pkgs, ... }:
 {
   services.immich = {
     enable        = true;
@@ -13,7 +13,14 @@
   # after filebrowser.nix) so immich can read/write its mediaLocation inside /mnt/cloud.
   systemd.tmpfiles.rules = [ "z /mnt/cloud 0755 - - -" ];
 
-  # Ensure Immich starts after /mnt/cloud is loop-mounted (mediaLocation lives there)
-  systemd.services.immich-server.after = [ "storj-local-mount.service" ];
-  systemd.services.immich-server.wants = [ "storj-local-mount.service" ];
+  # Ensure Immich starts after /mnt/cloud is loop-mounted (mediaLocation lives there).
+  # ExecStartPre chowns the mediaLocation to the immich user so it can create its
+  # subdirectory structure (the directory is root:root after mkfs/storj restore).
+  systemd.services.immich-server = {
+    after = [ "storj-local-mount.service" ];
+    wants = [ "storj-local-mount.service" ];
+    serviceConfig.ExecStartPre = [
+      "+${pkgs.coreutils}/bin/chown immich:immich /mnt/cloud/Photos"
+    ];
+  };
 }

--- a/rpi5/immich.nix
+++ b/rpi5/immich.nix
@@ -1,0 +1,16 @@
+{ ... }:
+{
+  services.immich = {
+    enable        = true;
+    port          = 2283;
+    # host defaults to 127.0.0.1 — Tailscale Serve owns TLS termination
+    mediaLocation = "/var/lib/immich";
+    settings = {
+      machineLearning.enabled = false;  # saves ~3-7 GB RAM
+    };
+  };
+
+  # Ensure Immich starts after /mnt/cloud is loop-mounted (external library path)
+  systemd.services.immich-server.after = [ "storj-local-mount.service" ];
+  systemd.services.immich-server.wants = [ "storj-local-mount.service" ];
+}

--- a/rpi5/immich.nix
+++ b/rpi5/immich.nix
@@ -3,10 +3,15 @@
   services.immich = {
     enable        = true;
     port          = 2283;
-    # host defaults to 127.0.0.1 — Tailscale Serve owns TLS termination
+    host          = "127.0.0.1";  # force IPv4; Tailscale Serve proxies to 127.0.0.1
     mediaLocation = "/var/lib/immich";
     machine-learning.enable = false;  # disable the systemd unit, not just the runtime config flag
   };
+
+  # filebrowser's tmpfiles rule sets /mnt/cloud to 0700 on every nixos-rebuild switch.
+  # Override it with a z rule (which runs after the d rule since immich.nix is imported
+  # after filebrowser.nix) so immich can traverse into the external library path.
+  systemd.tmpfiles.rules = [ "z /mnt/cloud 0755 - - -" ];
 
   # Ensure Immich starts after /mnt/cloud is loop-mounted (external library path)
   systemd.services.immich-server.after = [ "storj-local-mount.service" ];

--- a/rpi5/immich.nix
+++ b/rpi5/immich.nix
@@ -4,16 +4,16 @@
     enable        = true;
     port          = 2283;
     host          = "127.0.0.1";  # force IPv4; Tailscale Serve proxies to 127.0.0.1
-    mediaLocation = "/var/lib/immich";
+    mediaLocation = "/mnt/cloud/Photos";
     machine-learning.enable = false;  # disable the systemd unit, not just the runtime config flag
   };
 
   # filebrowser's tmpfiles rule sets /mnt/cloud to 0700 on every nixos-rebuild switch.
   # Override it with a z rule (which runs after the d rule since immich.nix is imported
-  # after filebrowser.nix) so immich can traverse into the external library path.
+  # after filebrowser.nix) so immich can read/write its mediaLocation inside /mnt/cloud.
   systemd.tmpfiles.rules = [ "z /mnt/cloud 0755 - - -" ];
 
-  # Ensure Immich starts after /mnt/cloud is loop-mounted (external library path)
+  # Ensure Immich starts after /mnt/cloud is loop-mounted (mediaLocation lives there)
   systemd.services.immich-server.after = [ "storj-local-mount.service" ];
   systemd.services.immich-server.wants = [ "storj-local-mount.service" ];
 }

--- a/rpi5/tailscale-serve.nix
+++ b/rpi5/tailscale-serve.nix
@@ -10,6 +10,7 @@ let
     { port = 3000;  backend = "http://127.0.0.1:3000";  } # grafana
     { port = 8085;  backend = "http://127.0.0.1:8085";  } # filebrowser
     { port = 443;   backend = "http://127.0.0.1:18789"; } # openclaw gateway (tailnet only)
+    { port = 2283;  backend = "http://127.0.0.1:2283";  } # immich photos
   ];
 
   # Publicly-accessible services (tailscale funnel).


### PR DESCRIPTION
## Summary

- Adds `rpi5/immich.nix` enabling Immich on port 2283 with ML disabled (saves ~3-7 GB RAM)
- Orders `immich-server` startup after `storj-local-mount.service` so `/mnt/cloud/Photos` is available
- Exposes Immich via Tailscale Serve at port 2283 (TLS terminated by Tailscale)

## Post-merge setup (web UI, one-time)

After `sudo nixos-rebuild switch --flake .#rpi5`:
- [ ] Open `https://rpi5.gate-mintaka.ts.net:2283` and complete onboarding
- [ ] Administration → External Libraries → Create Library → path `/mnt/cloud/Photos`
- [ ] Add exclusion pattern `**/._*` to filter macOS resource fork files
- [ ] Trigger initial scan

## Verification

- [ ] `systemctl status immich-server` — active/running; `immich-machine-learning` absent
- [ ] `curl http://127.0.0.1:2283/api/server-info` — returns JSON with server version

🤖 Generated with [Claude Code](https://claude.com/claude-code)