### PR TITLE
feat(ollama): add Ollama service

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -198,6 +198,7 @@
             };
           }
           ./rpi5/configuration.nix
+          ./rpi5/ollama.nix
         ];
       };
 

--- a/rpi5/ollama.nix
+++ b/rpi5/ollama.nix
@@ -1,0 +1,16 @@
+{ config, lib, pkgs, unstablePkgs, ... }:
+
+{
+  services.ollama = {
+    enable = true;
+    package = unstablePkgs.ollama;
+    # CPU-only on RPi5 (no GPU)
+    acceleration = false;
+    # Limit memory: Gemma 4 E2B Q4_K_M needs ~2.3 GB
+    environmentVariables = {
+      OLLAMA_MAX_LOADED_MODELS = "1";
+      OLLAMA_NUM_PARALLEL = "1";
+      GOMAXPROCS = "2";
+    };
+  };
+}


### PR DESCRIPTION
## Summary
- Add Ollama for local LLM inference on RPi5 (CPU-only)
- Memory-constrained: 1 loaded model, 2 GOMAXPROCS

## Test plan
- [ ] `nixos-rebuild switch` succeeds
- [ ] `ollama run` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)