### PR TITLE
feat: add AFFiNE desktop app

### DIFF
--- a/macos/components/homebrew.nix
+++ b/macos/components/homebrew.nix
@@ -33,6 +33,7 @@
 
   casks = [
     "1password"
+    "affine"
     "bitwarden"
     "android-studio"
     "arc"

--- a/nixos/packages.nix
+++ b/nixos/packages.nix
@@ -25,6 +25,7 @@ in
 {
   home.packages = with pkgs; [
     _1password-gui
+    affine
     bitwarden-desktop
     rbw
     pinentry-gnome3


### PR DESCRIPTION
## Summary
- Add AFFiNE as a Homebrew cask on macOS (nBookPro)
- Add AFFiNE as a nixpkg on BeAsT (Linux desktop)

## Test plan
- [x] Tested AFFiNE via `brew install --cask affine` on macOS — works
- [x] Tested AFFiNE via `nix run nixpkgs#affine` — package exists but .app bundle needs `open` on macOS
- [ ] Verify `nixos-rebuild switch` on BeAsT picks up the package

🤖 Generated with [Claude Code](https://claude.com/claude-code)