### PR TITLE
feat(affine): add AFFiNE self-hosted service

### DIFF
--- a/rpi5/affine.nix
+++ b/rpi5/affine.nix
@@ -152,7 +152,6 @@ in
       AFFINE_STORAGE_PATH = "${dataDir}/storage";
       PRISMA_QUERY_ENGINE_LIBRARY = "${appDir}/node_modules/@prisma/engines/libquery_engine-linux-arm64-openssl-3.0.x.so.node";
       PRISMA_SCHEMA_ENGINE_BINARY = "${appDir}/node_modules/@prisma/engines/schema-engine-linux-arm64-openssl-3.0.x";
-      LD_LIBRARY_PATH = rpath;
     };
     serviceConfig = {
       Type = "simple";

--- a/rpi5/affine.nix
+++ b/rpi5/affine.nix
@@ -1,7 +1,7 @@
 { pkgs, lib, pgHost, pgPort, redisHost, redisPort, ... }:
 let
   version = "0.26.6";
-  port = 3010;
+  port = 13010;  # internal; Tailscale Serve proxies 3010 → 13010
   dataDir = "/var/lib/affine";
   appDir = "${dataDir}/app";
 
@@ -133,6 +133,7 @@ in
   systemd.tmpfiles.rules = [
     "d ${dataDir} 0750 ${dbUser} ${dbUser} -"
     "d ${dataDir}/storage 0750 ${dbUser} ${dbUser} -"
+    "Z ${dataDir}/app 0755 ${dbUser} ${dbUser} -"
   ];
 
   systemd.services.affine = {
@@ -143,7 +144,7 @@ in
     wantedBy = [ "multi-user.target" ];
     environment = {
       NODE_ENV = "production";
-      AFFINE_SERVER_HOST = "0.0.0.0";
+      AFFINE_SERVER_HOST = "127.0.0.1";
       AFFINE_SERVER_PORT = toString port;
       DATABASE_URL = dbUrl;
       REDIS_SERVER_HOST = redisHost;
@@ -151,6 +152,7 @@ in
       AFFINE_STORAGE_PATH = "${dataDir}/storage";
       PRISMA_QUERY_ENGINE_LIBRARY = "${appDir}/node_modules/@prisma/engines/libquery_engine-linux-arm64-openssl-3.0.x.so.node";
       PRISMA_SCHEMA_ENGINE_BINARY = "${appDir}/node_modules/@prisma/engines/schema-engine-linux-arm64-openssl-3.0.x";
+      LD_LIBRARY_PATH = rpath;
     };
     serviceConfig = {
       Type = "simple";

--- a/rpi5/tailscale-serve.nix
+++ b/rpi5/tailscale-serve.nix
@@ -11,7 +11,7 @@ let
     { port = 3333;  backend = "http://127.0.0.1:13334"; } # sure (personal finance)
     { port = 4040;  backend = "http://127.0.0.1:4040";  } # openai-codex proxy
     { port = 8222;  backend = "http://127.0.0.1:8222";  } # vaultwarden (bitwarden)
-    { port = 3010;  backend = "http://127.0.0.1:3010";  } # affine
+    { port = 3010;  backend = "http://127.0.0.1:13010"; } # affine
   ];
 
   # Publicly-accessible services (tailscale funnel).


### PR DESCRIPTION
## Summary
- Add AFFiNE self-hosted service with Docker image extraction, PostgreSQL+pgvector setup, Prisma migrations, and systemd service
- Remove siyuan service (replaced by AFFiNE), increase zram to 200%
- Fix EADDRINUSE: use internal port 13010 with Tailscale Serve proxying 3010→13010
- Fix LD_LIBRARY_PATH conflict: openssl 3.0.x broke Node.js 22's built-in openssl 3.4.0

## Test plan
- [x] AFFiNE starts successfully and returns HTTP 200 on port 13010
- [x] Tailscale Serve proxies https://rpi5:3010 correctly
- [x] No more crash loop (was at 2675 restarts before fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)