### PR TITLE
feat(for-sure-swile): Swile Lunchflow connector

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -310,7 +310,7 @@
       },
       "locked": {
         "lastModified": 0,
-        "narHash": "sha256-pCerI3VfMolLNpVxlrLNI06a9GY16XRy/pSFzJMx2VE=",
+        "narHash": "sha256-tN5S8l7pOz3+Xn6SyPZtx2HjTxOAiSf/gqB6QcOaJvs=",
         "path": "/home/nsimon/for-sure/connectors/swile",
         "type": "path"
       },

--- a/flake.lock
+++ b/flake.lock
@@ -302,6 +302,23 @@
         "type": "github"
       }
     },
+    "for-sure-swile": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 0,
+        "narHash": "sha256-pCerI3VfMolLNpVxlrLNI06a9GY16XRy/pSFzJMx2VE=",
+        "path": "/home/nsimon/for-sure/connectors/swile",
+        "type": "path"
+      },
+      "original": {
+        "path": "/home/nsimon/for-sure/connectors/swile",
+        "type": "path"
+      }
+    },
     "git-hooks": {
       "inputs": {
         "flake-compat": "flake-compat_2",
@@ -811,6 +828,7 @@
     "root": {
       "inputs": {
         "darwin": "darwin",
+        "for-sure-swile": "for-sure-swile",
         "home-manager": "home-manager",
         "mac-app-util": "mac-app-util",
         "nix-citizen": "nix-citizen",

--- a/flake.lock
+++ b/flake.lock
@@ -309,14 +309,19 @@
         ]
       },
       "locked": {
-        "lastModified": 0,
-        "narHash": "sha256-tN5S8l7pOz3+Xn6SyPZtx2HjTxOAiSf/gqB6QcOaJvs=",
-        "path": "/home/nsimon/for-sure/connectors/swile",
-        "type": "path"
+        "dir": "connectors/swile",
+        "lastModified": 1775228122,
+        "narHash": "sha256-g9rEZ4F0WDuR/50SdZa7Or1eV+Mh3QCwnJ60ru4/w3M=",
+        "owner": "nSimonFR",
+        "repo": "for-sure",
+        "rev": "2d3e9294043b163a4b0cf97e2ff6b5da0b9c00cf",
+        "type": "github"
       },
       "original": {
-        "path": "/home/nsimon/for-sure/connectors/swile",
-        "type": "path"
+        "dir": "connectors/swile",
+        "owner": "nSimonFR",
+        "repo": "for-sure",
+        "type": "github"
       }
     },
     "git-hooks": {

--- a/flake.nix
+++ b/flake.nix
@@ -67,7 +67,7 @@
     };
 
     for-sure-swile = {
-      url = "path:/home/nsimon/for-sure/connectors/swile";
+      url = "github:nSimonFR/for-sure?dir=connectors/swile";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };

--- a/flake.nix
+++ b/flake.nix
@@ -65,6 +65,11 @@
       url = "path:/home/nsimon/sure-nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    for-sure-swile = {
+      url = "path:/home/nsimon/for-sure/connectors/swile";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   nixConfig = {
@@ -138,6 +143,7 @@
           inputs.ragenix.nixosModules.default
           inputs.home-manager.nixosModules.home-manager
           inputs.sure-nix.nixosModules.sure
+          inputs.for-sure-swile.nixosModules.default
           {
             home-manager = {
               useGlobalPkgs = true;

--- a/rpi5/configuration.nix
+++ b/rpi5/configuration.nix
@@ -118,6 +118,7 @@ in
     ./openai-codex-proxy.nix
     ./immich.nix
     ./sure.nix
+    ./for-sure-swile.nix
     # Tailscale with server features (subnet routing, SSH, exit node)
     (import ../shared/tailscale.nix {
       role = "server";

--- a/rpi5/for-sure-swile.nix
+++ b/rpi5/for-sure-swile.nix
@@ -1,8 +1,9 @@
 { ... }:
 {
   services.for-sure-swile = {
-    enable     = true;
-    port       = 8340;
-    apiKeyFile = "/run/agenix/for-sure-swile-api-key";
+    enable      = true;
+    port        = 8340;
+    apiKeyFile  = "/run/agenix/for-sure-swile-api-key";
+    accountName = "Swile";
   };
 }

--- a/rpi5/for-sure-swile.nix
+++ b/rpi5/for-sure-swile.nix
@@ -1,0 +1,8 @@
+{ ... }:
+{
+  services.for-sure-swile = {
+    enable     = true;
+    port       = 8340;
+    apiKeyFile = "/run/agenix/for-sure-swile-api-key";
+  };
+}

--- a/rpi5/secrets.nix
+++ b/rpi5/secrets.nix
@@ -43,5 +43,9 @@
       file = ./secrets/sure-pg-password.age;
       owner = "postgres"; # ensurePasswordFile reads as postgres user
     };
+    for-sure-swile-api-key = {
+      file = ./secrets/for-sure-swile-api-key.age;
+      owner = "for-sure-swile";
+    };
   };
 }

--- a/rpi5/secrets/for-sure-swile-api-key.age
+++ b/rpi5/secrets/for-sure-swile-api-key.age
@@ -1,0 +1,17 @@
+age-encryption.org/v1
+-> X25519 reXQebkBQGIOWyDQFnBRNzaDM1/NOuq4XOQ3N9NdwHI
+GzCLw7jpnSPDCIg5OTjfa/DL4eNB+y967V3Sxr6fp30
+-> ssh-rsa Yj2Y0A
+gM0IHGqUzYb5V9FKMnrvpqcgl8QwdiynRehzxXXs1Fa17AT631NVc/u5Hj8h6G27
+V4zxFJBa4Dj7C9obRWP6ouQT8GbK1onhAoYv1RvDE0eJDi6/4cV1l6k3vg4khQ02
+yPF9g5ZGMVwKfD4XxOhh6E3vbuMD43n+TGF2gCgZ8sEFcXhtMjCyONIwUpG8WxZq
+SGHk0Sl+N39uRLNlqAxMwKPtPiy9R2No1oAPif2x7ZZjF7lsfXEssvuJHMvHMvOS
+swPJYt+5zu5QiiP0ApMvL3TTZ58QwROU/W2+QqycInRPDDq0EQPLN/DrbcIQhZDR
+oqtqDm3/7cIoVqbj/tkWWDadBvv5e8TxcqBlD1ZTtf/XjUCmaegWFG1beqFcQ1Ub
+IoIMqzWsEGlS/4nTSSNjQVp/IoT7McaF5d6cr9fR7AGkZ2yph58/CsFuU6FhTo1J
+6lyrmH5BSA9Kj+B+jNQJOoRZkL+b/HePpIrWvCRsqfINkMKC3zaJMaZNIbmpBhmj
+l6sPk895hd27arcen92elDDixdwqbQ1RBcj8TTnuBlGmyQrJEgqSwDPSybOzsTNO
+1bapNTcuczSoSDtGFaWJzmGPZwK+nMgQdvJlgDxJMuCRKeAyUKh3YUk8a7a9mKco
+alUNqI0952i8LPr3myVtEcc3XV/ykN1XoyNnzdxW7Xw
+--- alWjtPrn2KNl3xpJDb2CBL1D2jduMYAAjUpRMMHQiPc
+Ê"πë¬ù/Ãtä˚¸“ìl‹êwR/um#≠è	†πkÎoï≤Ç[‰æ8™s≠v≠`±kÀsMrA˙≈÷„ñeΩvx◊R˜}Pû~4p%é@‚é=â›ÔÙœäZ¡€‘"?˛Ôôö

--- a/rpi5/secrets/secrets.nix
+++ b/rpi5/secrets/secrets.nix
@@ -12,4 +12,5 @@ in {
   "immich-api-key.age".publicKeys      = [ nsimon-age nsimon-rsa ];
   "sure-app-env.age".publicKeys        = [ nsimon-age nsimon-rsa ];
   "sure-pg-password.age".publicKeys    = [ nsimon-age nsimon-rsa ];
+  "for-sure-swile-api-key.age".publicKeys = [ nsimon-age nsimon-rsa ];
 }


### PR DESCRIPTION
## Summary

- Add `for-sure-swile` NixOS service: Lunchflow-compatible HTTP shim that translates Swile's neobank API into the 4 Lunchflow endpoints (`/accounts`, `/transactions`, `/balance`, `/holdings`) so Sure can import Swile meal voucher transactions
- Service runs on port 8340, auth via agenix secret `for-sure-swile-api-key`
- Set `accountName = "Swile"` for display in Sure
- Fix `/balance` response format to `{ balance: { amount, currency } }` as expected by Sure's `LunchflowItem::Importer`
- Include `REFUNDED` transactions in addition to `CAPTURED`/`VALIDATED`

## Test plan

- [ ] `systemctl status for-sure-swile` is active
- [ ] `/api/v1/accounts` returns Swile meal voucher wallet
- [ ] `/api/v1/accounts/:id/transactions` returns transactions with merchant names
- [ ] `/api/v1/accounts/:id/balance` returns `{ balance: { amount, currency } }`
- [ ] Sure syncs successfully and shows transactions

🤖 Generated with [Claude Code](https://claude.com/claude-code)