### PR TITLE
feat: openai-codex OAuth proxy via openai-oauth

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -521,7 +521,9 @@
       "inputs": {
         "flake-utils": "flake-utils_2",
         "home-manager": "home-manager_2",
-        "nix-steipete-tools": "nix-steipete-tools",
+        "nix-steipete-tools": [
+          "nix-steipete-tools"
+        ],
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -547,11 +549,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773561580,
-        "narHash": "sha256-wT0bKTp45YnMkc4yXQvk943Zz/rksYiIjEXGdWzxnic=",
+        "lastModified": 1774239543,
+        "narHash": "sha256-ZZ7V6xN0ATIHibLyaDBhmUGOqLqQzxuTx1ekOGCvLHI=",
         "owner": "openclaw",
         "repo": "nix-steipete-tools",
-        "rev": "cd4c429ff3b3aaef9f92e59812cf2baf5704b86f",
+        "rev": "5f677a283da837cad26c1ce982d85ee181085fc6",
         "type": "github"
       },
       "original": {
@@ -656,11 +658,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1774273680,
-        "narHash": "sha256-FDcP4L1NZMUpfB5HnAFlgmhui2O0jAMgmtqyHMsCQ2g=",
+        "lastModified": 1774701658,
+        "narHash": "sha256-CIS/4AMUSwUyC8X5g+5JsMRvIUL3YUfewe8K4VrbsSQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fdc7b8f7b30fdbedec91b71ed82f36e1637483ed",
+        "rev": "b63fe7f000adcfa269967eeff72c64cafecbbebe",
         "type": "github"
       },
       "original": {
@@ -752,11 +754,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1774581008,
-        "narHash": "sha256-6CLBABGpmb5wGGZ5yzFuo5B3m+t5L+AKO/JQGyIIplc=",
+        "lastModified": 1774854794,
+        "narHash": "sha256-cEi4ZFOzjOutw1MyECQFgJOoYrmMJwQPd8YEVDPlVYs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1517500ef61719613fb24d2320b8ba55bfca8f91",
+        "rev": "f571b33c0cbc74f7e6018bfc0ae4d98ac04753cc",
         "type": "github"
       },
       "original": {
@@ -815,6 +817,7 @@
         "nix-flatpak": "nix-flatpak",
         "nix-gaming": "nix-gaming",
         "nix-openclaw": "nix-openclaw",
+        "nix-steipete-tools": "nix-steipete-tools",
         "nixos-raspberrypi": "nixos-raspberrypi",
         "nixpkgs": "nixpkgs_7",
         "nixpkgs-unstable": "nixpkgs-unstable",
@@ -853,8 +856,8 @@
         ]
       },
       "locked": {
-        "lastModified": 1774459165,
-        "narHash": "sha256-03NpbiyruYjqy+TkNvZ7JM2CY5uww6lICAFmyowPSXU=",
+        "lastModified": 1774473187,
+        "narHash": "sha256-x9kRIfTb38QoRGIA6D6soirMDWFZiCD3Zh9PNuohkdc=",
         "path": "/home/nsimon/sure-nix",
         "type": "path"
       },

--- a/flake.nix
+++ b/flake.nix
@@ -35,10 +35,17 @@
       inputs.nix-gaming.follows = "nix-gaming";
     };
 
+    nix-steipete-tools = {
+      url = "github:openclaw/nix-steipete-tools";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     nix-openclaw = {
       url = "github:openclaw/nix-openclaw";
       inputs.nixpkgs.follows = "nixpkgs";
-      inputs.nix-steipete-tools.inputs.nixpkgs.follows = "nixpkgs";
+      # Force our lock file to control nix-steipete-tools so root's timestamps
+      # are used, avoiding Nix 2.31.2 lastModified mismatch on nix-openclaw's lock.
+      inputs.nix-steipete-tools.follows = "nix-steipete-tools";
     };
     openclaw-source = {
       url = "github:openclaw/openclaw";

--- a/rpi5/configuration.nix
+++ b/rpi5/configuration.nix
@@ -116,6 +116,7 @@ in
     ./monitoring
     ./storj.nix
     ./filebrowser.nix
+    ./openai-codex-proxy.nix
     ./immich.nix
     ./sure.nix
     # Tailscale with server features (subnet routing, SSH, exit node)

--- a/rpi5/openai-codex-proxy.nix
+++ b/rpi5/openai-codex-proxy.nix
@@ -36,44 +36,20 @@ with open('$out/package.json', 'w') as f: json.dump(d, f, indent=2)
     meta.mainProgram = "openai-oauth";
   };
 
-  port            = 4040;
-  openclawAuth    = "/home/nsimon/.openclaw/agents/main/agent/auth-profiles.json";
-  codexAuth       = "/home/nsimon/.codex/auth.json";
-  profileKey      = "openai-codex:default";
+  port         = 4040;
+  openclawAuth = "/home/nsimon/.openclaw/agents/main/agent/auth-profiles.json";
+  codexAuth    = "/home/nsimon/.codex/auth.json";
 
   # Seed ~/.codex/auth.json from openclaw's auth-profiles.json on first run.
   # openai-oauth then takes over token refresh for its own file.
-  seedScript = pkgs.writeText "seed-codex-auth.py" ''
-    import json, os, sys
-
-    OPENCLAW = "${openclawAuth}"
-    CODEX    = "${codexAuth}"
-    KEY      = "${profileKey}"
-
-    # Skip if already seeded
-    try:
-        with open(CODEX) as f:
-            if json.load(f).get("tokens", {}).get("access_token"):
-                sys.exit(0)
-    except Exception:
-        pass
-
-    try:
-        with open(OPENCLAW) as f:
-            p = json.load(f)["profiles"][KEY]
-    except Exception as e:
-        print(f"cannot read openclaw auth: {e}", file=sys.stderr)
-        sys.exit(1)
-
-    os.makedirs(os.path.dirname(CODEX), exist_ok=True)
-    with open(CODEX, "w") as f:
-        json.dump({"tokens": {
-            "access_token":  p["access"],
-            "refresh_token": p["refresh"],
-            "account_id":    p.get("accountId", ""),
-        }}, f, indent=2)
-    os.chmod(CODEX, 0o600)
-    print(f"seeded {CODEX} from openclaw auth")
+  seedScript = pkgs.writeShellScript "seed-codex-auth" ''
+    [ -s ${codexAuth} ] && exit 0
+    mkdir -p "$(dirname ${codexAuth})"
+    ${pkgs.jq}/bin/jq -n \
+      --argjson p "$(${pkgs.jq}/bin/jq '.profiles["openai-codex:default"]' ${openclawAuth})" \
+      '{tokens:{access_token:$p.access,refresh_token:$p.refresh,account_id:($p.accountId//"")}}' \
+      > ${codexAuth}
+    chmod 600 ${codexAuth}
   '';
 in
 {
@@ -83,8 +59,8 @@ in
     wantedBy    = [ "multi-user.target" ];
     serviceConfig = {
       Type         = "simple";
-      User         = "nsimon"; # needs read access to ~/.openclaw/
-      ExecStartPre = "${pkgs.python3}/bin/python3 ${seedScript}";
+      User         = "nsimon";
+      ExecStartPre = "${seedScript}";
       ExecStart    = "${openai-oauth}/bin/openai-oauth --host 127.0.0.1 --port ${toString port} --oauth-file ${codexAuth}";
       Restart      = "on-failure";
       RestartSec   = "5s";

--- a/rpi5/openai-codex-proxy.nix
+++ b/rpi5/openai-codex-proxy.nix
@@ -1,0 +1,93 @@
+{ pkgs, lib, ... }:
+let
+  version = "1.0.2";
+
+  # openai-oauth: OpenAI-compatible proxy using ChatGPT/Codex OAuth tokens.
+  # https://github.com/EvanZhouDev/openai-oauth
+  #
+  # The dist bundles the entire 'ai' SDK into chunk-2AENSHRT.js; only yargs
+  # is needed at runtime, so the lock file tracks yargs deps only.
+  openai-oauth = pkgs.buildNpmPackage {
+    pname = "openai-oauth";
+    inherit version;
+
+    src = pkgs.runCommand "openai-oauth-${version}-src" {
+      tarball = pkgs.fetchurl {
+        url = "https://registry.npmjs.org/openai-oauth/-/openai-oauth-${version}.tgz";
+        hash = "sha512-5wSwwR76Mc+1ePjwEIzM34qk2Kaw8Ng2zgBCo5eLscOLfciC0N8Z1jCgTCcqeHtyRvywB1kcb0BsHxFHIVJ2Vg==";
+      };
+      packageLock = ./openai-oauth/package-lock.json;
+    } ''
+      mkdir -p $out
+      tar xzf $tarball --strip-components=1 -C $out
+      cp $packageLock $out/package-lock.json
+      # Strip workspace:* devDeps only (ai and yargs are real runtime externals)
+      ${pkgs.python3}/bin/python3 -c "
+import json
+with open('$out/package.json') as f: d = json.load(f)
+d['devDependencies'] = {}
+with open('$out/package.json', 'w') as f: json.dump(d, f, indent=2)
+"
+    '';
+
+    npmDepsHash = "sha256-NAvnKyuOmhpHoaJzjkJmBaaXxHMACcmdayDyWIAuBBQ=";
+    dontNpmBuild = true;
+
+    meta.mainProgram = "openai-oauth";
+  };
+
+  port            = 4040;
+  openclawAuth    = "/home/nsimon/.openclaw/agents/main/agent/auth-profiles.json";
+  codexAuth       = "/home/nsimon/.codex/auth.json";
+  profileKey      = "openai-codex:default";
+
+  # Seed ~/.codex/auth.json from openclaw's auth-profiles.json on first run.
+  # openai-oauth then takes over token refresh for its own file.
+  seedScript = pkgs.writeText "seed-codex-auth.py" ''
+    import json, os, sys
+
+    OPENCLAW = "${openclawAuth}"
+    CODEX    = "${codexAuth}"
+    KEY      = "${profileKey}"
+
+    # Skip if already seeded
+    try:
+        with open(CODEX) as f:
+            if json.load(f).get("tokens", {}).get("access_token"):
+                sys.exit(0)
+    except Exception:
+        pass
+
+    try:
+        with open(OPENCLAW) as f:
+            p = json.load(f)["profiles"][KEY]
+    except Exception as e:
+        print(f"cannot read openclaw auth: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    os.makedirs(os.path.dirname(CODEX), exist_ok=True)
+    with open(CODEX, "w") as f:
+        json.dump({"tokens": {
+            "access_token":  p["access"],
+            "refresh_token": p["refresh"],
+            "account_id":    p.get("accountId", ""),
+        }}, f, indent=2)
+    os.chmod(CODEX, 0o600)
+    print(f"seeded {CODEX} from openclaw auth")
+  '';
+in
+{
+  systemd.services.openai-codex-proxy = {
+    description = "OpenAI-compatible proxy via openai-codex OAuth (openai-oauth)";
+    after       = [ "network.target" ];
+    wantedBy    = [ "multi-user.target" ];
+    serviceConfig = {
+      Type         = "simple";
+      User         = "nsimon"; # needs read access to ~/.openclaw/
+      ExecStartPre = "${pkgs.python3}/bin/python3 ${seedScript}";
+      ExecStart    = "${openai-oauth}/bin/openai-oauth --host 127.0.0.1 --port ${toString port} --oauth-file ${codexAuth}";
+      Restart      = "on-failure";
+      RestartSec   = "5s";
+    };
+  };
+}

--- a/rpi5/openai-oauth/package-lock.json
+++ b/rpi5/openai-oauth/package-lock.json
@@ -1,0 +1,311 @@
+{
+  "name": "openai-oauth",
+  "version": "1.0.2",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "openai-oauth",
+      "version": "1.0.2",
+      "license": "AGPL-3.0-only",
+      "dependencies": {
+        "ai": "6.0.116",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "openai-oauth": "dist/cli.js"
+      },
+      "devDependencies": {}
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.66",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.66.tgz",
+      "integrity": "sha512-SIQ0YY0iMuv+07HLsZ+bB990zUJ6S4ujORAh+Jv1V2KGNn73qQKnGO0JBk+w+Res8YqOFSycwDoWcFlQrVxS4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.19",
+        "@vercel/oidc": "3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.19",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.19.tgz",
+      "integrity": "sha512-3eG55CrSWCu2SXlqq2QCsFjo3+E7+Gmg7i/oRVoSZzIodTuDSfLb3MRje67xE9RFea73Zao7Lm4mADIfUETKGg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@vercel/oidc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
+      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/ai": {
+      "version": "6.0.116",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.116.tgz",
+      "integrity": "sha512-7yM+cTmyRLeNIXwt4Vj+mrrJgVQ9RMIW5WO0ydoLoYkewIvsMcvUmqS4j2RJTUXaF1HphwmSKUMQ/HypNRGOmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.66",
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.19",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/rpi5/tailscale-serve.nix
+++ b/rpi5/tailscale-serve.nix
@@ -12,6 +12,7 @@ let
     { port = 443;   backend = "http://127.0.0.1:18789"; } # openclaw gateway (tailnet only)
     { port = 2283;  backend = "http://127.0.0.1:2283";  } # immich photos
     { port = 3333;  backend = "http://127.0.0.1:13334"; } # sure (personal finance)
+    { port = 4040;  backend = "http://127.0.0.1:4040";  } # openai-codex proxy
   ];
 
   # Publicly-accessible services (tailscale funnel).


### PR DESCRIPTION
## Summary

- Packages [openai-oauth 1.0.2](https://github.com/EvanZhouDev/openai-oauth) via `buildNpmPackage` — no new flake inputs needed
- Seeds `~/.codex/auth.json` from openclaw's existing `auth-profiles.json` on first start; openai-oauth then manages its own token refresh
- Exposes an OpenAI-compatible endpoint at `https://rpi5.gate-mintaka.ts.net:4040/v1` — point any OpenAI client at it, no API key required
- Available models discovered from account: gpt-5.4, gpt-5.4-mini, gpt-5.3-codex, gpt-5.2-codex, gpt-5.2, gpt-5.1-codex-max, gpt-5.1-codex, gpt-5.1, gpt-5-codex, gpt-5, gpt-5.1-codex-mini, gpt-5-codex-mini
- Bonus: promotes `nix-steipete-tools` to a top-level `follows` input, fixing recurring Nix 2.31.2 `lastModified` mismatches on nixos-rebuild

## Test plan

- [x] `systemctl status openai-codex-proxy.service` → active (running)
- [x] Service logs show `OpenAI-compatible endpoint ready at http://127.0.0.1:4040/v1`
- [ ] Point a client (Cursor, etc.) at `https://rpi5.gate-mintaka.ts.net:4040` with any dummy API key

🤖 Generated with [Claude Code](https://claude.com/claude-code)