### PR TITLE
chore: bump all flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -154,6 +154,22 @@
       }
     },
     "flake-compat_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_4": {
       "locked": {
         "lastModified": 1767039857,
         "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
@@ -194,11 +210,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769996383,
-        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
         "type": "github"
       },
       "original": {
@@ -212,11 +228,11 @@
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
-        "lastModified": 1772408722,
-        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
         "type": "github"
       },
       "original": {
@@ -344,7 +360,7 @@
     },
     "git-hooks": {
       "inputs": {
-        "flake-compat": "flake-compat_2",
+        "flake-compat": "flake-compat_3",
         "gitignore": "gitignore",
         "nixpkgs": [
           "nix-gaming",
@@ -352,11 +368,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772893680,
-        "narHash": "sha256-JDqZMgxUTCq85ObSaFw0HhE+lvdOre1lx9iI6vYyOEs=",
+        "lastModified": 1775036584,
+        "narHash": "sha256-zW0lyy7ZNNT/x8JhzFHBsP2IPx7ATZIPai4FJj12BgU=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "8baab586afc9c9b57645a734c820e4ac0a604af9",
+        "rev": "4e0eb042b67d863b1b34b3f64d52ceb9cd926735",
         "type": "github"
       },
       "original": {
@@ -394,11 +410,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772633058,
-        "narHash": "sha256-SO7JapRy2HPhgmqiLbfnW1kMx5rakPMKZ9z3wtRLQjI=",
+        "lastModified": 1775425411,
+        "narHash": "sha256-KY6HsebJHEe5nHOWP7ur09mb0drGxYSzE3rQxy62rJo=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "080657a04188aca25f8a6c70a0fb2ea7e37f1865",
+        "rev": "0d02ec1d0a05f88ef9e74b516842900c41f0f2fe",
         "type": "github"
       },
       "original": {
@@ -497,6 +513,7 @@
     },
     "nix-citizen": {
       "inputs": {
+        "flake-compat": "flake-compat_2",
         "flake-parts": "flake-parts_2",
         "nix-gaming": [
           "nix-gaming"
@@ -509,11 +526,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1772097162,
-        "narHash": "sha256-io1PJ0eXpAY9Pbiag8p2qxJ35jPC3Kbb6zTGxD2jmzU=",
+        "lastModified": 1775468538,
+        "narHash": "sha256-j1dslOr5tgrn4HCx/gDIr9BGfik4uAYkm+dVdhH4cPw=",
         "owner": "LovingMelody",
         "repo": "nix-citizen",
-        "rev": "abefae91a50c91ee7684a4c5b68156bbdf9af05f",
+        "rev": "bdf733ea564c906bbc4bfb3a46dd48c5218c8077",
         "type": "github"
       },
       "original": {
@@ -544,11 +561,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1773196297,
-        "narHash": "sha256-3cTCid9mn1VwqZwxoIjh7NKlUhnsNZUuEn++AAjaWsk=",
+        "lastModified": 1775616834,
+        "narHash": "sha256-Se4dxrfyPQR2+N16Cq6C6li0JVd1p+Oa8GWTPzzRiwg=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "283b7757411109bec421885dca788984c423d4af",
+        "rev": "3c545996db7b1dc05aaddc0cf667235e32c7c834",
         "type": "github"
       },
       "original": {
@@ -610,11 +627,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774239543,
-        "narHash": "sha256-ZZ7V6xN0ATIHibLyaDBhmUGOqLqQzxuTx1ekOGCvLHI=",
+        "lastModified": 1775606539,
+        "narHash": "sha256-aYvej+QTr8g5/NZi8heCHlBHxIt5KArLrs3ULusaiU8=",
         "owner": "openclaw",
         "repo": "nix-steipete-tools",
-        "rev": "5f677a283da837cad26c1ce982d85ee181085fc6",
+        "rev": "d17f197c47f30afb82bbfaa3a98bc46a97654e09",
         "type": "github"
       },
       "original": {
@@ -652,7 +669,7 @@
     "nixos-raspberrypi": {
       "inputs": {
         "argononed": "argononed",
-        "flake-compat": "flake-compat_3",
+        "flake-compat": "flake-compat_4",
         "nixos-images": "nixos-images",
         "nixpkgs": "nixpkgs_6"
       },
@@ -704,11 +721,11 @@
     },
     "nixpkgs-lib_2": {
       "locked": {
-        "lastModified": 1772328832,
-        "narHash": "sha256-e+/T/pmEkLP6BHhYjx6GmwP5ivonQQn0bJdH9YrRB+Q=",
+        "lastModified": 1774748309,
+        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "c185c7a5e5dd8f9add5b2f8ebeff00888b070742",
+        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
         "type": "github"
       },
       "original": {
@@ -783,11 +800,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1772736753,
-        "narHash": "sha256-au/m3+EuBLoSzWUCb64a/MZq6QUtOV8oC0D9tY2scPQ=",
+        "lastModified": 1775126147,
+        "narHash": "sha256-J0dZU4atgcfo4QvM9D92uQ0Oe1eLTxBVXjJzdEMQpD0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "917fec990948658ef1ccd07cef2a1ef060786846",
+        "rev": "8d8c1fa5b412c223ffa47410867813290cdedfef",
         "type": "github"
       },
       "original": {
@@ -815,11 +832,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1774854794,
-        "narHash": "sha256-cEi4ZFOzjOutw1MyECQFgJOoYrmMJwQPd8YEVDPlVYs=",
+        "lastModified": 1775730577,
+        "narHash": "sha256-5i3MKmxBFQP9/wp3QyFWyS7DqURq/M4T8gr1JSbyygI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "f571b33c0cbc74f7e6018bfc0ae4d98ac04753cc",
+        "rev": "0d5a853f7004a5fc57b61a97ccb02832f8e7ed9d",
         "type": "github"
       },
       "original": {
@@ -1081,11 +1098,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770228511,
-        "narHash": "sha256-wQ6NJSuFqAEmIg2VMnLdCnUc0b7vslUohqqGGD+Fyxk=",
+        "lastModified": 1775125835,
+        "narHash": "sha256-2qYcPgzFhnQWchHo0SlqLHrXpux5i6ay6UHA+v2iH4U=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "337a4fe074be1042a35086f15481d763b8ddc0e7",
+        "rev": "75925962939880974e3ab417879daffcba36c4a3",
         "type": "github"
       },
       "original": {
@@ -1104,11 +1121,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772638901,
-        "narHash": "sha256-kzAyU054Mzpnzgx475MgmcjYJXxXWQWBG7LLsYtHXKw=",
+        "lastModified": 1775699406,
+        "narHash": "sha256-YpDALorsidLjSyS5ozvsNI7Gz/bkmDs/ls/9oHKPv40=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "75de12ddd50616a3628499ec18b648bceb88eb0d",
+        "rev": "b05c87c1a474cdd6979a4e5f7058edf4073554df",
         "type": "github"
       },
       "original": {

--- a/rpi5/openclaw/openclaw.nix
+++ b/rpi5/openclaw/openclaw.nix
@@ -144,6 +144,8 @@ in
 
     instances.default = {
       enable = true;
+      # openclaw bundles node/python/etc.; lower priority avoids conflicts with nixpkgs versions.
+      package = pkgs.openclaw.overrideAttrs (_: { meta.priority = 20; });
 
       config = {
         gateway.mode = "local";

--- a/rpi5/openclaw/plugins/gogcli/flake.lock
+++ b/rpi5/openclaw/plugins/gogcli/flake.lock
@@ -18,12 +18,18 @@
     },
     "root": {
       "inputs": {
+        "nixpkgs": "nixpkgs",
+        "root": "root_2"
+      }
+    },
+    "root_2": {
+      "inputs": {
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1769793795,
+        "lastModified": 1769797395,
         "narHash": "sha256-QkPl/Rgk9DXgaVNhjvHHHjy5e81j+MzcVOouZRdUTLA=",
         "owner": "openclaw",
         "repo": "nix-steipete-tools",
@@ -37,14 +43,8 @@
         "rev": "dbf0a31a57407d9140e32357ea8d0215bd9feed9",
         "type": "github"
       }
-    },
-    "self": {
-      "inputs": {
-        "nixpkgs": "nixpkgs",
-        "root": "root"
-      }
     }
   },
-  "root": "self",
+  "root": "root",
   "version": 7
 }

--- a/rpi5/openclaw/plugins/goplaces/flake.lock
+++ b/rpi5/openclaw/plugins/goplaces/flake.lock
@@ -18,12 +18,18 @@
     },
     "root": {
       "inputs": {
+        "nixpkgs": "nixpkgs",
+        "root": "root_2"
+      }
+    },
+    "root_2": {
+      "inputs": {
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1770234344,
+        "lastModified": 1770237944,
         "narHash": "sha256-nfCSSyNU97XpKVPgo6mODBwrVeTOuMCl3i18QuGjpN0=",
         "owner": "openclaw",
         "repo": "nix-steipete-tools",
@@ -37,14 +43,8 @@
         "rev": "6352c8247b3b889d7f17bce1f09d6c58fd34932c",
         "type": "github"
       }
-    },
-    "self": {
-      "inputs": {
-        "nixpkgs": "nixpkgs",
-        "root": "root"
-      }
     }
   },
-  "root": "self",
+  "root": "root",
   "version": 7
 }

--- a/rpi5/openclaw/plugins/summarize/flake.lock
+++ b/rpi5/openclaw/plugins/summarize/flake.lock
@@ -18,12 +18,18 @@
     },
     "root": {
       "inputs": {
+        "nixpkgs": "nixpkgs",
+        "root": "root_2"
+      }
+    },
+    "root_2": {
+      "inputs": {
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1769793795,
+        "lastModified": 1769797395,
         "narHash": "sha256-QkPl/Rgk9DXgaVNhjvHHHjy5e81j+MzcVOouZRdUTLA=",
         "owner": "openclaw",
         "repo": "nix-steipete-tools",
@@ -37,14 +43,8 @@
         "rev": "dbf0a31a57407d9140e32357ea8d0215bd9feed9",
         "type": "github"
       }
-    },
-    "self": {
-      "inputs": {
-        "nixpkgs": "nixpkgs",
-        "root": "root"
-      }
     }
   },
-  "root": "self",
+  "root": "root",
   "version": 7
 }


### PR DESCRIPTION
## Summary
- Bump all flake inputs (nixpkgs, home-manager, nix-gaming, nix-citizen, zen-browser, nix-steipete-tools, nixpkgs-unstable)
- Pin `openclaw-source` and `nix-openclaw` to previous versions to avoid openclaw-gateway rebuild (exhausts inodes on RPi5 ext4)
- Fix plugin wrapper `flake.lock` lastModified for root nix compat
- Add `meta.priority = 20` on openclaw instance package to resolve `/bin/node` and `/bin/python3-config` conflicts with nixpkgs

## Test plan
- [x] NixOS rebuild switch succeeded (generation 315)
- [x] All services running, no failures
- [x] ha-linky recovered after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)