### PR TITLE
fix: make claude-code settings.json writable at runtime

### DIFF
--- a/home/claude.nix
+++ b/home/claude.nix
@@ -108,39 +108,20 @@ in
       '';
     });
 
-    settings = {
-      effortLevel = "medium";
-      skipDangerousModePermissionPrompt = true;
-      trustAll = true;
-      permissions = {
-        allow = [
-          "Bash(*)"
-          "Read(*)"
-          "Write(*)"
-          "Edit(*)"
-          "Glob(*)"
-          "Grep(*)"
-          "WebFetch(*)"
-          "WebSearch(*)"
-          "NotebookEdit(*)"
-          "Task(*)"
-        ];
-        deny = [ ];
-      };
-hooks = {
-        Notification = [
-          {
-            matcher = "";
-            hooks = [
-              {
-                type = "command";
-                command = "${notifyScript}";
-                timeout = 10;
-              }
-            ];
-          }
-        ];
-      };
-    };
+    # Settings delivered as a writable file via mkOutOfStoreSymlink
+    # (points to the repo checkout, not the Nix store) so Claude Code
+    # can update them at runtime (e.g. /voice toggle).
+    # Baseline: home/dotfiles/claude-settings.json
+  };
+
+  # Writable settings.json — symlinked to the repo checkout
+  home.file.".claude/settings.json".source =
+    config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/nic-os/home/dotfiles/claude-settings.json";
+
+  # Stable path for the Telegram notify hook so the settings JSON
+  # doesn't need to embed a Nix store path that changes on rebuild.
+  home.file.".claude/hooks/telegram-notify" = {
+    source = notifyScript;
+    executable = true;
   };
 }

--- a/home/dotfiles/claude-settings.json
+++ b/home/dotfiles/claude-settings.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "effortLevel": "medium",
+  "voiceEnabled": true,
+  "skipDangerousModePermissionPrompt": true,
+  "trustAll": true,
+  "permissions": {
+    "allow": [
+      "Bash(*)",
+      "Read(*)",
+      "Write(*)",
+      "Edit(*)",
+      "Glob(*)",
+      "Grep(*)",
+      "WebFetch(*)",
+      "WebSearch(*)",
+      "NotebookEdit(*)",
+      "Task(*)"
+    ],
+    "deny": []
+  },
+  "hooks": {
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "command": "$HOME/.claude/hooks/telegram-notify",
+            "timeout": 10,
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Claude Code's `/voice` (and other runtime setting toggles) failed with "Failed to update settings" because home-manager's `programs.claude-code.settings` generates a read-only Nix store symlink
- Use `mkOutOfStoreSymlink` to point `~/.claude/settings.json` at a versioned dotfile in the repo checkout — writable at runtime AND version-controlled
- Add a stable `~/.claude/hooks/telegram-notify` symlink so the settings JSON doesn't embed a Nix store path that changes on rebuild

## Test plan
- [x] `home-manager switch` succeeds
- [x] `~/.claude/settings.json` resolves to the repo file (`readlink -f` → `~/nic-os/home/dotfiles/claude-settings.json`)
- [x] `/voice` toggle works without "Failed to update settings" error
- [x] Runtime changes to settings.json are reflected in the repo checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)