### PR TITLE
feat: add AFFiNE, remove siyuan, bump zram

### DIFF
--- a/rpi5/affine.nix
+++ b/rpi5/affine.nix
@@ -1,0 +1,169 @@
+{ pkgs, lib, pgHost, pgPort, redisHost, redisPort, ... }:
+let
+  version = "0.26.6";
+  port = 3010;
+  dataDir = "/var/lib/affine";
+  appDir = "${dataDir}/app";
+
+  openssl3 = pkgs.openssl_3;
+  nodejs = pkgs.nodejs_22;
+  rpath = lib.makeLibraryPath [ openssl3 pkgs.glibc pkgs.stdenv.cc.cc.lib ];
+  interpreter = "${pkgs.glibc}/lib/ld-linux-aarch64.so.1";
+
+  dbName = "affine";
+  dbUser = "affine";
+  dbUrl = "postgresql://${dbUser}@localhost:${toString pgPort}/${dbName}?host=/run/postgresql";
+
+  # Update script: pulls arm64 image, extracts app layer, patches binaries for NixOS
+  updateScript = pkgs.writeShellScript "affine-update" ''
+    set -euo pipefail
+    export PATH="${lib.makeBinPath [ pkgs.skopeo pkgs.jq pkgs.gnutar pkgs.gzip pkgs.coreutils pkgs.patchelf pkgs.findutils ]}"
+    export SSL_CERT_FILE="${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+
+    TAG="''${1:-stable}"
+    WORK=$(mktemp -d)
+    trap 'rm -rf "$WORK"' EXIT
+
+    echo "Pulling ghcr.io/toeverything/affine:$TAG (arm64)..."
+    skopeo copy --override-arch arm64 \
+      "docker://ghcr.io/toeverything/affine:$TAG" \
+      "dir:$WORK/image"
+
+    # Find the app layer (largest layer, contains /app)
+    APP_LAYER=$(ls -S "$WORK/image"/*.* 2>/dev/null | head -1)
+    # More robust: parse manifest for layers, find the one with /app
+    MANIFEST="$WORK/image/manifest.json"
+    for digest in $(jq -r '.layers[].digest' "$MANIFEST"); do
+      BLOB="$WORK/image/$(echo "$digest" | cut -d: -f2)"
+      if tar tzf "$BLOB" 2>/dev/null | grep -q "^app/dist/main.js$"; then
+        APP_LAYER="$BLOB"
+        break
+      fi
+    done
+
+    if [ -z "$APP_LAYER" ]; then
+      echo "ERROR: could not find app layer in image"
+      exit 1
+    fi
+
+    echo "Extracting app from layer..."
+    mkdir -p "$WORK/extract"
+    tar xzf "$APP_LAYER" -C "$WORK/extract"
+
+    echo "Patching native binaries for NixOS..."
+    # Patch .node shared libraries (prisma, argon2, crc32, napi, etc.)
+    find "$WORK/extract/app" -name "*.node" -type f | while read -r f; do
+      patchelf --set-rpath "${rpath}" "$f" 2>/dev/null || true
+    done
+
+    # Patch schema-engine binary
+    SE="$WORK/extract/app/node_modules/@prisma/engines/schema-engine-linux-arm64-openssl-3.0.x"
+    if [ -f "$SE" ]; then
+      chmod +x "$SE"
+      patchelf --set-interpreter "${interpreter}" --set-rpath "${rpath}" "$SE"
+    fi
+
+    # Atomic swap
+    echo "Installing to ${appDir}..."
+    rm -rf "${appDir}.new"
+    mv "$WORK/extract/app" "${appDir}.new"
+
+    if [ -d "${appDir}" ]; then
+      mv "${appDir}" "${appDir}.old"
+    fi
+    mv "${appDir}.new" "${appDir}"
+    rm -rf "${appDir}.old"
+
+    VERSION=$(jq -r .version "${appDir}/package.json")
+    echo "AFFiNE $VERSION installed. Restart the service:"
+    echo "  sudo systemctl restart affine-migrate affine"
+  '';
+in
+{
+  # ── PostgreSQL: database + pgvector extension ──────────────────────────
+  services.postgresql = {
+    ensureUsers = [{ name = dbUser; ensureClauses.login = true; }];
+    ensureDatabases = [ dbName ];
+    extensions = ps: with ps; [ pgvector ];
+  };
+
+  systemd.services.affine-pg-setup = {
+    description = "AFFiNE PostgreSQL setup";
+    after = [ "postgresql.service" "postgresql-setup.service" ];
+    requires = [ "postgresql.service" "postgresql-setup.service" ];
+    wantedBy = [ "multi-user.target" ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      User = "postgres";
+    };
+    script = ''
+      ${pkgs.postgresql}/bin/psql -d ${dbName} -c "CREATE EXTENSION IF NOT EXISTS vector;"
+      ${pkgs.postgresql}/bin/psql -c "ALTER DATABASE ${dbName} OWNER TO ${dbUser};"
+    '';
+  };
+
+  # ── Prisma migrations ─────────────────────────────────────────────────
+  systemd.services.affine-migrate = {
+    description = "AFFiNE database migrations";
+    after = [ "affine-pg-setup.service" ];
+    requires = [ "affine-pg-setup.service" ];
+    wantedBy = [ "multi-user.target" ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      User = dbUser;
+    };
+    environment.DATABASE_URL = dbUrl;
+    script = ''
+      export PRISMA_QUERY_ENGINE_LIBRARY="${appDir}/node_modules/@prisma/engines/libquery_engine-linux-arm64-openssl-3.0.x.so.node"
+      export PRISMA_SCHEMA_ENGINE_BINARY="${appDir}/node_modules/@prisma/engines/schema-engine-linux-arm64-openssl-3.0.x"
+      exec ${nodejs}/bin/node ${appDir}/node_modules/.bin/prisma migrate deploy --schema ${appDir}/schema.prisma
+    '';
+  };
+
+  # ── AFFiNE server ─────────────────────────────────────────────────────
+  users.users.${dbUser} = {
+    isSystemUser = true;
+    group = dbUser;
+    home = dataDir;
+  };
+  users.groups.${dbUser} = { };
+
+  systemd.tmpfiles.rules = [
+    "d ${dataDir} 0750 ${dbUser} ${dbUser} -"
+    "d ${dataDir}/storage 0750 ${dbUser} ${dbUser} -"
+  ];
+
+  systemd.services.affine = {
+    description = "AFFiNE";
+    after = [ "network.target" "affine-migrate.service" "redis-shared.service" ];
+    requires = [ "affine-migrate.service" ];
+    wants = [ "redis-shared.service" ];
+    wantedBy = [ "multi-user.target" ];
+    environment = {
+      NODE_ENV = "production";
+      AFFINE_SERVER_HOST = "0.0.0.0";
+      AFFINE_SERVER_PORT = toString port;
+      DATABASE_URL = dbUrl;
+      REDIS_SERVER_HOST = redisHost;
+      REDIS_SERVER_PORT = toString redisPort;
+      AFFINE_STORAGE_PATH = "${dataDir}/storage";
+      PRISMA_QUERY_ENGINE_LIBRARY = "${appDir}/node_modules/@prisma/engines/libquery_engine-linux-arm64-openssl-3.0.x.so.node";
+      PRISMA_SCHEMA_ENGINE_BINARY = "${appDir}/node_modules/@prisma/engines/schema-engine-linux-arm64-openssl-3.0.x";
+    };
+    serviceConfig = {
+      Type = "simple";
+      User = dbUser;
+      Group = dbUser;
+      WorkingDirectory = appDir;
+      ExecStart = "${nodejs}/bin/node ${appDir}/dist/main.js";
+      Restart = "on-failure";
+      RestartSec = "5s";
+      PrivateUsers = lib.mkForce false;
+    };
+  };
+
+  # Make update script available system-wide
+  environment.systemPackages = [ (pkgs.writeShellScriptBin "affine-update" (builtins.readFile updateScript)) ];
+}

--- a/rpi5/configuration.nix
+++ b/rpi5/configuration.nix
@@ -119,7 +119,7 @@ in
     ./sure.nix
     ./sumeria-mitm.nix
     ./vaultwarden.nix
-    ./siyuan.nix
+    ./affine.nix
     # Tailscale with server features (subnet routing, SSH, exit node)
     (import ../shared/tailscale.nix {
       role = "server";
@@ -335,8 +335,8 @@ in
 
   zramSwap = {
     enable = true;
-    memoryPercent = 75; # 75% of 4 GiB = 3 GiB (was default 50% = 2 GiB)
-    memoryMax = 4 * 1024 * 1024 * 1024;
+    memoryPercent = 200; # 200% of 4 GiB ≈ 8 GiB virtual; actual RAM bounded by zstd compression (~3-4x)
+    memoryMax = 10 * 1024 * 1024 * 1024;
   };
 
   system.stateVersion = "25.11";

--- a/rpi5/secrets.nix
+++ b/rpi5/secrets.nix
@@ -50,9 +50,5 @@
       file  = ./secrets/vaultwarden-admin-token.age;
       owner = "vaultwarden";
     };
-    siyuan-auth-code = {
-      file  = ./secrets/siyuan-auth-code.age;
-      owner = "siyuan";
-    };
   };
 }

--- a/rpi5/tailscale-serve.nix
+++ b/rpi5/tailscale-serve.nix
@@ -11,7 +11,7 @@ let
     { port = 3333;  backend = "http://127.0.0.1:13334"; } # sure (personal finance)
     { port = 4040;  backend = "http://127.0.0.1:4040";  } # openai-codex proxy
     { port = 8222;  backend = "http://127.0.0.1:8222";  } # vaultwarden (bitwarden)
-    { port = 6806;  backend = "http://127.0.0.1:6806";  } # siyuan (notes/wiki)
+    { port = 3010;  backend = "http://127.0.0.1:3010";  } # affine
   ];
 
   # Publicly-accessible services (tailscale funnel).
@@ -31,7 +31,7 @@ in
 {
   systemd.services.tailscale-serve = {
     description = "Tailscale Serve + Funnel";
-    after    = [ "network-online.target" "tailscaled.service" "tailscale-autoconnect.service" "siyuan.service" ];
+    after    = [ "network-online.target" "tailscaled.service" "tailscale-autoconnect.service" ];
     wants    = [ "network-online.target" "tailscaled.service" "tailscale-autoconnect.service" ];
     requires = [ "tailscale-autoconnect.service" ];
     wantedBy = [ "multi-user.target" ];


### PR DESCRIPTION
## Summary
- Add AFFiNE self-hosted service (extracted from Docker image, patchelf'd for NixOS) on port 3010 with Tailscale Serve
- Remove siyuan service, secret, and Tailscale Serve entry
- Increase zram swap from 75% to 200% of RAM

## Test plan
- [x] AFFiNE running and accessible at https://rpi5.gate-mintaka.ts.net:3010/
- [x] Prisma migrations applied successfully
- [x] Siyuan service removed cleanly (user/group removed)
- [x] nixos-rebuild switch succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)