### PR TITLE
fix: restart tun2proxy on darwin-rebuild

### DIFF
--- a/macos/components/system.nix
+++ b/macos/components/system.nix
@@ -4,9 +4,10 @@
 
   stateVersion = 5;
 
-  # Reload yabai scripting addition on every darwin-rebuild switch
+  # Post-rebuild: reload yabai scripting addition + restart tun2proxy
   activationScripts.postActivation.text = ''
     sudo yabai --load-sa 2>/dev/null || true
+    launchctl kickstart -k system/org.nixos.tun2proxy-work 2>/dev/null || true
   '';
   
   keyboard = {


### PR DESCRIPTION
## Summary
- Kick tun2proxy-work in post-activation alongside yabai --load-sa
- After a rebuild, tailscale-work gets reloaded which invalidates tun2proxy's SOCKS5 connections
- Fresh restart ensures working routes and connections

## Test plan
- [x] `darwin-rebuild switch` restarts tun2proxy automatically
- [x] kubectl and MCP work after rebuild without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)