### PR TITLE
feat: add T3 Code to macOS homebrew casks

### DIFF
--- a/macos/components/homebrew.nix
+++ b/macos/components/homebrew.nix
@@ -68,6 +68,7 @@
     "sikarugir"
     "slack"
     "steam"
+    "t3-code"
     "tailscale-app"
     "stolendata-mpv"
     "spotify"


### PR DESCRIPTION
## Summary
- Add `t3-code` cask to macOS Homebrew configuration

## Test plan
- [x] Verified install via `darwin-rebuild switch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)