### PR TITLE
fix(openclaw): remove Claude OAuth env injection

### DIFF
--- a/rpi5/openclaw/openclaw.nix
+++ b/rpi5/openclaw/openclaw.nix
@@ -80,7 +80,6 @@ in
     export OPENCLAW_NO_RESPAWN=1
     export NODE_COMPILE_CACHE=/var/tmp/openclaw-compile-cache
     [ -r /run/agenix/openclaw-env ] && source /run/agenix/openclaw-env
-    [ -n "$ANTHROPIC_API_KEY" ] && export CLAUDE_CODE_OAUTH_TOKEN="$ANTHROPIC_API_KEY"
   '';
   # Restore OpenAI Codex OAuth auth profile on fresh install (only if missing).
   # openclaw manages token rotation itself; we never overwrite an existing file.


### PR DESCRIPTION
## Summary
- Remove the `CLAUDE_CODE_OAUTH_TOKEN` export from `ANTHROPIC_API_KEY` in openclaw's zsh env config — no longer needed.

## Test plan
- [x] home-manager rebuild succeeds
- [x] openclaw-gateway restarts cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)