### PR TITLE
fix+perf: siyuan, openclaw env, memory optimizations

### DIFF
--- a/rpi5/configuration.nix
+++ b/rpi5/configuration.nix
@@ -214,6 +214,12 @@ in
 
   services.resolved.enable = true;
 
+  # Cap journal size to reduce RSS and disk usage on 4 GB RPi5
+  services.journald.extraConfig = ''
+    SystemMaxUse=500M
+    RuntimeMaxUse=20M
+  '';
+
   time.timeZone = "Europe/Paris";
 
   i18n.defaultLocale = "en_US.UTF-8";

--- a/rpi5/monitoring/prometheus.nix
+++ b/rpi5/monitoring/prometheus.nix
@@ -8,14 +8,14 @@ in
     enable         = true;
     port           = prometheusPort;
     listenAddress  = "127.0.0.1";
-    retentionTime  = "30d";
+    retentionTime  = "15d";
     # Disable build-time config validation: bearer_token_file for Home Assistant
     # points to a runtime secret that doesn't exist in the Nix build sandbox.
     checkConfig    = false;
 
     globalConfig = {
-      scrape_interval     = "15s";
-      evaluation_interval = "15s";
+      scrape_interval     = "60s";
+      evaluation_interval = "60s";
     };
 
     scrapeConfigs = [
@@ -36,6 +36,9 @@ in
         ]; }
     ];
   };
+
+  # Limit Go runtime threads to reduce GC overhead on 4 GB RPi5
+  systemd.services.prometheus.environment.GOMAXPROCS = "2";
 
   # ── Exporters ───────────────────────────────────────────────────────────────
   services.prometheus.exporters = {

--- a/rpi5/sure.nix
+++ b/rpi5/sure.nix
@@ -64,6 +64,15 @@ in
     redisUrl        = "redis://${redisHost}:${toString redisPort}/2";
   };
 
+  # ── Sure memory optimizations ──────────────────────────────────────────────
+  # Reduce Sidekiq concurrency (personal app, no need for 3 threads) and limit
+  # glibc malloc arenas to curb RSS on a 4 GB RPi5.
+  systemd.services.sure-worker.environment = {
+    RAILS_MAX_THREADS = "1";
+    MALLOC_ARENA_MAX  = "2";
+  };
+  systemd.services.sure-web.environment.MALLOC_ARENA_MAX = "2";
+
   # sure-setup (migrations) must run after the password is set
   systemd.services.sure-setup = {
     after    = [ "sure-pg-setup.service" ];


### PR DESCRIPTION
## Summary
- **siyuan**: fix auto-exit and port conflicts (`RUN_IN_CONTAINER`, correct internal port 6806)
- **openclaw**: stop leaking OAuth env vars into user shell
- **sure**: reduce Sidekiq concurrency 3→1, add `MALLOC_ARENA_MAX=2` to curb Ruby RSS
- **prometheus**: scrape interval 15s→60s, retention 30d→15d, `GOMAXPROCS=2`
- **journald**: cap `SystemMaxUse=500M`, `RuntimeMaxUse=20M` (was unlimited, 3.9G on disk)

## Test plan
- [x] `nixos-rebuild switch` succeeds
- [x] All services active (`sure-web`, `sure-worker`, `prometheus`, `journald`)
- [x] Sidekiq shows `0 of 1 busy` (was `0 of 3`)
- [x] Available RAM improved from ~600 MB to ~1.3 GB

🤖 Generated with [Claude Code](https://claude.com/claude-code)