### PR TITLE
feat: add gemma4 local inference aliases via litellm proxies

### DIFF
--- a/home/default.nix
+++ b/home/default.nix
@@ -11,6 +11,7 @@
     ./zsh.nix
     ./claude.nix
     ./mcp.nix
+    ./llm-aliases.nix
   ];
 
   fonts.fontconfig.enable = true;

--- a/home/dotfiles/zsh/aliases.zsh
+++ b/home/dotfiles/zsh/aliases.zsh
@@ -22,8 +22,8 @@ alias claude='command claude --dangerously-skip-permissions --remote-control'
 cc()     { command claude --continue "$@"; }
 cr()     { command claude --resume "$@"; }
 
-# claude-local: Claude Code routed through local gemma4:26b via litellm proxy (port 4000)
-alias claude-local='ANTHROPIC_BASE_URL=http://localhost:4000 ANTHROPIC_API_KEY=litellm-local command claude --dangerously-skip-permissions --remote-control'
+# claude-local: Claude Code → local gemma4:26b (M3 Pro) via litellm proxy (port 4000)
+alias claude-local='ANTHROPIC_BASE_URL=http://localhost:4000 ANTHROPIC_API_KEY=litellm-local ANTHROPIC_MODEL=ollama_chat/gemma4:26b command claude --dangerously-skip-permissions --remote-control'
 
-# claude-beast: Claude Code routed through Beast's gemma4:26b (RTX 3080 Ti, CUDA) via litellm proxy (port 4001)
-alias claude-beast='ANTHROPIC_BASE_URL=http://localhost:4001 ANTHROPIC_API_KEY=litellm-local command claude --dangerously-skip-permissions --remote-control'
+# claude-beast: Claude Code → Beast gemma4:e4b (RTX 3080 Ti) via litellm proxy (port 4001)
+alias claude-beast='ANTHROPIC_BASE_URL=http://localhost:4001 ANTHROPIC_API_KEY=litellm-local ANTHROPIC_MODEL=ollama_chat/gemma4:e4b command claude --dangerously-skip-permissions --remote-control'

--- a/home/dotfiles/zsh/aliases.zsh
+++ b/home/dotfiles/zsh/aliases.zsh
@@ -23,7 +23,7 @@ cc()     { command claude --continue "$@"; }
 cr()     { command claude --resume "$@"; }
 
 # claude-local: Claude Code → local gemma4:26b (M3 Pro) via litellm proxy (port 4000)
-alias claude-local='ANTHROPIC_BASE_URL=http://localhost:4000 ANTHROPIC_API_KEY=litellm-local ANTHROPIC_MODEL=ollama_chat/gemma4:26b command claude --dangerously-skip-permissions --remote-control'
+alias claude-local='ANTHROPIC_BASE_URL=http://localhost:4000 ANTHROPIC_API_KEY=litellm-local ANTHROPIC_MODEL=ollama/gemma4:26b command claude --dangerously-skip-permissions --remote-control'
 
 # claude-beast: Claude Code → Beast gemma4:e4b (RTX 3080 Ti) via litellm proxy (port 4001)
-alias claude-beast='ANTHROPIC_BASE_URL=http://localhost:4001 ANTHROPIC_API_KEY=litellm-local ANTHROPIC_MODEL=ollama_chat/gemma4:e4b command claude --dangerously-skip-permissions --remote-control'
+alias claude-beast='ANTHROPIC_BASE_URL=http://localhost:4001 ANTHROPIC_API_KEY=litellm-local ANTHROPIC_MODEL=ollama/gemma4:e4b command claude --dangerously-skip-permissions --remote-control'

--- a/home/dotfiles/zsh/aliases.zsh
+++ b/home/dotfiles/zsh/aliases.zsh
@@ -21,3 +21,9 @@ alias vpn-status='tailscale status | grep -E "(rpi5|exit node)" || echo "Exit no
 alias claude='command claude --dangerously-skip-permissions --remote-control'
 cc()     { command claude --continue "$@"; }
 cr()     { command claude --resume "$@"; }
+
+# claude-local: Claude Code routed through local gemma4:26b via litellm proxy (port 4000)
+alias claude-local='ANTHROPIC_BASE_URL=http://localhost:4000 ANTHROPIC_API_KEY=litellm-local command claude --dangerously-skip-permissions --remote-control'
+
+# claude-beast: Claude Code routed through Beast's gemma4:26b (RTX 3080 Ti, CUDA) via litellm proxy (port 4001)
+alias claude-beast='ANTHROPIC_BASE_URL=http://localhost:4001 ANTHROPIC_API_KEY=litellm-local command claude --dangerously-skip-permissions --remote-control'

--- a/home/dotfiles/zsh/aliases.zsh
+++ b/home/dotfiles/zsh/aliases.zsh
@@ -23,7 +23,7 @@ cc()     { command claude --continue "$@"; }
 cr()     { command claude --resume "$@"; }
 
 # claude-local: Claude Code → local gemma4:26b (M3 Pro) via litellm proxy (port 4000)
-alias claude-local='ANTHROPIC_BASE_URL=http://localhost:4000 ANTHROPIC_API_KEY=litellm-local ANTHROPIC_MODEL=ollama/gemma4:26b command claude --dangerously-skip-permissions --remote-control'
+alias claude-local='ANTHROPIC_BASE_URL=http://localhost:4000 ANTHROPIC_API_KEY=litellm-local ANTHROPIC_MODEL=openai/gemma4:26b command claude --dangerously-skip-permissions --remote-control'
 
 # claude-beast: Claude Code → Beast gemma4:e4b (RTX 3080 Ti) via litellm proxy (port 4001)
-alias claude-beast='ANTHROPIC_BASE_URL=http://localhost:4001 ANTHROPIC_API_KEY=litellm-local ANTHROPIC_MODEL=ollama/gemma4:e4b command claude --dangerously-skip-permissions --remote-control'
+alias claude-beast='ANTHROPIC_BASE_URL=http://localhost:4001 ANTHROPIC_API_KEY=litellm-local ANTHROPIC_MODEL=openai/gemma4:e4b command claude --dangerously-skip-permissions --remote-control'

--- a/home/dotfiles/zsh/aliases.zsh
+++ b/home/dotfiles/zsh/aliases.zsh
@@ -23,7 +23,7 @@ cc()     { command claude --continue "$@"; }
 cr()     { command claude --resume "$@"; }
 
 # claude-local: Claude Code → local gemma4:26b (M3 Pro) via litellm proxy (port 4000)
-alias claude-local='ANTHROPIC_BASE_URL=http://localhost:4000 ANTHROPIC_API_KEY=litellm-local ANTHROPIC_MODEL=openai/gemma4:26b command claude --dangerously-skip-permissions --remote-control'
+alias claude-local='ANTHROPIC_BASE_URL=http://localhost:4000 ANTHROPIC_API_KEY=litellm-local ANTHROPIC_MODEL=openai/gemma4:e4b command claude --dangerously-skip-permissions --remote-control'
 
 # claude-beast: Claude Code → Beast gemma4:e4b (RTX 3080 Ti) via litellm proxy (port 4001)
 alias claude-beast='ANTHROPIC_BASE_URL=http://localhost:4001 ANTHROPIC_API_KEY=litellm-local ANTHROPIC_MODEL=openai/gemma4:e4b command claude --dangerously-skip-permissions --remote-control'

--- a/home/llm-aliases.nix
+++ b/home/llm-aliases.nix
@@ -2,45 +2,44 @@
 let
   litellmBin = "${pkgs.litellm}/bin/litellm";
 
-  # litellm proxy definitions: name → { args, port, description }
-  proxies = {
-    litellm-ollama = {
-      description = "litellm Anthropic→Ollama proxy (local, port 4000)";
-      args = [ litellmBin "--model" "ollama_chat/gemma4:26b" "--port" "4000" ];
-      logSuffix = "ollama";
+  beastProxy = {
+    description = "litellm Anthropic→Ollama proxy (Beast RTX 3080 Ti via Tailscale, port 4001)";
+    args = [ litellmBin "--model" "ollama_chat/gemma4:26b" "--port" "4001" "--api_base" "http://beast:11434" ];
+    logSuffix = "beast";
+  };
+
+  localProxy = {
+    description = "litellm Anthropic→Ollama proxy (local gemma4:26b, port 4000)";
+    args = [ litellmBin "--model" "ollama_chat/gemma4:26b" "--port" "4000" ];
+    logSuffix = "ollama";
+  };
+
+  mkLaunchdAgent = p: {
+    enable = true;
+    config = {
+      ProgramArguments = p.args;
+      RunAtLoad = true;
+      KeepAlive = true;
+      StandardOutPath = "/tmp/litellm-${p.logSuffix}.log";
+      StandardErrorPath = "/tmp/litellm-${p.logSuffix}.log";
     };
-    litellm-beast = {
-      description = "litellm Anthropic→Ollama proxy (Beast RTX 3080 Ti via Tailscale, port 4001)";
-      args = [ litellmBin "--model" "ollama_chat/gemma4:26b" "--port" "4001" "--api_base" "http://beast:11434" ];
-      logSuffix = "beast";
+  };
+
+  mkSystemdService = p: {
+    Unit.Description = p.description;
+    Service = {
+      ExecStart = lib.escapeShellArgs p.args;
+      Restart = "always";
+      RestartSec = "5s";
     };
+    Install.WantedBy = [ "default.target" ];
   };
 in
 {
-  # macOS: launchd user agents
-  launchd.agents = lib.mkIf pkgs.stdenv.isDarwin (
-    lib.mapAttrs (name: p: {
-      enable = true;
-      config = {
-        ProgramArguments = p.args;
-        RunAtLoad = true;
-        KeepAlive = true;
-        StandardOutPath = "/tmp/litellm-${p.logSuffix}.log";
-        StandardErrorPath = "/tmp/litellm-${p.logSuffix}.log";
-      };
-    }) proxies
-  );
+  # Beast proxy: all machines (Tailscale-accessible)
+  launchd.agents.litellm-beast = lib.mkIf pkgs.stdenv.isDarwin (mkLaunchdAgent beastProxy);
+  systemd.user.services.litellm-beast = lib.mkIf pkgs.stdenv.isLinux (mkSystemdService beastProxy);
 
-  # Linux: systemd user services
-  systemd.user.services = lib.mkIf pkgs.stdenv.isLinux (
-    lib.mapAttrs (name: p: {
-      Unit.Description = p.description;
-      Service = {
-        ExecStart = lib.escapeShellArgs p.args;
-        Restart = "always";
-        RestartSec = "5s";
-      };
-      Install.WantedBy = [ "default.target" ];
-    }) proxies
-  );
+  # Local proxy: macOS only (gemma4:26b runs on the M3 Pro)
+  launchd.agents.litellm-ollama = lib.mkIf pkgs.stdenv.isDarwin (mkLaunchdAgent localProxy);
 }

--- a/home/llm-aliases.nix
+++ b/home/llm-aliases.nix
@@ -6,13 +6,13 @@ let
     # gemma4:e4b: best fit for RTX 3080 Ti 12GB (llmfit score 89.2, Perfect, 62.7 tok/s, 78.5% VRAM)
     # gemma4:26b scores 82.6 but is Marginal (93.3% VRAM — too tight)
     description = "litellm Anthropic→Ollama proxy (Beast RTX 3080 Ti via Tailscale, port 4001)";
-    args = [ litellmBin "--model" "ollama_chat/gemma4:e4b" "--port" "4001" "--api_base" "http://beast:11434" "--drop_params" ];
+    args = [ litellmBin "--model" "ollama/gemma4:e4b" "--port" "4001" "--api_base" "http://beast:11434" "--drop_params" ];
     logSuffix = "beast";
   };
 
   localProxy = {
     description = "litellm Anthropic→Ollama proxy (local gemma4:26b, port 4000)";
-    args = [ litellmBin "--model" "ollama_chat/gemma4:26b" "--port" "4000" "--drop_params" ];
+    args = [ litellmBin "--model" "ollama/gemma4:26b" "--port" "4000" "--drop_params" ];
     logSuffix = "ollama";
   };
 

--- a/home/llm-aliases.nix
+++ b/home/llm-aliases.nix
@@ -6,13 +6,13 @@ let
     # gemma4:e4b: best fit for RTX 3080 Ti 12GB (llmfit score 89.2, Perfect, 62.7 tok/s, 78.5% VRAM)
     # gemma4:26b scores 82.6 but is Marginal (93.3% VRAM — too tight)
     description = "litellm Anthropic→Ollama proxy (Beast RTX 3080 Ti via Tailscale, port 4001)";
-    args = [ litellmBin "--model" "ollama_chat/gemma4:e4b" "--port" "4001" "--api_base" "http://beast:11434" ];
+    args = [ litellmBin "--model" "ollama_chat/gemma4:e4b" "--port" "4001" "--api_base" "http://beast:11434" "--drop_params" ];
     logSuffix = "beast";
   };
 
   localProxy = {
     description = "litellm Anthropic→Ollama proxy (local gemma4:26b, port 4000)";
-    args = [ litellmBin "--model" "ollama_chat/gemma4:26b" "--port" "4000" ];
+    args = [ litellmBin "--model" "ollama_chat/gemma4:26b" "--port" "4000" "--drop_params" ];
     logSuffix = "ollama";
   };
 

--- a/home/llm-aliases.nix
+++ b/home/llm-aliases.nix
@@ -14,8 +14,8 @@ let
   };
 
   localProxy = {
-    description = "litellm Anthropic→Ollama proxy (local gemma4:26b, port 4000)";
-    args = [ litellmBin "--model" "openai/gemma4:26b" "--port" "4000" "--api_base" "http://localhost:11434/v1" "--drop_params" ];
+    description = "litellm Anthropic→Ollama proxy (local gemma4:e4b, port 4000)";
+    args = [ litellmBin "--model" "openai/gemma4:e4b" "--port" "4000" "--api_base" "http://localhost:11434/v1" "--drop_params" ];
     env = { OPENAI_API_KEY = "ollama"; };
     logSuffix = "ollama";
   };

--- a/home/llm-aliases.nix
+++ b/home/llm-aliases.nix
@@ -2,17 +2,21 @@
 let
   litellmBin = "${pkgs.litellm}/bin/litellm";
 
+  # Use openai/ prefix pointing at Ollama's /v1 endpoint — avoids litellm bugs
+  # with both ollama/ ('str' has no .get) and ollama_chat/ (array content unmarshal).
+  # OPENAI_API_KEY is required by litellm but ignored by Ollama.
   beastProxy = {
     # gemma4:e4b: best fit for RTX 3080 Ti 12GB (llmfit score 89.2, Perfect, 62.7 tok/s, 78.5% VRAM)
-    # gemma4:26b scores 82.6 but is Marginal (93.3% VRAM — too tight)
     description = "litellm Anthropic→Ollama proxy (Beast RTX 3080 Ti via Tailscale, port 4001)";
-    args = [ litellmBin "--model" "ollama/gemma4:e4b" "--port" "4001" "--api_base" "http://beast:11434" "--drop_params" ];
+    args = [ litellmBin "--model" "openai/gemma4:e4b" "--port" "4001" "--api_base" "http://beast:11434/v1" "--drop_params" ];
+    env = { OPENAI_API_KEY = "ollama"; };
     logSuffix = "beast";
   };
 
   localProxy = {
     description = "litellm Anthropic→Ollama proxy (local gemma4:26b, port 4000)";
-    args = [ litellmBin "--model" "ollama/gemma4:26b" "--port" "4000" "--drop_params" ];
+    args = [ litellmBin "--model" "openai/gemma4:26b" "--port" "4000" "--api_base" "http://localhost:11434/v1" "--drop_params" ];
+    env = { OPENAI_API_KEY = "ollama"; };
     logSuffix = "ollama";
   };
 
@@ -20,6 +24,7 @@ let
     enable = true;
     config = {
       ProgramArguments = p.args;
+      EnvironmentVariables = p.env;
       RunAtLoad = true;
       KeepAlive = true;
       StandardOutPath = "/tmp/litellm-${p.logSuffix}.log";
@@ -31,6 +36,7 @@ let
     Unit.Description = p.description;
     Service = {
       ExecStart = lib.escapeShellArgs p.args;
+      Environment = lib.mapAttrsToList (k: v: "${k}=${v}") p.env;
       Restart = "always";
       RestartSec = "5s";
     };

--- a/home/llm-aliases.nix
+++ b/home/llm-aliases.nix
@@ -1,0 +1,46 @@
+{ pkgs, lib, ... }:
+let
+  litellmBin = "${pkgs.litellm}/bin/litellm";
+
+  # litellm proxy definitions: name → { args, port, description }
+  proxies = {
+    litellm-ollama = {
+      description = "litellm Anthropic→Ollama proxy (local, port 4000)";
+      args = [ litellmBin "--model" "ollama_chat/gemma4:26b" "--port" "4000" ];
+      logSuffix = "ollama";
+    };
+    litellm-beast = {
+      description = "litellm Anthropic→Ollama proxy (Beast RTX 3080 Ti via Tailscale, port 4001)";
+      args = [ litellmBin "--model" "ollama_chat/gemma4:26b" "--port" "4001" "--api_base" "http://beast:11434" ];
+      logSuffix = "beast";
+    };
+  };
+in
+{
+  # macOS: launchd user agents
+  launchd.agents = lib.mkIf pkgs.stdenv.isDarwin (
+    lib.mapAttrs (name: p: {
+      enable = true;
+      config = {
+        ProgramArguments = p.args;
+        RunAtLoad = true;
+        KeepAlive = true;
+        StandardOutPath = "/tmp/litellm-${p.logSuffix}.log";
+        StandardErrorPath = "/tmp/litellm-${p.logSuffix}.log";
+      };
+    }) proxies
+  );
+
+  # Linux: systemd user services
+  systemd.user.services = lib.mkIf pkgs.stdenv.isLinux (
+    lib.mapAttrs (name: p: {
+      Unit.Description = p.description;
+      Service = {
+        ExecStart = lib.escapeShellArgs p.args;
+        Restart = "always";
+        RestartSec = "5s";
+      };
+      Install.WantedBy = [ "default.target" ];
+    }) proxies
+  );
+}

--- a/home/llm-aliases.nix
+++ b/home/llm-aliases.nix
@@ -3,8 +3,10 @@ let
   litellmBin = "${pkgs.litellm}/bin/litellm";
 
   beastProxy = {
+    # gemma4:e4b: best fit for RTX 3080 Ti 12GB (llmfit score 89.2, Perfect, 62.7 tok/s, 78.5% VRAM)
+    # gemma4:26b scores 82.6 but is Marginal (93.3% VRAM — too tight)
     description = "litellm Anthropic→Ollama proxy (Beast RTX 3080 Ti via Tailscale, port 4001)";
-    args = [ litellmBin "--model" "ollama_chat/gemma4:26b" "--port" "4001" "--api_base" "http://beast:11434" ];
+    args = [ litellmBin "--model" "ollama_chat/gemma4:e4b" "--port" "4001" "--api_base" "http://beast:11434" ];
     logSuffix = "beast";
   };
 

--- a/home/packages.nix
+++ b/home/packages.nix
@@ -81,6 +81,9 @@
 
       # LLM-to-hardware matching CLI
       inputs.llmfit.packages.${pkgs.system}.default
+
+      # Anthropic→Ollama proxy (used by the claude-local alias)
+      pkgs.litellm
     ]
     ++ lib.optionals devSetup [
       # Dev tools (heavy packages, only on dev machines)

--- a/macos/components/homebrew.nix
+++ b/macos/components/homebrew.nix
@@ -26,6 +26,7 @@
     "cookcli"
     "dbt-postgres"
     "helm"
+    "ollama"
     "pinentry-touchid"
     "RhetTbull/osxphotos/osxphotos"
     "tailscale"

--- a/macos/home.nix
+++ b/macos/home.nix
@@ -1,41 +1,8 @@
-{ username, pkgs, ... }:
+{ username, ... }:
 {
   imports = [
     ./applications-patch.nix
   ];
-
-  # litellm proxy: translates Anthropic API format → Ollama, used by claude-local alias
-  launchd.agents."litellm-ollama" = {
-    enable = true;
-    config = {
-      ProgramArguments = [
-        "${pkgs.litellm}/bin/litellm"
-        "--model" "ollama_chat/gemma4:26b"
-        "--port" "4000"
-      ];
-      RunAtLoad = true;
-      KeepAlive = true;
-      StandardErrorPath = "/tmp/litellm-ollama.log";
-      StandardOutPath = "/tmp/litellm-ollama.log";
-    };
-  };
-
-  # litellm proxy: routes to Beast's Ollama (RTX 3080 Ti, CUDA) via Tailscale, used by claude-beast alias
-  launchd.agents."litellm-beast" = {
-    enable = true;
-    config = {
-      ProgramArguments = [
-        "${pkgs.litellm}/bin/litellm"
-        "--model" "ollama_chat/gemma4:26b"
-        "--port" "4001"
-        "--api_base" "http://beast:11434"
-      ];
-      RunAtLoad = true;
-      KeepAlive = true;
-      StandardErrorPath = "/tmp/litellm-beast.log";
-      StandardOutPath = "/tmp/litellm-beast.log";
-    };
-  };
 
   home = {
     username = username;

--- a/macos/home.nix
+++ b/macos/home.nix
@@ -1,8 +1,41 @@
-{ username, ... }:
+{ username, pkgs, ... }:
 {
   imports = [
     ./applications-patch.nix
   ];
+
+  # litellm proxy: translates Anthropic API format → Ollama, used by claude-local alias
+  launchd.agents."litellm-ollama" = {
+    enable = true;
+    config = {
+      ProgramArguments = [
+        "${pkgs.litellm}/bin/litellm"
+        "--model" "ollama_chat/gemma4:26b"
+        "--port" "4000"
+      ];
+      RunAtLoad = true;
+      KeepAlive = true;
+      StandardErrorPath = "/tmp/litellm-ollama.log";
+      StandardOutPath = "/tmp/litellm-ollama.log";
+    };
+  };
+
+  # litellm proxy: routes to Beast's Ollama (RTX 3080 Ti, CUDA) via Tailscale, used by claude-beast alias
+  launchd.agents."litellm-beast" = {
+    enable = true;
+    config = {
+      ProgramArguments = [
+        "${pkgs.litellm}/bin/litellm"
+        "--model" "ollama_chat/gemma4:26b"
+        "--port" "4001"
+        "--api_base" "http://beast:11434"
+      ];
+      RunAtLoad = true;
+      KeepAlive = true;
+      StandardErrorPath = "/tmp/litellm-beast.log";
+      StandardOutPath = "/tmp/litellm-beast.log";
+    };
+  };
 
   home = {
     username = username;


### PR DESCRIPTION
## Summary

- Add `ollama` to homebrew and pull `gemma4:26b` — best Gemma 4 fit for M3 Pro 36GB per `llmfit` (score 67.8, 80% mem util, 3.1 tok/s)
- Add `pkgs.litellm` as an Anthropic→Ollama API translation layer
- Two `launchd.agents` in `macos/home.nix` that start at login:
  - `litellm-ollama` (port 4000): local M3 Pro GPU via Ollama
  - `litellm-beast` (port 4001): Beast RTX 3080 Ti via Tailscale (`beast:11434`)
- Two shell aliases in `aliases.zsh`:
  - `claude-local` — Claude Code routed through local gemma4:26b
  - `claude-beast` — Claude Code routed through Beast's CUDA gemma4:26b

## Test plan

- [ ] `launchctl list | grep litellm` shows both agents running
- [ ] `curl http://localhost:4000/health` and `curl http://localhost:4001/health` respond
- [ ] `claude-local` launches Claude Code against local Ollama
- [ ] `claude-beast` launches Claude Code against Beast (requires Tailscale)

🤖 Generated with [Claude Code](https://claude.com/claude-code)