### PR TITLE
feat(for-sure): Sumeria MITM transparent proxy via Tailscale exit node

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -310,11 +310,11 @@
       },
       "locked": {
         "dir": "connectors/for-sure",
-        "lastModified": 1775399974,
-        "narHash": "sha256-aiv2SGpiftRAe4URdlmG+Vw1MGDqX2RoCakkTonosvA=",
+        "lastModified": 1775402063,
+        "narHash": "sha256-fkesPLL+X8D4jtItKosLGYAx2NWQcAVfS0jESReNs7I=",
         "owner": "nSimonFR",
         "repo": "for-sure",
-        "rev": "1a70b590988e06ef11ed93928beaf190cf8925fd",
+        "rev": "fd452eabb3679056c539f9a6dfa8d67d155db3ff",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -310,11 +310,11 @@
       },
       "locked": {
         "dir": "connectors/for-sure",
-        "lastModified": 1775399517,
-        "narHash": "sha256-G3gMDjCt5zreesVTPCwIGr243vK+BPD71EoSDdJ3iYg=",
+        "lastModified": 1775399974,
+        "narHash": "sha256-aiv2SGpiftRAe4URdlmG+Vw1MGDqX2RoCakkTonosvA=",
         "owner": "nSimonFR",
         "repo": "for-sure",
-        "rev": "54c19f091f6101a093f4b3a27bbcd2f4fec93ef5",
+        "rev": "1a70b590988e06ef11ed93928beaf190cf8925fd",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -310,11 +310,11 @@
       },
       "locked": {
         "dir": "connectors/for-sure",
-        "lastModified": 1775402063,
-        "narHash": "sha256-fkesPLL+X8D4jtItKosLGYAx2NWQcAVfS0jESReNs7I=",
+        "lastModified": 1775404281,
+        "narHash": "sha256-mCrdo+kejc5plLLwx/9GRb9/4uvyHc6Xxz63smUp70c=",
         "owner": "nSimonFR",
         "repo": "for-sure",
-        "rev": "fd452eabb3679056c539f9a6dfa8d67d155db3ff",
+        "rev": "411b5b6cab3a20923be711f44732533d23283933",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -310,11 +310,11 @@
       },
       "locked": {
         "dir": "connectors/for-sure",
-        "lastModified": 1775404281,
-        "narHash": "sha256-mCrdo+kejc5plLLwx/9GRb9/4uvyHc6Xxz63smUp70c=",
+        "lastModified": 1775404631,
+        "narHash": "sha256-PXi2RvIPhFVzEURLwupuX/pD7j7SsblNn2nmSapTwb8=",
         "owner": "nSimonFR",
         "repo": "for-sure",
-        "rev": "411b5b6cab3a20923be711f44732533d23283933",
+        "rev": "e6179373aa3f95ea28b649af522b2e83af045201",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -310,11 +310,11 @@
       },
       "locked": {
         "dir": "connectors/for-sure",
-        "lastModified": 1775309575,
-        "narHash": "sha256-ogGEbT9FmbTsHyh5QjmmuoSA/ADTFli46qm+NGvTgrI=",
+        "lastModified": 1775399517,
+        "narHash": "sha256-G3gMDjCt5zreesVTPCwIGr243vK+BPD71EoSDdJ3iYg=",
         "owner": "nSimonFR",
         "repo": "for-sure",
-        "rev": "792ffb7a8583751f361d039da13ebf9e4cde783f",
+        "rev": "54c19f091f6101a093f4b3a27bbcd2f4fec93ef5",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -310,11 +310,11 @@
       },
       "locked": {
         "dir": "connectors/for-sure",
-        "lastModified": 1775404631,
-        "narHash": "sha256-PXi2RvIPhFVzEURLwupuX/pD7j7SsblNn2nmSapTwb8=",
+        "lastModified": 1775406700,
+        "narHash": "sha256-lvlAg9qpO+SXttnjST1fFxkvNGuMKCaqH6QqEOp0O34=",
         "owner": "nSimonFR",
         "repo": "for-sure",
-        "rev": "e6179373aa3f95ea28b649af522b2e83af045201",
+        "rev": "534e992843e9816acdc666743a97443731f4172d",
         "type": "github"
       },
       "original": {

--- a/rpi5/configuration.nix
+++ b/rpi5/configuration.nix
@@ -118,6 +118,7 @@ in
     ./openai-codex-proxy.nix
     ./immich.nix
     ./sure.nix
+    ./sumeria-mitm.nix
     # Tailscale with server features (subnet routing, SSH, exit node)
     (import ../shared/tailscale.nix {
       role = "server";

--- a/rpi5/secrets.nix
+++ b/rpi5/secrets.nix
@@ -12,8 +12,10 @@
       owner = "nsimon";
     };
     telegram-bot-token = {
-      file = ../shared/telegram-bot-token.age;
+      file  = ../shared/telegram-bot-token.age;
       owner = "nsimon";
+      group = "for-sure";
+      mode  = "0440";
     };
     supervisor-token = {
       file = ./secrets/supervisor-token.age;

--- a/rpi5/sumeria-mitm.nix
+++ b/rpi5/sumeria-mitm.nix
@@ -1,0 +1,115 @@
+{ config, lib, pkgs, ... }:
+let
+  cfg = config.services.sumeria-mitm;
+
+  # Intercepts requests to api.lydia-app.com and extracts the three static session
+  # headers (auth_token / public_token / access-token) that Sumeria uses instead of OAuth.
+  # Tokens are written atomically so the consumer picks them up without a restart.
+  # NOTE: these headers are undocumented and were discovered by MITM. Update if auth changes.
+  tokenExtractor = pkgs.writeText "sumeria-token-extractor.py" ''
+    import json, os
+    from mitmproxy import http
+
+    TOKEN_FILE = os.environ["SUMERIA_TOKEN_FILE"]
+
+    class SumeriaTokenExtractor:
+        def request(self, flow: http.HTTPFlow):
+            if "api.lydia-app.com" not in flow.request.host:
+                return
+            h = flow.request.headers
+            if h.get("auth_token") and h.get("public_token") and h.get("access-token"):
+                tokens = {
+                    "auth_token":   h["auth_token"],
+                    "public_token": h["public_token"],
+                    "access_token": h["access-token"],
+                }
+                tmp = TOKEN_FILE + ".tmp"
+                with open(tmp, "w") as f:
+                    json.dump(tokens, f, indent=2)
+                os.rename(tmp, TOKEN_FILE)
+
+    addons = [SumeriaTokenExtractor()]
+  '';
+in
+{
+  options.services.sumeria-mitm = {
+    enable = lib.mkEnableOption "Sumeria token extractor (mitmproxy transparent proxy)";
+
+    port = lib.mkOption {
+      type        = lib.types.port;
+      default     = 8889;
+      description = "Port for the mitmproxy transparent proxy";
+    };
+
+    tokenFile = lib.mkOption {
+      type        = lib.types.str;
+      default     = "/var/lib/sumeria-mitm/tokens.json";
+      description = "Path where captured Sumeria tokens are written";
+    };
+
+    tokenFileGroup = lib.mkOption {
+      type        = lib.types.str;
+      default     = "sumeria-mitm";
+      description = "Group that gets read access to the token file (set to consumer's group)";
+    };
+
+    exitNodeClients = lib.mkOption {
+      type        = lib.types.listOf lib.types.str;
+      default     = [];
+      description = "Tailscale IPs of devices using the RPi5 as exit node (HTTPS intercepted)";
+      example     = [ "100.112.22.60" ];
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    users.users.sumeria-mitm  = { isSystemUser = true; group = "sumeria-mitm"; };
+    users.groups.sumeria-mitm = {};
+
+    systemd.tmpfiles.rules = [
+      "d /var/lib/sumeria-mitm 0750 sumeria-mitm ${cfg.tokenFileGroup} - -"
+    ];
+
+    # Prerequisites:
+    # - mitmproxy CA must be installed + trusted on the iPhone (visit http://mitm.it via proxy)
+    # - exit node must be approved in Tailscale admin console
+    systemd.services.sumeria-mitm = {
+      description = "Sumeria token extractor (mitmproxy transparent)";
+      wantedBy    = [ "multi-user.target" ];
+      after       = [ "network-online.target" ];
+      wants       = [ "network-online.target" ];
+
+      serviceConfig = {
+        ExecStart = lib.concatStringsSep " " [
+          "${pkgs.mitmproxy}/bin/mitmdump"
+          "--mode transparent"
+          "-p ${toString cfg.port}"
+          "--ignore-hosts '(?!api\\.lydia-app\\.com).*'"
+          "--set confdir=/var/lib/sumeria-mitm/mitmproxy"
+          "--set block_global=false"
+          "-s ${tokenExtractor}"
+        ];
+        User                = "sumeria-mitm";
+        Group               = "sumeria-mitm";
+        Restart             = "on-failure";
+        RestartSec          = "5";
+        ReadWritePaths      = [ "/var/lib/sumeria-mitm" ];
+        AmbientCapabilities = [ "CAP_NET_BIND_SERVICE" ];
+        LimitNOFILE         = 65536;
+      };
+
+      environment.SUMERIA_TOKEN_FILE = cfg.tokenFile;
+    };
+
+    # Redirect HTTPS from exit-node clients → mitmproxy. Scoped to specific IPs only.
+    networking.firewall.extraCommands = lib.mkIf (cfg.exitNodeClients != []) (
+      lib.concatMapStringsSep "\n" (ip:
+        "iptables -t nat -A PREROUTING -i tailscale0 -s ${ip} -p tcp --dport 443 -j REDIRECT --to-port ${toString cfg.port}"
+      ) cfg.exitNodeClients
+    );
+    networking.firewall.extraStopCommands = lib.mkIf (cfg.exitNodeClients != []) (
+      lib.concatMapStringsSep "\n" (ip:
+        "iptables -t nat -D PREROUTING -i tailscale0 -s ${ip} -p tcp --dport 443 -j REDIRECT --to-port ${toString cfg.port} || true"
+      ) cfg.exitNodeClients
+    );
+  };
+}

--- a/rpi5/sure.nix
+++ b/rpi5/sure.nix
@@ -1,19 +1,24 @@
-{ pkgs, lib, pgHost, pgPort, redisHost, redisPort, telegramChatId, ... }:
+{ config, pkgs, lib, pgHost, pgPort, redisHost, redisPort, telegramChatId, ... }:
 let
   port = 13334; # internal port; Tailscale Serve exposes this as HTTPS :3333 on the tailnet
 in
 {
   # ── for-sure: combined Swile + Sumeria Lunchflow connector ────────────────
   # Single service on port 8340; Sure connects to http://127.0.0.1:8340/api/v1
+  services.sumeria-mitm = {
+    enable           = true;
+    exitNodeClients  = [ "100.112.22.60" ]; # nphone
+    tokenFileGroup   = "for-sure";
+  };
+
   services.for-sure = {
-    enable            = true;
-    port              = 8340;
-    apiKeyFile        = "/run/agenix/for-sure-api-key";
-    swile.accountName        = "Swile";
-    mitm.enable              = true;
-    mitm.exitNodeClients     = [ "100.112.22.60" ]; # nphone
-    telegram.botTokenFile    = "/run/agenix/telegram-bot-token";
-    telegram.chatId          = toString telegramChatId;
+    enable                = true;
+    port                  = 8340;
+    apiKeyFile            = "/run/agenix/for-sure-api-key";
+    swile.accountName     = "Swile";
+    sumeria.tokenFile     = config.services.sumeria-mitm.tokenFile;
+    telegram.botTokenFile = "/run/agenix/telegram-bot-token";
+    telegram.chatId       = toString telegramChatId;
   };
 
 

--- a/rpi5/sure.nix
+++ b/rpi5/sure.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, pgHost, pgPort, redisHost, redisPort, ... }:
+{ pkgs, lib, pgHost, pgPort, redisHost, redisPort, telegramChatId, ... }:
 let
   port = 13334; # internal port; Tailscale Serve exposes this as HTTPS :3333 on the tailnet
 in
@@ -9,8 +9,10 @@ in
     enable            = true;
     port              = 8340;
     apiKeyFile        = "/run/agenix/for-sure-api-key";
-    swile.accountName = "Swile";
-    mitm.enable       = true;
+    swile.accountName        = "Swile";
+    mitm.enable              = true;
+    telegram.botTokenFile    = "/run/agenix/telegram-bot-token";
+    telegram.chatId          = toString telegramChatId;
   };
 
 

--- a/rpi5/sure.nix
+++ b/rpi5/sure.nix
@@ -11,6 +11,7 @@ in
     apiKeyFile        = "/run/agenix/for-sure-api-key";
     swile.accountName        = "Swile";
     mitm.enable              = true;
+    mitm.exitNodeClients     = [ "100.112.22.60" ]; # nphone
     telegram.botTokenFile    = "/run/agenix/telegram-bot-token";
     telegram.chatId          = toString telegramChatId;
   };


### PR DESCRIPTION
## Summary

- **Transparent MITM via exit node**: switches mitmproxy from manual HTTP proxy mode to transparent mode — when the iPhone uses the RPi5 as a Tailscale exit node, Sumeria tokens are captured automatically with no per-network proxy config
- **Scoped iptables REDIRECT**: only intercepts HTTPS from `nphone` (100.112.22.60), not all Tailscale peers — avoids fd exhaustion from unrelated traffic
- **Raised `LimitNOFILE`**: mitmproxy service gets 65536 file descriptors (transparent mode handles more concurrent connections)
- **Tailscale firewall port removed**: port 8889 no longer needs to be open on tailscale0 for manual proxy use
- **Telegram alerts on token expiry**: `notify.ts` fires when Sumeria returns 401, with instructions to re-open the app via exit node
- **`exitNodeClients` module option**: list of Tailscale IPs to intercept, configurable per deployment

## Commits

- `fix(for-sure)`: restrict mitmproxy port to tailscale0 interface only
- `feat(for-sure)`: wire Telegram token-expiry alerts + telegram-bot-token group access
- `feat(for-sure)`: update lock for mitmproxy transparent mode
- `fix(for-sure)`: update lock — raise mitmproxy LimitNOFILE
- `fix(for-sure)`: scope MITM REDIRECT to nphone IP only

## Test plan

- [ ] Enable RPi5 as exit node in Tailscale iOS app (requires admin console approval if not already done)
- [ ] Open Sumeria app → verify `/var/lib/for-sure/sumeria-tokens.json` is updated
- [ ] Verify other Tailscale devices (macbook, beast) are unaffected
- [ ] Let tokens expire → confirm Telegram alert is received with renewal instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)