### PR TITLE
fix(SC): pin RSI Launcher Flatpak to GNOME Platform 49 runtime

### DIFF
--- a/nixos/home.nix
+++ b/nixos/home.nix
@@ -27,6 +27,26 @@
       --filesystem=/home/${username}/.cache/nvidia-shader-cache/star-citizen \
       --env=__GL_SHADER_DISK_CACHE_PATH=/home/${username}/.cache/nvidia-shader-cache/star-citizen \
       --talk-name=com.feralinteractive.GameMode
+
+    # Pin GNOME Platform 49 runtime: the RSI Launcher Flatpak ships GNOME 48 (EOL)
+    # which bundles libwayland-client 1.23.1. The host runs wayland 1.24.0 and the
+    # mismatch causes the Wayland client to segfault — wine creates surfaces but
+    # no window appears in the compositor. GNOME 49 ships wayland 1.24.0.
+    # `flatpak override` doesn't support [Application] section, so write it directly.
+    $DRY_RUN_CMD ${pkgs.coreutils}/bin/install -Dm644 /dev/stdin \
+      /home/${username}/.local/share/flatpak/overrides/io.github.mactan_sc.RSILauncher <<FLATPAK_OVERRIDE
+    [Application]
+    runtime=org.gnome.Platform/x86_64/49
+
+    [Context]
+    filesystems=/nix/store:ro;/run/current-system:ro;/home/${username}/mangohud-logs;/home/${username}/.cache/nvidia-shader-cache/star-citizen;xdg-config/MangoHud:ro;!/run/opengl-driver;
+
+    [Session Bus Policy]
+    com.feralinteractive.GameMode=talk
+
+    [Environment]
+    __GL_SHADER_DISK_CACHE_PATH=/home/${username}/.cache/nvidia-shader-cache/star-citizen
+    FLATPAK_OVERRIDE
   '';
 
   services.flatpak.remotes = [


### PR DESCRIPTION
## Summary
- RSI Launcher Flatpak invisible window caused by wayland library mismatch: GNOME Platform 48 (EOL) ships `libwayland-client 1.23.1` but host runs `1.24.0`
- The Wayland client segfaults when creating surfaces — wine connects but no `xdg_toplevel` appears in Hyprland
- Fix: pin Flatpak runtime to GNOME Platform 49 (ships wayland 1.24.0) via override file

## Test plan
- [ ] Reboot and launch RSI Launcher — window should appear
- [ ] Verify `flatpak override --user --show io.github.mactan_sc.RSILauncher` shows `runtime=org.gnome.Platform/x86_64/49`
- [ ] Once upstream (mactan-sc/rsilauncher) rebuilds against GNOME 49+, this pin can be removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)