### PR TITLE
feat: Sumeria MITM token capture + swap to SD card

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 result
 
 __pycache__/
+.claude/
+.claude/
+.claude/

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,3 @@ result
 
 __pycache__/
 .claude/
-.claude/
-.claude/

--- a/flake.lock
+++ b/flake.lock
@@ -311,10 +311,10 @@
       "locked": {
         "dir": "connectors/for-sure",
         "lastModified": 1775309575,
-        "narHash": "sha256-4Ru+mZL7N2Ake9EZrQd0xfHi+Teth/CHzACDDzu3/ns=",
+        "narHash": "sha256-ogGEbT9FmbTsHyh5QjmmuoSA/ADTFli46qm+NGvTgrI=",
         "owner": "nSimonFR",
         "repo": "for-sure",
-        "rev": "8c3450f838422a51ebec70d38a8658ac378d2f56",
+        "rev": "792ffb7a8583751f361d039da13ebf9e4cde783f",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -310,11 +310,11 @@
       },
       "locked": {
         "dir": "connectors/for-sure",
-        "lastModified": 1775302383,
-        "narHash": "sha256-y9TNX5MNd4eeD9/fapsJcVjhuWfR7IHEgmA9NCHkHbA=",
+        "lastModified": 1775309575,
+        "narHash": "sha256-4Ru+mZL7N2Ake9EZrQd0xfHi+Teth/CHzACDDzu3/ns=",
         "owner": "nSimonFR",
         "repo": "for-sure",
-        "rev": "1abe9c5a2d2ab4e3e97a555fbffc9f09640da03c",
+        "rev": "8c3450f838422a51ebec70d38a8658ac378d2f56",
         "type": "github"
       },
       "original": {

--- a/rpi5/configuration.nix
+++ b/rpi5/configuration.nix
@@ -345,59 +345,10 @@ in
   swapDevices = [
     {
       # Dedicated swap partition on SD card (mmcblk0p3) — keeps swap I/O off NVMe.
-      # Created by sd-swap-setup.service on first boot after config activation.
       device = "/dev/mmcblk0p3";
       randomEncryption.enable = false;
     }
   ];
-
-  # One-shot service: runs before /home mounts, carves mmcblk0p3 out of the SD card.
-  # Skipped automatically on every subsequent boot once /dev/mmcblk0p3 exists.
-  systemd.services.sd-swap-setup = {
-    description = "One-time: resize /home RAID to carve SD card swap partition";
-    wantedBy = [ "local-fs-pre.target" ];
-    before    = [ "home.mount" "dev-mmcblk0p3.swap" ];
-    after     = [ "dev-md127.device" "systemd-udevd.service" ];
-    unitConfig = {
-      DefaultDependencies = false;
-      ConditionPathExists = "!/dev/mmcblk0p3";
-    };
-    path = with pkgs; [ e2fsprogs mdadm parted util-linux ];
-    serviceConfig = {
-      Type            = "oneshot";
-      RemainAfterExit = true;
-      ExecStart       = pkgs.writeShellScript "sd-swap-setup" ''
-        set -euxo pipefail
-
-        # 1. Filesystem check (required before offline resize)
-        e2fsck -f -y /dev/md127 || true
-
-        # 2. Shrink /home filesystem to 48G
-        resize2fs /dev/md127 48G
-
-        # 3. Shrink RAID array to match (48G in KiB)
-        mdadm --grow /dev/md127 --array-size $((48 * 1024 * 1024))
-        sleep 2
-
-        # 4. Remove mmcblk0p2 from RAID (RAID stays alive on sda2)
-        mdadm --fail   /dev/md127 /dev/mmcblk0p2
-        sleep 2
-        mdadm --remove /dev/md127 /dev/mmcblk0p2
-
-        # 5. Repartition SD card: shrink p2 to ~49G, create p3 for swap
-        parted -s /dev/mmcblk0 resizepart 2 50GiB
-        parted -s /dev/mmcblk0 mkpart primary linux-swap 50GiB 100%
-        partprobe /dev/mmcblk0
-        sleep 1
-
-        # 6. Re-add resized mmcblk0p2 to RAID (resyncs in background)
-        mdadm --add /dev/md127 /dev/mmcblk0p2
-
-        # 7. Format the new swap partition
-        mkswap /dev/mmcblk0p3
-      '';
-    };
-  };
 
   zramSwap = {
     enable = true;

--- a/rpi5/configuration.nix
+++ b/rpi5/configuration.nix
@@ -344,11 +344,60 @@ in
 
   swapDevices = [
     {
-      # Swapfile on root (NIXOS_SD) — avoids ordering dependency on /home mount
-      device = "/swapfile";
-      size = 2 * 1024;
+      # Dedicated swap partition on SD card (mmcblk0p3) — keeps swap I/O off NVMe.
+      # Created by sd-swap-setup.service on first boot after config activation.
+      device = "/dev/mmcblk0p3";
+      randomEncryption.enable = false;
     }
   ];
+
+  # One-shot service: runs before /home mounts, carves mmcblk0p3 out of the SD card.
+  # Skipped automatically on every subsequent boot once /dev/mmcblk0p3 exists.
+  systemd.services.sd-swap-setup = {
+    description = "One-time: resize /home RAID to carve SD card swap partition";
+    wantedBy = [ "local-fs-pre.target" ];
+    before    = [ "home.mount" "dev-mmcblk0p3.swap" ];
+    after     = [ "dev-md127.device" "systemd-udevd.service" ];
+    unitConfig = {
+      DefaultDependencies = false;
+      ConditionPathExists = "!/dev/mmcblk0p3";
+    };
+    path = with pkgs; [ e2fsprogs mdadm parted util-linux ];
+    serviceConfig = {
+      Type            = "oneshot";
+      RemainAfterExit = true;
+      ExecStart       = pkgs.writeShellScript "sd-swap-setup" ''
+        set -euxo pipefail
+
+        # 1. Filesystem check (required before offline resize)
+        e2fsck -f -y /dev/md127 || true
+
+        # 2. Shrink /home filesystem to 48G
+        resize2fs /dev/md127 48G
+
+        # 3. Shrink RAID array to match (48G in KiB)
+        mdadm --grow /dev/md127 --array-size $((48 * 1024 * 1024))
+        sleep 2
+
+        # 4. Remove mmcblk0p2 from RAID (RAID stays alive on sda2)
+        mdadm --fail   /dev/md127 /dev/mmcblk0p2
+        sleep 2
+        mdadm --remove /dev/md127 /dev/mmcblk0p2
+
+        # 5. Repartition SD card: shrink p2 to ~49G, create p3 for swap
+        parted -s /dev/mmcblk0 resizepart 2 50GiB
+        parted -s /dev/mmcblk0 mkpart primary linux-swap 50GiB 100%
+        partprobe /dev/mmcblk0
+        sleep 1
+
+        # 6. Re-add resized mmcblk0p2 to RAID (resyncs in background)
+        mdadm --add /dev/md127 /dev/mmcblk0p2
+
+        # 7. Format the new swap partition
+        mkswap /dev/mmcblk0p3
+      '';
+    };
+  };
 
   zramSwap = {
     enable = true;

--- a/rpi5/sure.nix
+++ b/rpi5/sure.nix
@@ -10,6 +10,7 @@ in
     port              = 8340;
     apiKeyFile        = "/run/agenix/for-sure-api-key";
     swile.accountName = "Swile";
+    mitm.enable       = true;
   };
 
 


### PR DESCRIPTION
## Summary

- **Sumeria MITM auto-capture**: adds a persistent `for-sure-mitm` mitmproxy service that intercepts `api.lydia-app.com` requests and atomically writes auth tokens to `/var/lib/for-sure/sumeria-tokens.json` — configure iPhone proxy to RPi5:8889 to auto-refresh tokens when opening the Sumeria app
- **Swap migration**: moves swap from NVMe swapfile to dedicated SD card partition (`/dev/mmcblk0p3`, 9.5 GiB), reducing I/O contention on the NVMe during heavy builds
- **Cleanup**: removes the completed one-shot `sd-swap-setup` migration service

## Commits

- `feat(for-sure)`: add persistent mitmproxy service for Sumeria token auto-capture
- `feat(swap)`: migrate swap from NVMe swapfile to SD card partition (mmcblk0p3)
- `chore(swap)`: remove completed sd-swap-setup migration service

## Test plan

- [ ] Set iPhone HTTP proxy to `<rpi5-tailscale-ip>:8889`, open Sumeria app, verify `/var/lib/for-sure/sumeria-tokens.json` is updated
- [ ] `swapon --show` confirms `/dev/mmcblk0p3` active, no `/swapfile`
- [ ] `cat /proc/mdstat` shows `[UU]` once RAID resync completes (~45 min from activation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)