### PR TITLE
Fix(greeter): add monitor config for correct login screen

### DIFF
--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -20,6 +20,9 @@ let
     }
   '';
   greeterHyprlandConfig = pkgs.writeText "greetd-hyprland.conf" ''
+    monitor = desc:LG Electronics 38GN950 008NTKFBE741, 3840x1600@160, 1080x0, 1
+    monitor = desc:Acer Technologies GN246HL LW3EE0058532, 1920x1080@60, 0x0, 1, transform, 3
+    monitor = , preferred, auto, 1
     misc {
       disable_hyprland_logo = true
       disable_splash_rendering = true


### PR DESCRIPTION
## Summary
- The greeter Hyprland config (added in 35a4c38) had no `monitor` lines, so the login prompt appeared on the rotated Acer monitor instead of the LG ultrawide
- Adds the same monitor layout from `hyprland.conf` to the greeter config

## Test plan
- [ ] Reboot beast and verify the login prompt appears on the LG ultrawide
- [ ] Verify DPMS still works (screens off after 5min idle at greeter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)