### PR TITLE
Feat(sure): native services.sure module (we-promise/sure v0.6.8)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -853,8 +853,8 @@
         ]
       },
       "locked": {
-        "lastModified": 1774454445,
-        "narHash": "sha256-YW+jUCK5stY5FqwFLM0Sg3CQoPuABm6b5nZsgFCtQNI=",
+        "lastModified": 1774459165,
+        "narHash": "sha256-03NpbiyruYjqy+TkNvZ7JM2CY5uww6lICAFmyowPSXU=",
         "path": "/home/nsimon/sure-nix",
         "type": "path"
       },

--- a/flake.lock
+++ b/flake.lock
@@ -225,6 +225,27 @@
         "type": "github"
       }
     },
+    "flake-parts_4": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "sure-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1772408722,
+        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": [
@@ -799,6 +820,7 @@
         "nixpkgs-unstable": "nixpkgs-unstable",
         "openclaw-source": "openclaw-source",
         "ragenix": "ragenix",
+        "sure-nix": "sure-nix",
         "zen-browser": "zen-browser"
       }
     },
@@ -821,6 +843,24 @@
         "owner": "oxalica",
         "repo": "rust-overlay",
         "type": "github"
+      }
+    },
+    "sure-nix": {
+      "inputs": {
+        "flake-parts": "flake-parts_4",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774454445,
+        "narHash": "sha256-YW+jUCK5stY5FqwFLM0Sg3CQoPuABm6b5nZsgFCtQNI=",
+        "path": "/home/nsimon/sure-nix",
+        "type": "path"
+      },
+      "original": {
+        "path": "/home/nsimon/sure-nix",
+        "type": "path"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -53,6 +53,11 @@
     mac-app-util.url = "github:hraban/mac-app-util";
 
     nix-flatpak.url = "github:gmodena/nix-flatpak";
+
+    sure-nix = {
+      url = "path:/home/nsimon/sure-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   nixConfig = {
@@ -121,6 +126,7 @@
           ./rpi5/overlays.nix
           inputs.ragenix.nixosModules.default
           inputs.home-manager.nixosModules.home-manager
+          inputs.sure-nix.nixosModules.sure
           {
             home-manager = {
               useGlobalPkgs = true;

--- a/rpi5/sure.nix
+++ b/rpi5/sure.nix
@@ -1,18 +1,6 @@
 { pkgs, lib, pgHost, pgPort, redisHost, redisPort, ... }:
 let
   port = 13334; # internal port; Tailscale Serve exposes this as HTTPS :3333 on the tailnet
-  commonEnv = {
-    DB_HOST       = pgHost;
-    DB_PORT       = toString pgPort;
-    POSTGRES_USER = "sure_user";
-    POSTGRES_DB   = "sure_production";
-    REDIS_URL     = "redis://${redisHost}:${toString redisPort}/2";
-    SELF_HOSTED   = "true";
-    RAILS_FORCE_SSL  = "false";
-    RAILS_ASSUME_SSL = "false";
-    PORT          = toString port;
-  };
-  secretsEnvFile = "/run/agenix/sure-app-env";
 in
 {
   # ── PostgreSQL: sure_production database + sure_user ──────────────────────
@@ -29,28 +17,8 @@ in
     '';
   };
 
-  # ── Sure containers (host networking → can reach 127.0.0.1:{5432,6379}) ──
-  virtualisation.oci-containers.containers = {
-    sure-web = {
-      image = "ghcr.io/we-promise/sure:stable";
-      environment = commonEnv;
-      environmentFiles = [ secretsEnvFile ];
-      extraOptions = [ "--network=host" ];
-      dependsOn = []; # postgres/redis are host services, not containers
-    };
-
-    sure-worker = {
-      image = "ghcr.io/we-promise/sure:stable";
-      cmd   = [ "bundle" "exec" "sidekiq" ];
-      environment = commonEnv;
-      environmentFiles = [ secretsEnvFile ];
-      volumes = [ "/var/lib/sure/storage:/rails/storage" ];
-      extraOptions = [ "--network=host" ];
-    };
-  };
-
-  # Set sure_user password from agenix secret (ensurePasswordFile not available
-  # in this nixpkgs version; use a oneshot service instead).
+  # Set sure_user password and DB ownership from agenix secret (ensurePasswordFile not
+  # available in NixOS 25.11; use a oneshot service instead).
   systemd.services.sure-pg-setup = {
     description = "Set sure_user PostgreSQL password";
     after    = [ "postgresql.service" ];
@@ -68,16 +36,18 @@ in
     '';
   };
 
-  # sure-web must start after postgres and password setup are ready
-  systemd.services.docker-sure-web = {
-    after    = [ "sure-pg-setup.service" ];
-    requires = [ "sure-pg-setup.service" ];
-  };
-  systemd.services.docker-sure-worker = {
-    after    = [ "sure-pg-setup.service" ];
-    requires = [ "sure-pg-setup.service" ];
+  # ── Sure application (native Nix, via sure-nix flake) ─────────────────────
+  services.sure = {
+    enable          = true;
+    port            = port;
+    environmentFile = "/run/agenix/sure-app-env";
+    databaseUrl     = "postgresql://sure_user@${pgHost}/sure_production";
+    redisUrl        = "redis://${redisHost}:${toString redisPort}/2";
   };
 
-  # Shared app storage directory (Active Storage uploads)
-  systemd.tmpfiles.rules = [ "d /var/lib/sure/storage 0755 root root -" ];
+  # sure-setup (migrations) must run after the password is set
+  systemd.services.sure-setup = {
+    after    = [ "sure-pg-setup.service" ];
+    requires = [ "sure-pg-setup.service" ];
+  };
 }


### PR DESCRIPTION
## Summary

- Replaces Docker containers (`virtualisation.oci-containers`) with native `services.sure` NixOS module from the `sure-nix` flake (`path:/home/nsimon/sure-nix`)
- Sure web (Puma) runs on internal port 13334, exposed as HTTPS :3333 on tailnet
- DB `sure_production` owned by `sure_user`; password set via `sure-pg-setup.service` oneshot
- Secrets via agenix: `sure-app-env` (env file) + `sure-pg-password` (raw, for postgres setup)

## sure-nix packaging highlights (local flake)

- `bundlerEnv` builds all 885 gems from source (ruby platform)
- tailwindcss-ruby 4.x ships a Bun-bundled binary — patched with `patchelf --set-interpreter` + `LD_LIBRARY_PATH` for NixOS compat
- Platform-aware: `aarch64-linux-gnu` / `x86_64-linux-gnu` tailwindcss gem with correct ELF interpreter per arch
- `SELF_HOSTED=true` suppresses the SaaS trial/deletion nag

## Test plan

- [ ] `systemctl is-active sure-web sure-worker sure-setup sure-pg-setup`
- [ ] `curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:13334` → 302
- [ ] Visit https://rpi5.gate-mintaka.ts.net:3333 → Sure login page
- [ ] No "data deleted in 45 days" banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)