### PR TITLE
feat(macos): auto-reload yabai scripting addition on rebuild

### DIFF
--- a/macos/components/system.nix
+++ b/macos/components/system.nix
@@ -1,8 +1,13 @@
 { username, ... }:
 {
   primaryUser = username;
-  
+
   stateVersion = 5;
+
+  # Reload yabai scripting addition on every darwin-rebuild switch
+  activationScripts.postActivation.text = ''
+    sudo yabai --load-sa 2>/dev/null || true
+  '';
   
   keyboard = {
     enableKeyMapping = true;


### PR DESCRIPTION
## Summary
- Runs `sudo yabai --load-sa` as a nix-darwin post-activation script
- No more manual reload needed after `darwin-rebuild switch`

## Test plan
- [x] `darwin-rebuild switch` completes without error
- [x] `sudo yabai --load-sa` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)