### PR TITLE
Fix(Claude): separate git identity for Claude vs personal use

### DIFF
--- a/home/default.nix
+++ b/home/default.nix
@@ -23,7 +23,7 @@
   ];
 
   xdg.enable = true;
-  xdg.configFile."git/config".source = ./dotfiles/git/gitconfig;
+  xdg.configFile."git/config".source = ./dotfiles/git/gitconfig-personal;
   xdg.configFile."git/config-shared".source = ./dotfiles/git/gitconfig-shared;
   xdg.configFile."git/config-personal".source = ./dotfiles/git/gitconfig-personal;
   xdg.configFile."git/ignore".source = ./dotfiles/git/gitignore;

--- a/home/default.nix
+++ b/home/default.nix
@@ -23,9 +23,8 @@
   ];
 
   xdg.enable = true;
-  xdg.configFile."git/config".source = ./dotfiles/git/gitconfig-personal;
+  xdg.configFile."git/config".source = ./dotfiles/git/gitconfig;
   xdg.configFile."git/config-shared".source = ./dotfiles/git/gitconfig-shared;
-  xdg.configFile."git/config-personal".source = ./dotfiles/git/gitconfig-personal;
   xdg.configFile."git/ignore".source = ./dotfiles/git/gitignore;
   xdg.configFile."tmux/tmux.conf".source = ./dotfiles/tmux.conf;
   xdg.configFile."atuin/config.toml".source = ./dotfiles/atuin.toml;

--- a/home/dotfiles/git/gitconfig
+++ b/home/dotfiles/git/gitconfig
@@ -1,9 +1,8 @@
 [include]
   path = ~/.config/git/config-shared
 [user]
-  email = 13413730+nSimonFR@users.noreply.github.com
-  name = nSimonFR-ai
-[core]
-  sshCommand = ssh -i ~/.ssh/ai_id_ed25519 -o IdentityAgent=none
+  email = nsimon@pm.me
+  name = Nicolas Simon
+  signingkey = DA790614A5E94643A86333BBFDA7E6C61C9EA664
 [commit]
-  gpgsign = false
+  gpgsign = true

--- a/home/dotfiles/git/gitconfig-personal
+++ b/home/dotfiles/git/gitconfig-personal
@@ -1,8 +1,0 @@
-[include]
-  path = ~/.config/git/config-shared
-[user]
-  email = nsimon@pm.me
-  name = Nicolas Simon
-  signingkey = DA790614A5E94643A86333BBFDA7E6C61C9EA664
-[commit]
-  gpgsign = true

--- a/home/dotfiles/zsh/aliases.zsh
+++ b/home/dotfiles/zsh/aliases.zsh
@@ -23,9 +23,12 @@ alias vpn-status='tailscale status | grep -E "(rpi5|exit node)" || echo "Exit no
 _claude_with_env() {
   env \
     GIT_SSH_COMMAND="ssh -i ~/.ssh/ai_id_ed25519 -o IdentityAgent=none" \
+    GIT_AUTHOR_NAME="nSimonFR-ai" \
+    GIT_AUTHOR_EMAIL="265587706+nSimonFR-ai@users.noreply.github.com" \
+    GIT_COMMITTER_NAME="nSimonFR-ai" \
+    GIT_COMMITTER_EMAIL="265587706+nSimonFR-ai@users.noreply.github.com" \
     GH_TOKEN="$(gh auth token --user nSimonFR-ai)" \
     GITHUB_TOKEN="" \
-    PATH="$HOME/.claude/bin:$PATH" \
     claude "$@"
 }
 claude() { _claude_with_env --dangerously-skip-permissions --remote-control "$@"; }

--- a/rpi5/openclaw/openclaw.nix
+++ b/rpi5/openclaw/openclaw.nix
@@ -65,6 +65,12 @@ in
     "OPENCLAW_BUNDLED_SKILLS_DIR=${bundledSkillsLink}"
     "OPENCLAW_NO_RESPAWN=1"
     "NODE_COMPILE_CACHE=/var/tmp/openclaw-compile-cache"
+    # AI git identity for agents dispatched by openclaw (Claude Code, codex, etc.)
+    "GIT_SSH_COMMAND=ssh -i /home/nsimon/.ssh/ai_id_ed25519 -o IdentityAgent=none"
+    "GIT_AUTHOR_NAME=nSimonFR-ai"
+    "GIT_AUTHOR_EMAIL=265587706+nSimonFR-ai@users.noreply.github.com"
+    "GIT_COMMITTER_NAME=nSimonFR-ai"
+    "GIT_COMMITTER_EMAIL=265587706+nSimonFR-ai@users.noreply.github.com"
   ];
   systemd.user.services.openclaw-gateway.Service.ExecStartPre = [ "${setupScript}" ];
   systemd.user.services.openclaw-gateway.Install.WantedBy = [ "default.target" ];


### PR DESCRIPTION
## Summary
- Switch global git config (`~/.config/git/config`) from the AI gitconfig to `gitconfig-personal` so interactive commits use Nicolas Simon's identity with GPG signing
- Set Claude's AI identity (nSimonFR-ai) via `GIT_AUTHOR_*`/`GIT_COMMITTER_*` env vars in `_claude_with_env`, which override config files at runtime
- Remove non-existent `~/.claude/bin` PATH entry

## Test plan
- [ ] Run `git config user.name` in a normal shell — should show "Nicolas Simon"
- [ ] Run `claude` and check `git config user.name` inside — env vars should override to "nSimonFR-ai"
- [ ] Verify commits from Claude are attributed to nSimonFR-ai on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)