### PR TITLE
feat(ollama): add Gemma 4 E4B model

### DIFF
--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -599,7 +599,7 @@ kdePackages.kwallet
       config.cudaSupport = true;
     }).ollama-cuda;
     host = "0.0.0.0"; # Bind all interfaces — firewalled to tailscale0 + localhost
-    loadModels = [ "gemma4:26b" "qwen3.5:35b-a3b" ];
+    loadModels = [ "gemma4:26b" "gemma4:e4b" "qwen3.5:35b-a3b" ];
   };
 
   services.hardware.openrgb = {

--- a/rpi5/openclaw/openclaw.nix
+++ b/rpi5/openclaw/openclaw.nix
@@ -201,6 +201,7 @@ in
           api = "ollama";
           models = [
             { id = "gemma4:26b";        name = "Gemma 4 26B"; }
+            { id = "gemma4:e4b";        name = "Gemma 4 E4B"; }
             { id = "qwen3.5:35b-a3b";   name = "Qwen3.5 35B A3B"; }
           ];
         };
@@ -209,7 +210,7 @@ in
           skipBootstrap = true;
           model = {
             primary = "openai-codex/gpt-5.4";
-            fallbacks = [ "ollama/gemma4:26b" "ollama/qwen3.5:35b-a3b" ];
+            fallbacks = [ "ollama/gemma4:e4b" "ollama/gemma4:26b" "ollama/qwen3.5:35b-a3b" ];
           };
           models = {
             "openai-codex/gpt-5.4" = {
@@ -218,8 +219,11 @@ in
             "ollama/qwen3.5:35b-a3b" = {
               alias = "qwen";
             };
+            "ollama/gemma4:e4b" = {
+              alias = "gemma-small";
+            };
             "ollama/gemma4:26b" = {
-              alias = "gemma";
+              alias = "gemma-large";
             };
           };
           heartbeat = {

--- a/rpi5/openclaw/openclaw.nix
+++ b/rpi5/openclaw/openclaw.nix
@@ -220,7 +220,7 @@ in
               alias = "qwen";
             };
             "ollama/gemma4:e4b" = {
-              alias = "gemma-small";
+              alias = "gemma-medium";
             };
             "ollama/gemma4:26b" = {
               alias = "gemma-large";


### PR DESCRIPTION
## Summary
- Add `gemma4:e4b` (8B, Q8_0) to ollama — fits entirely in 12GB VRAM (78% utilization) vs `gemma4:26b` which spills to CPU RAM at Q2_K
- Register model in OpenClaw provider config with `gemma-small` alias, first fallback
- Rename existing aliases: `gemma` → `gemma-large`, new model → `gemma-small`

## Test plan
- [ ] Verify `ollama run gemma4:e4b` responds on BeAsT
- [ ] Rebuild RPi5, verify OpenClaw can reach both gemma models via `http://beast:11434`
- [ ] Compare output quality between gemma-small and gemma-large

🤖 Generated with [Claude Code](https://claude.com/claude-code)