### PR TITLE
feat: Vaultwarden SSH migration, SiYuan, Claude desktop

### DIFF
--- a/macos/components/homebrew.nix
+++ b/macos/components/homebrew.nix
@@ -38,6 +38,7 @@
     "arc"
     "beekeeper-studio"
     "beeper"
+    "claude"
     "cursor"
     "cyberduck"
     "disk-inventory-x"


### PR DESCRIPTION
## Summary
- Migrate SSH agent from 1Password to Vaultwarden + rotate keys to ed25519
- Add SiYuan Notes self-hosted service on RPi5
- Add Claude desktop app via Homebrew
- Clean up git configs, add AI git identity env vars, fix greeter monitor config

## Test plan
- [x] darwin-rebuild switch succeeds
- [x] Claude desktop installed via brew
- [x] SiYuan accessible on RPi5 via Tailscale

🤖 Generated with [Claude Code](https://claude.com/claude-code)