### PR TITLE
feat(rofi-rbw): add Bitwarden password picker via rofi

### DIFF
--- a/nixos/dotfiles/rofi-rbw.rc
+++ b/nixos/dotfiles/rofi-rbw.rc
@@ -1,0 +1,5 @@
+action = copy
+target = menu
+prompt = Bitwarden
+selector-args = -theme ~/.config/rofi/spotlight/theme.rasi
+clipboarder = wl-copy

--- a/nixos/home.nix
+++ b/nixos/home.nix
@@ -177,6 +177,8 @@
     X-Flatpak-Tags=proprietary;
   '';
 
+  xdg.configFile."rofi-rbw.rc".source = ./dotfiles/rofi-rbw.rc;
+
   xdg.configFile."rofi" = {
     source = ./dotfiles/rofi;
     recursive = true;

--- a/nixos/packages.nix
+++ b/nixos/packages.nix
@@ -26,6 +26,10 @@ in
   home.packages = with pkgs; [
     _1password-gui
     bitwarden-desktop
+    rbw
+    pinentry-gnome3
+    pinentry-rofi
+    rofi-rbw-wayland
     beeper
     bemoji
     cliphist


### PR DESCRIPTION
## Summary
- Add `rofi-rbw-wayland` for Wayland-native Bitwarden password selection through rofi
- Install `rbw`, `pinentry-gnome3`, and `pinentry-rofi` as dependencies
- Add `rofi-rbw.rc` config (copy action, wl-copy clipboarder, spotlight theme)

## Test plan
- [ ] `rbw unlocked` after initial setup
- [ ] `rofi-rbw` opens rofi with Bitwarden entries
- [ ] Selecting an entry copies password via `wl-copy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)