### PR TITLE
chore: update for-sure input to main branch

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -310,17 +310,16 @@
       },
       "locked": {
         "dir": "connectors/for-sure",
-        "lastModified": 1775408334,
-        "narHash": "sha256-yUbASSjz6uMnWPsvEtRthLuza0n6qYyXWiOxYlFKu6E=",
+        "lastModified": 1775675476,
+        "narHash": "sha256-IVxWxu/ngt4GmafAaUUaPcsWqn6GXTgWfl+/GKdThX4=",
         "owner": "nSimonFR",
         "repo": "for-sure",
-        "rev": "3dd4cf7fc9c3a883220837e9f8c9cc41755c4951",
+        "rev": "8a5781ae2feb98c85c96c1a74f768068b427b80b",
         "type": "github"
       },
       "original": {
         "dir": "connectors/for-sure",
         "owner": "nSimonFR",
-        "ref": "feat/lunchflow-shared-sumeria-connector",
         "repo": "for-sure",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -67,7 +67,7 @@
     };
 
     for-sure = {
-      url = "github:nSimonFR/for-sure/feat/lunchflow-shared-sumeria-connector?dir=connectors/for-sure";
+      url = "github:nSimonFR/for-sure?dir=connectors/for-sure";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };


### PR DESCRIPTION
## Summary
- Point `for-sure` flake input to `main` (old branch `feat/lunchflow-shared-sumeria-connector` was merged)
- Picks up: removed old standalone swile connector, typo fix, consistent error handling, token file permissions, build fix

## Test plan
- [x] `nixos-rebuild switch` succeeded
- [x] `for-sure` service running, all 6 accounts (Swile + 5 Sumeria) returning 200s

🤖 Generated with [Claude Code](https://claude.com/claude-code)