### PR TITLE
feat(ssh): migrate to Vaultwarden SSH agent + rotate to ed25519

### DIFF
--- a/home/dotfiles/zsh/functions.zsh
+++ b/home/dotfiles/zsh/functions.zsh
@@ -188,7 +188,7 @@ function age-edit() {
   local tmp=$(mktemp)
   age -d -i ~/.ssh/age "$file" > "$tmp" \
     && vim "$tmp" \
-    && age -R ~/.ssh/age.pub -R ~/.ssh/id_rsa.pub -o "$file" "$tmp"
+    && age -R ~/.ssh/age.pub -o "$file" "$tmp"
   rm -f "$tmp"
 }
 

--- a/macos/home.nix
+++ b/macos/home.nix
@@ -7,5 +7,10 @@
   home = {
     username = username;
     homeDirectory = "/Users/${username}";
+
+    sessionVariables = {
+      # Bitwarden/Vaultwarden SSH agent (desktop app)
+      SSH_AUTH_SOCK = "$HOME/.bitwarden-ssh-agent.sock";
+    };
   };
 }

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -149,8 +149,7 @@ in
     home = "/home/${username}";
 
     openssh.authorizedKeys.keys = [
-      # TODO: fetch from github
-      "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCfTlFbZh0ufzEysBxzaEhLU7A4J/n+c3ObaBr+nJPoovoBh9q4hB9KYwkr7y1wkkZgA6/aZqJu4HH2SCARGabyPJW2h2QY+IXs/pI7TV0eFaCP8SZjHWtz5rBm92pVSzXd/6/YoO+Ugn9EsuPYgnuGYlFaQ1BQrqCpJ7d+c9ZNU4mEKPNM5Ly/yo2V5Ox5nBfQg7jq9YIP0UFFwRe28Pi5OGCn0Wl+1aTOtd9sB06pXB4/CxCGRKZJLGe6QVMTFZJLObitjYpEX3zZ4Cj2MEiHVf6eubH0kTo6RSxYBZJBB2mmgBoDr9uae95LTXUBYoMPFb0dNYxzwe6HDZnqkBvlfsO6CHHAJYxqkRhxHgCy2gItJXpZ4HAPGezcnvBinTfuyf18Crb9wxiH5VaCaNaLhp66881KdLoMzNUTWU9L0ZRMzmabj0XgjpRLEqnTdvqq6H+NwYF1Avew07zwb8iZtbCIb2dxu653RxM8DwxmUnfmAAuxvxOoFpgYjDsDkahDEOynTkYWASbOoha66H5tU0mrAdeyooieHlFqAz/vjo5X/eIerWVrKEy0MdLx4Yu15ObTlWscU3qQyUmVlnH0SDg7ulH+4uNsXFE7jGHwg03MpYYAExTbPMpKlhJdaQI2Jzp3CcSqIG+1ODuPK8VcshTAtP0IrZ+ykFflB4EIcw=="
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBZ7wzLFXmWeZ52SWjvsfXSZr+LbvpZYt/EE/tzVZnFd"
     ];
   };
 

--- a/nixos/home.nix
+++ b/nixos/home.nix
@@ -58,8 +58,8 @@
       ELECTRON_OZONE_PLATFORM_HINT = "auto";
       NIXOS_OZONE_WL = "1";
 
-      # 1Password SSH agent
-      SSH_AUTH_SOCK = "$HOME/.1password/agent.sock";
+      # Bitwarden/Vaultwarden SSH agent (desktop app)
+      SSH_AUTH_SOCK = "$HOME/.bitwarden-ssh-agent.sock";
 
       # Vulkan shader cache size (increase from default ~1GB to 10GB)
       "MESA_SHADER_CACHE_MAX_SIZE" = "10G";

--- a/rpi5/configuration.nix
+++ b/rpi5/configuration.nix
@@ -232,7 +232,7 @@ in
     ];
     home = "/home/${username}";
     openssh.authorizedKeys.keys = [
-      "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCfTlFbZh0ufzEysBxzaEhLU7A4J/n+c3ObaBr+nJPoovoBh9q4hB9KYwkr7y1wkkZgA6/aZqJu4HH2SCARGabyPJW2h2QY+IXs/pI7TV0eFaCP8SZjHWtz5rBm92pVSzXd/6/YoO+Ugn9EsuPYgnuGYlFaQ1BQrqCpJ7d+c9ZNU4mEKPNM5Ly/yo2V5Ox5nBfQg7jq9YIP0UFFwRe28Pi5OGCn0Wl+1aTOtd9sB06pXB4/CxCGRKZJLGe6QVMTFZJLObitjYpEX3zZ4Cj2MEiHVf6eubH0kTo6RSxYBZJBB2mmgBoDr9uae95LTXUBYoMPFb0dNYxzwe6HDZnqkBvlfsO6CHHAJYxqkRhxHgCy2gItJXpZ4HAPGezcnvBinTfuyf18Crb9wxiH5VaCaNaLhp66881KdLoMzNUTWU9L0ZRMzmabj0XgjpRLEqnTdvqq6H+NwYF1Avew07zwb8iZtbCIb2dxu653RxM8DwxmUnfmAAuxvxOoFpgYjDsDkahDEOynTkYWASbOoha66H5tU0mrAdeyooieHlFqAz/vjo5X/eIerWVrKEy0MdLx4Yu15ObTlWscU3qQyUmVlnH0SDg7ulH+4uNsXFE7jGHwg03MpYYAExTbPMpKlhJdaQI2Jzp3CcSqIG+1ODuPK8VcshTAtP0IrZ+ykFflB4EIcw=="
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBZ7wzLFXmWeZ52SWjvsfXSZr+LbvpZYt/EE/tzVZnFd"
       "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIoO5ICofBCfox+M2Uz91qBRF794BwHhQJBL/9dSZahr nsimon@rpi5-openclaw"
     ];
   };

--- a/rpi5/secrets/secrets.nix
+++ b/rpi5/secrets/secrets.nix
@@ -1,17 +1,17 @@
 let
   nsimon-age = "age1x99u04m887emqp9dp44r4ey8ky8m8gtuwx07z2fm89u8xu6jfa2sxjux9w";
-  nsimon-rsa = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCfTlFbZh0ufzEysBxzaEhLU7A4J/n+c3ObaBr+nJPoovoBh9q4hB9KYwkr7y1wkkZgA6/aZqJu4HH2SCARGabyPJW2h2QY+IXs/pI7TV0eFaCP8SZjHWtz5rBm92pVSzXd/6/YoO+Ugn9EsuPYgnuGYlFaQ1BQrqCpJ7d+c9ZNU4mEKPNM5Ly/yo2V5Ox5nBfQg7jq9YIP0UFFwRe28Pi5OGCn0Wl+1aTOtd9sB06pXB4/CxCGRKZJLGe6QVMTFZJLObitjYpEX3zZ4Cj2MEiHVf6eubH0kTo6RSxYBZJBB2mmgBoDr9uae95LTXUBYoMPFb0dNYxzwe6HDZnqkBvlfsO6CHHAJYxqkRhxHgCy2gItJXpZ4HAPGezcnvBinTfuyf18Crb9wxiH5VaCaNaLhp66881KdLoMzNUTWU9L0ZRMzmabj0XgjpRLEqnTdvqq6H+NwYF1Avew07zwb8iZtbCIb2dxu653RxM8DwxmUnfmAAuxvxOoFpgYjDsDkahDEOynTkYWASbOoha66H5tU0mrAdeyooieHlFqAz/vjo5X/eIerWVrKEy0MdLx4Yu15ObTlWscU3qQyUmVlnH0SDg7ulH+4uNsXFE7jGHwg03MpYYAExTbPMpKlhJdaQI2Jzp3CcSqIG+1ODuPK8VcshTAtP0IrZ+ykFflB4EIcw==";
+  nsimon-ed25519 = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBZ7wzLFXmWeZ52SWjvsfXSZr+LbvpZYt/EE/tzVZnFd";
 in {
-  "openclaw.env.age".publicKeys       = [ nsimon-age nsimon-rsa ];
-  "supervisor-token.age".publicKeys   = [ nsimon-age nsimon-rsa ];
-  "linky-token.age".publicKeys        = [ nsimon-age nsimon-rsa ];
-  "linky-prm.age".publicKeys          = [ nsimon-age nsimon-rsa ];
-  "openclaw-codex-auth.age".publicKeys = [ nsimon-age nsimon-rsa ];
-  "rclone-storj.age".publicKeys        = [ nsimon-age nsimon-rsa ];
-  "immich-api-key.age".publicKeys      = [ nsimon-age nsimon-rsa ];
-  "sure-app-env.age".publicKeys        = [ nsimon-age nsimon-rsa ];
-  "sure-pg-password.age".publicKeys    = [ nsimon-age nsimon-rsa ];
-  "for-sure-swile-api-key.age".publicKeys   = [ nsimon-age nsimon-rsa ];
-  "vaultwarden-admin-token.age".publicKeys  = [ nsimon-age nsimon-rsa ];
-  "siyuan-auth-code.age".publicKeys        = [ nsimon-age nsimon-rsa ];
+  "openclaw.env.age".publicKeys       = [ nsimon-age nsimon-ed25519 ];
+  "supervisor-token.age".publicKeys   = [ nsimon-age nsimon-ed25519 ];
+  "linky-token.age".publicKeys        = [ nsimon-age nsimon-ed25519 ];
+  "linky-prm.age".publicKeys          = [ nsimon-age nsimon-ed25519 ];
+  "openclaw-codex-auth.age".publicKeys = [ nsimon-age nsimon-ed25519 ];
+  "rclone-storj.age".publicKeys        = [ nsimon-age nsimon-ed25519 ];
+  "immich-api-key.age".publicKeys      = [ nsimon-age nsimon-ed25519 ];
+  "sure-app-env.age".publicKeys        = [ nsimon-age nsimon-ed25519 ];
+  "sure-pg-password.age".publicKeys    = [ nsimon-age nsimon-ed25519 ];
+  "for-sure-swile-api-key.age".publicKeys   = [ nsimon-age nsimon-ed25519 ];
+  "vaultwarden-admin-token.age".publicKeys  = [ nsimon-age nsimon-ed25519 ];
+  "siyuan-auth-code.age".publicKeys        = [ nsimon-age nsimon-ed25519 ];
 }

--- a/shared/secrets.nix
+++ b/shared/secrets.nix
@@ -1,7 +1,7 @@
 let
   nsimon-age = "age1x99u04m887emqp9dp44r4ey8ky8m8gtuwx07z2fm89u8xu6jfa2sxjux9w";
-  nsimon-rsa = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCfTlFbZh0ufzEysBxzaEhLU7A4J/n+c3ObaBr+nJPoovoBh9q4hB9KYwkr7y1wkkZgA6/aZqJu4HH2SCARGabyPJW2h2QY+IXs/pI7TV0eFaCP8SZjHWtz5rBm92pVSzXd/6/YoO+Ugn9EsuPYgnuGYlFaQ1BQrqCpJ7d+c9ZNU4mEKPNM5Ly/yo2V5Ox5nBfQg7jq9YIP0UFFwRe28Pi5OGCn0Wl+1aTOtd9sB06pXB4/CxCGRKZJLGe6QVMTFZJLObitjYpEX3zZ4Cj2MEiHVf6eubH0kTo6RSxYBZJBB2mmgBoDr9uae95LTXUBYoMPFb0dNYxzwe6HDZnqkBvlfsO6CHHAJYxqkRhxHgCy2gItJXpZ4HAPGezcnvBinTfuyf18Crb9wxiH5VaCaNaLhp66881KdLoMzNUTWU9L0ZRMzmabj0XgjpRLEqnTdvqq6H+NwYF1Avew07zwb8iZtbCIb2dxu653RxM8DwxmUnfmAAuxvxOoFpgYjDsDkahDEOynTkYWASbOoha66H5tU0mrAdeyooieHlFqAz/vjo5X/eIerWVrKEy0MdLx4Yu15ObTlWscU3qQyUmVlnH0SDg7ulH+4uNsXFE7jGHwg03MpYYAExTbPMpKlhJdaQI2Jzp3CcSqIG+1ODuPK8VcshTAtP0IrZ+ykFflB4EIcw==";
+  nsimon-ed25519 = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBZ7wzLFXmWeZ52SWjvsfXSZr+LbvpZYt/EE/tzVZnFd";
 in {
-  "secrets.zsh.age".publicKeys        = [ nsimon-age nsimon-rsa ];
-  "telegram-bot-token.age".publicKeys = [ nsimon-age nsimon-rsa ];
+  "secrets.zsh.age".publicKeys        = [ nsimon-age nsimon-ed25519 ];
+  "telegram-bot-token.age".publicKeys = [ nsimon-age nsimon-ed25519 ];
 }


### PR DESCRIPTION
## Summary
- Switch SSH agent from 1Password to Bitwarden/Vaultwarden (`~/.bitwarden-ssh-agent.sock`) on both macOS and NixOS
- Replace old RSA key with new ed25519 key in `authorizedKeys` (beast + rpi5)
- Rotate agenix secrets encryption from `nsimon-rsa` to `nsimon-ed25519`
- Remove `id_rsa.pub` recipient from `age-edit()` helper

## Post-merge TODO
- [ ] Re-key agenix secrets: `cd rpi5/secrets && agenix -r` + `cd shared && agenix -r`
- [ ] Add new ed25519 pubkey to GitHub SSH keys
- [ ] Update any other remote `authorized_keys` not managed by this repo
- [ ] Rebuild NixOS on beast and rpi5

🤖 Generated with [Claude Code](https://claude.com/claude-code)