### PR TITLE
Fix(Claude): remove `command` builtin from `env` invocation

### DIFF
--- a/home/dotfiles/zsh/aliases.zsh
+++ b/home/dotfiles/zsh/aliases.zsh
@@ -26,7 +26,7 @@ _claude_with_env() {
     GH_TOKEN="$(gh auth token --user nSimonFR-ai)" \
     GITHUB_TOKEN="" \
     PATH="$HOME/.claude/bin:$PATH" \
-    command claude "$@"
+    claude "$@"
 }
 claude() { _claude_with_env --dangerously-skip-permissions --remote-control "$@"; }
 cc()     { _claude_with_env --continue "$@"; }


### PR DESCRIPTION
## Summary
- Remove `command` from `env ... command claude "$@"` in `_claude_with_env()` — `env` is an external binary that can't execute shell builtins, causing `env: 'command': No such file or directory`
- `env` already only searches `$PATH` for executables (ignores shell functions), so `command` was redundant for preventing recursion
- Works identically on both Linux and macOS

## Test plan
- [ ] Run `claude` on macOS — should launch without `env: 'command'` error
- [ ] Run `claude` on Linux (rpi5) — same

🤖 Generated with [Claude Code](https://claude.com/claude-code)