### PR TITLE
fix(siyuan): container mode + port handling

### DIFF
--- a/rpi5/siyuan.nix
+++ b/rpi5/siyuan.nix
@@ -1,6 +1,6 @@
 { pkgs, ... }:
 let
-  port = 16806; # internal port (6806 conflicts with Tailscale Serve on 0.0.0.0)
+  port = 6806; # RUN_IN_CONTAINER overrides this to 6806 on 0.0.0.0 regardless
   dataDir = "/var/lib/siyuan";
 in
 {

--- a/rpi5/siyuan.nix
+++ b/rpi5/siyuan.nix
@@ -29,8 +29,7 @@ in
           -port ${toString port} \
           -workspace ${dataDir} \
           -wd ${pkgs.siyuan}/share/siyuan/resources \
-          -accessAuthCode "$AUTH_CODE" \
-          -resident true
+          -accessAuthCode "$AUTH_CODE"
       '';
       Restart = "on-failure";
       RestartSec = "5s";

--- a/rpi5/siyuan.nix
+++ b/rpi5/siyuan.nix
@@ -15,6 +15,7 @@ in
     description = "SiYuan Notes";
     after = [ "network.target" ];
     wantedBy = [ "multi-user.target" ];
+    environment.RUN_IN_CONTAINER = "true";
     serviceConfig = {
       Type = "simple";
       User = "siyuan";
@@ -22,12 +23,14 @@ in
       StateDirectory = "siyuan";
       WorkingDirectory = dataDir;
       ExecStart = pkgs.writeShellScript "siyuan-start" ''
+        export RUN_IN_CONTAINER=true
         AUTH_CODE=$(cat /run/agenix/siyuan-auth-code)
         exec ${pkgs.siyuan.kernel}/bin/kernel \
           -port ${toString port} \
           -workspace ${dataDir} \
           -wd ${pkgs.siyuan}/share/siyuan/resources \
-          -accessAuthCode "$AUTH_CODE"
+          -accessAuthCode "$AUTH_CODE" \
+          -resident true
       '';
       Restart = "on-failure";
       RestartSec = "5s";

--- a/rpi5/siyuan.nix
+++ b/rpi5/siyuan.nix
@@ -1,6 +1,6 @@
 { pkgs, ... }:
 let
-  port = 6806;
+  port = 16806; # internal port (6806 conflicts with Tailscale Serve on 0.0.0.0)
   dataDir = "/var/lib/siyuan";
 in
 {

--- a/rpi5/tailscale-serve.nix
+++ b/rpi5/tailscale-serve.nix
@@ -11,7 +11,7 @@ let
     { port = 3333;  backend = "http://127.0.0.1:13334"; } # sure (personal finance)
     { port = 4040;  backend = "http://127.0.0.1:4040";  } # openai-codex proxy
     { port = 8222;  backend = "http://127.0.0.1:8222";  } # vaultwarden (bitwarden)
-    { port = 6806;  backend = "http://127.0.0.1:16806"; } # siyuan (notes/wiki)
+    { port = 6806;  backend = "http://127.0.0.1:6806";  } # siyuan (notes/wiki)
   ];
 
   # Publicly-accessible services (tailscale funnel).

--- a/rpi5/tailscale-serve.nix
+++ b/rpi5/tailscale-serve.nix
@@ -11,7 +11,7 @@ let
     { port = 3333;  backend = "http://127.0.0.1:13334"; } # sure (personal finance)
     { port = 4040;  backend = "http://127.0.0.1:4040";  } # openai-codex proxy
     { port = 8222;  backend = "http://127.0.0.1:8222";  } # vaultwarden (bitwarden)
-    { port = 6806;  backend = "http://127.0.0.1:6806";  } # siyuan (notes/wiki)
+    { port = 6806;  backend = "http://127.0.0.1:16806"; } # siyuan (notes/wiki)
   ];
 
   # Publicly-accessible services (tailscale funnel).


### PR DESCRIPTION
## Summary
- Set `RUN_IN_CONTAINER=true` to prevent kernel auto-exit (no UI proc detection)
- SiYuan in container mode hardcodes `0.0.0.0:6806` (ignores `-port` flag)
- No Tailscale Serve port conflict since they bind different IPs
- Removed invalid `-resident` flag (not in v3.5.4)

## Verified
- Service stays active (previously died after ~90s)
- HTTP 401 on `http://127.0.0.1:6806` (auth required = working)
- Tailscale Serve proxying correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)