### PR TITLE
chore: update sure to 0.6.9 and immich to 2.7.4

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -736,11 +736,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1775639890,
-        "narHash": "sha256-9O9gNidrdzcb7vgKGtff7QiLtr0IsVaCi0pAXm8anhQ=",
+        "lastModified": 1775888245,
+        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "456e8a9468b9d46bd8c9524425026c00745bc4d2",
+        "rev": "13043924aaa7375ce482ebe2494338e058282925",
         "type": "github"
       },
       "original": {
@@ -936,11 +936,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775305199,
-        "narHash": "sha256-sI0uazGr7JQ+ppgpoN6DOE8x6wx356EarDDa53KUbX8=",
+        "lastModified": 1776080374,
+        "narHash": "sha256-kTAnVMJIe6zRmyGF5QWKB8gANJad4T/TCX1iXIQYmcM=",
         "owner": "nSimonFR",
         "repo": "sure-nix",
-        "rev": "3d83d7b8265b854738099fc137b88f3c2be70a9c",
+        "rev": "45c1a75f749fc3526c7805118128ac70a3c7d978",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- Update sure-nix flake input (Sure 0.6.8 → 0.6.9)
- Update nixpkgs-unstable flake input (immich 2.7.4)

## Test plan
- [x] `nixos-rebuild switch` succeeded
- [x] `immich-server`, `immich-machine-learning`, `sure-web`, `sure-worker` all active

🤖 Generated with [Claude Code](https://claude.com/claude-code)