### PR TITLE
Fix(ollama): use ollama-cuda for GPU offloading

### DIFF
--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -592,8 +592,8 @@ kdePackages.kwallet
     package = (import inputs.nixpkgs-unstable {
       system = "x86_64-linux";
       config.allowUnfree = true;
-    }).ollama;
-    acceleration = "cuda";
+      config.cudaSupport = true;
+    }).ollama-cuda;
     host = "0.0.0.0"; # Bind all interfaces — firewalled to tailscale0 + localhost
     loadModels = [ "gemma4:26b" "qwen3.5:35b-a3b" ];
   };


### PR DESCRIPTION
## Summary
- The `acceleration = "cuda"` option was removed in nixpkgs-unstable, so Ollama was silently falling back to CPU-only inference (0/31 layers offloaded to GPU)
- Switch to `ollama-cuda` package with `cudaSupport = true` so the RTX 3080 Ti is used
- Verified: Ollama now detects CUDA compute 8.6 with 11.5 GiB available VRAM

## Test plan
- [x] `nixos-rebuild switch` succeeds
- [x] `journalctl -u ollama` shows `inference compute ... library=CUDA ... name="NVIDIA GeForce RTX 3080 Ti"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)