### PR TITLE
feat(rofi-rbw): replace 1Password keybind and reduce idle timeout

### DIFF
--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -16,7 +16,7 @@ let
     name = "hypr/hypridle.conf";
     path = pkgs.writeText "hypridle.conf" ''
       listener {
-        timeout = 300
+        timeout = 180
         on-timeout = hyprctl dispatch dpms off
         on-resume = hyprctl dispatch dpms on
       }

--- a/nixos/dotfiles/hypr/hyprland.conf
+++ b/nixos/dotfiles/hypr/hyprland.conf
@@ -100,7 +100,7 @@ bind = SUPERCONTROL, Delete, exec, hyprctl dispatch exit
 bind = SUPER,    Return, exec, ghostty
 bind = SUPER,     Space, exec, rofi -no-lazy-grab -show drun -modi run -theme ~/.config/rofi/launcher/theme.rasi
 bind = SUPER,         V, exec, cliphist list | rofi -dmenu -theme ~/.config/rofi/spotlight/theme.rasi | cliphist decode | wl-copy
-bind = SUPER, backslash, exec, 1password --quick-access
+bind = SUPER, backslash, exec, rbw unlocked 2>/dev/null || rbw unlock && rofi-rbw
 bind = SUPER,    period, exec, BEMOJI_PICKER_CMD="rofi -dmenu -theme ~/.config/rofi/spotlight/theme.rasi" bemoji -t
 
 bind = CONTROLSHIFT, page_up,   exec, wpctl set-volume @DEFAULT_AUDIO_SINK@ 5%+
@@ -250,7 +250,6 @@ exec-once = hypridle
 exec-once = hyprsunset
 exec-once = zen-twilight
 exec-once = sleep 1 && steam
-exec-once = sleep 1 && 1password --silent
 exec-once = sleep 1 && discord
 exec-once = sleep 2 && spotify
 exec-once = sleep 3 && hyprctl dispatch workspace 1


### PR DESCRIPTION
## Summary
- Switch `SUPER+\` from `1password --quick-access` to `rofi-rbw` (with auto-unlock)
- Remove `1password --silent` from Hyprland autostart
- Reduce hypridle DPMS timeout from 300s to 180s

_This commit was missed from #87's merge._

🤖 Generated with [Claude Code](https://claude.com/claude-code)