### PR TITLE
chore: add probot settings for repo configuration

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,56 @@
+# These settings are synced to GitHub by https://github.com/probot/settings
+
+repository:
+  name: nic-os
+  description: "\U0001F4BB My nixOS / macOS configurations !"
+  homepage: ""
+  topics: dotfiles, nix, nix-darwin, nixos
+  private: false
+  has_issues: true
+  has_projects: true
+  has_wiki: true
+  has_downloads: true
+  default_branch: main
+  allow_squash_merge: false
+  allow_merge_commit: false
+  allow_rebase_merge: true
+  delete_branch_on_merge: false
+  allow_auto_merge: false
+
+labels:
+  - name: bug
+    color: d73a4a
+    description: Something isn't working
+  - name: documentation
+    color: 0075ca
+    description: Improvements or additions to documentation
+  - name: duplicate
+    color: cfd3d7
+    description: This issue or pull request already exists
+  - name: enhancement
+    color: a2eeef
+    description: New feature or request
+  - name: good first issue
+    color: 7057ff
+    description: Good for newcomers
+  - name: help wanted
+    color: 008672
+    description: Extra attention is needed
+  - name: invalid
+    color: e4e669
+    description: This doesn't seem right
+  - name: question
+    color: d876e3
+    description: Further information is requested
+  - name: wontfix
+    color: ffffff
+    description: This will not be worked on
+
+branches:
+  - name: main
+    protection:
+      required_pull_request_reviews:
+        required_approving_review_count: 1
+      required_status_checks: null
+      enforce_admins: true
+      restrictions: null


### PR DESCRIPTION
## Summary
- Add `.github/settings.yml` for probot/settings GitHub App
- Only allow rebase merges (disable squash and merge commit)
- Require PR with 1 approval on main, enforced for admins
- Mirror existing labels and repo metadata

## Setup
Install the [probot/settings](https://github.com/apps/settings) GitHub App on the repo for settings to sync on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)