### PR TITLE
fix(claude): wrap binary with AI identity and GH_TOKEN

### DIFF
--- a/home/claude.nix
+++ b/home/claude.nix
@@ -94,7 +94,19 @@ in
 
   programs.claude-code = {
     enable = true;
-    package = unstablePkgs.claude-code;
+    package = unstablePkgs.claude-code.overrideAttrs (old: {
+      nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ pkgs.makeWrapper ];
+      postFixup = (old.postFixup or "") + ''
+        wrapProgram $out/bin/claude \
+          --set GIT_SSH_COMMAND "ssh -i ~/.ssh/ai_id_ed25519 -o IdentityAgent=none" \
+          --set GIT_AUTHOR_NAME "nSimonFR-ai" \
+          --set GIT_AUTHOR_EMAIL "265587706+nSimonFR-ai@users.noreply.github.com" \
+          --set GIT_COMMITTER_NAME "nSimonFR-ai" \
+          --set GIT_COMMITTER_EMAIL "265587706+nSimonFR-ai@users.noreply.github.com" \
+          --run 'export GH_TOKEN="$(gh auth token --user nSimonFR-ai 2>/dev/null || true)"' \
+          --set GITHUB_TOKEN ""
+      '';
+    });
 
     settings = {
       effortLevel = "medium";

--- a/home/dotfiles/zsh/aliases.zsh
+++ b/home/dotfiles/zsh/aliases.zsh
@@ -17,20 +17,7 @@ alias vpn-on='tailscale up --exit-node=rpi5 --accept-routes && echo "✅ Exit no
 alias vpn-off='tailscale up --exit-node= --accept-routes && echo "❌ Exit node disabled (direct internet)"'
 alias vpn-status='tailscale status | grep -E "(rpi5|exit node)" || echo "Exit node: disabled"'
 
-# Claude Code: AI identity (nSimonFR-ai), clear personal GITHUB_TOKEN
-# Uses functions + `env` so env var assignments work correctly in zsh
-# (zsh does not treat dynamically-expanded array words as env var prefixes)
-_claude_with_env() {
-  env \
-    GIT_SSH_COMMAND="ssh -i ~/.ssh/ai_id_ed25519 -o IdentityAgent=none" \
-    GIT_AUTHOR_NAME="nSimonFR-ai" \
-    GIT_AUTHOR_EMAIL="265587706+nSimonFR-ai@users.noreply.github.com" \
-    GIT_COMMITTER_NAME="nSimonFR-ai" \
-    GIT_COMMITTER_EMAIL="265587706+nSimonFR-ai@users.noreply.github.com" \
-    GH_TOKEN="$(gh auth token --user nSimonFR-ai)" \
-    GITHUB_TOKEN="" \
-    claude "$@"
-}
-claude() { _claude_with_env --dangerously-skip-permissions --remote-control "$@"; }
-cc()     { _claude_with_env --continue "$@"; }
-cr()     { _claude_with_env --resume "$@"; }
+# Claude Code: env vars are set by the Nix wrapper (claude.nix)
+alias claude='command claude --dangerously-skip-permissions --remote-control'
+cc()     { command claude --continue "$@"; }
+cr()     { command claude --resume "$@"; }


### PR DESCRIPTION
## Summary
- Move env var setup (`GIT_*`, `GH_TOKEN`, `GITHUB_TOKEN=""`) from zsh alias into `makeWrapper` on the claude-code Nix package
- Ensures Claude Code always has the correct AI identity and GitHub token regardless of launch method
- Simplify shell aliases to only pass flags

## Test plan
- [ ] `echo $GH_TOKEN` is set inside Claude Code session
- [ ] `gh pr create` works without manual token setup
- [ ] Git commits use `nSimonFR-ai` identity

🤖 Generated with [Claude Code](https://claude.com/claude-code)