### PR TITLE
fix: patch code-cursor AppImage hash for x86_64-linux

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -229,6 +229,20 @@
             unstablePkgs = import nixpkgs-unstable {
               system = "x86_64-linux";
               config.allowUnfree = true;
+              overlays = [
+                (final: prev: {
+                  code-cursor = prev.code-cursor.overrideAttrs (old: {
+                    src = prev.appimageTools.extract {
+                      pname = "cursor";
+                      inherit (old) version;
+                      src = prev.fetchurl {
+                        url = "https://downloads.cursor.com/production/475871d112608994deb2e3065dfb7c6b0baa0c54/linux/x64/Cursor-3.0.16-x86_64.AppImage";
+                        hash = "sha256-dN8tFSppIpO/P0Thst5uaNzlmfWZDh0Y81Lx1BuSYt0=";
+                      };
+                    };
+                  });
+                })
+              ];
             };
           };
           modules = [


### PR DESCRIPTION
## Summary
- Cursor re-published the 3.0.16 x86_64 AppImage with different contents, causing a hash mismatch in nixpkgs-unstable
- Adds an overlay on `unstablePkgs` to patch the hash until upstream nixpkgs is updated

## Test plan
- [x] `home-manager switch --flake .#nsimon@BeAsT` succeeds on beast

🤖 Generated with [Claude Code](https://claude.com/claude-code)