### PR TITLE
feat: serve both local gemma4 models from one litellm proxy

### DIFF
--- a/home/dotfiles/zsh/aliases.zsh
+++ b/home/dotfiles/zsh/aliases.zsh
@@ -23,7 +23,10 @@ cc()     { command claude --continue "$@"; }
 cr()     { command claude --resume "$@"; }
 
 # claude-local: Claude Code → local gemma4:26b (M3 Pro) via litellm proxy (port 4000)
-alias claude-local='ANTHROPIC_BASE_URL=http://localhost:4000 ANTHROPIC_API_KEY=litellm-local ANTHROPIC_MODEL=openai/gemma4:e4b command claude --dangerously-skip-permissions --remote-control'
+# claude-local: gemma4-a4b (26.5B MoE, 4B active — quality, 3 tok/s, 80% mem)
+alias claude-local='ANTHROPIC_BASE_URL=http://localhost:4000 ANTHROPIC_API_KEY=litellm-local ANTHROPIC_MODEL=gemma4-a4b command claude --dangerously-skip-permissions --remote-control'
+# claude-local-fast: gemma4-e4b (8B dense — speed, 10 tok/s, 25% mem)
+alias claude-local-fast='ANTHROPIC_BASE_URL=http://localhost:4000 ANTHROPIC_API_KEY=litellm-local ANTHROPIC_MODEL=gemma4-e4b command claude --dangerously-skip-permissions --remote-control'
 
 # claude-beast: Claude Code → Beast gemma4:e4b (RTX 3080 Ti) via litellm proxy (port 4001)
 alias claude-beast='ANTHROPIC_BASE_URL=http://localhost:4001 ANTHROPIC_API_KEY=litellm-local ANTHROPIC_MODEL=openai/gemma4:e4b command claude --dangerously-skip-permissions --remote-control'

--- a/home/llm-aliases.nix
+++ b/home/llm-aliases.nix
@@ -13,9 +13,28 @@ let
     logSuffix = "beast";
   };
 
+  # Config-file approach: one proxy, two models, aliases pick via ANTHROPIC_MODEL
+  localConfig = pkgs.writeText "litellm-local-config.yaml" ''
+    model_list:
+      - model_name: gemma4-a4b
+        litellm_params:
+          model: openai/gemma4:26b-a4b-it-q4_K_M
+          api_base: http://localhost:11434/v1
+          api_key: ollama
+          drop_params: true
+      - model_name: gemma4-e4b
+        litellm_params:
+          model: openai/gemma4:e4b
+          api_base: http://localhost:11434/v1
+          api_key: ollama
+          drop_params: true
+  '';
+
   localProxy = {
-    description = "litellm Anthropic→Ollama proxy (local gemma4:e4b, port 4000)";
-    args = [ litellmBin "--model" "openai/gemma4:e4b" "--port" "4000" "--api_base" "http://localhost:11434/v1" "--drop_params" ];
+    # gemma4-a4b: 26.5B MoE, 4B active (score 67.8, 3.1 tok/s, 80% mem)
+    # gemma4-e4b: 8B dense (score 63.9, 10.3 tok/s, 25% mem)
+    description = "litellm Anthropic→Ollama proxy (local models, port 4000)";
+    args = [ litellmBin "--config" "${localConfig}" "--port" "4000" ];
     env = { OPENAI_API_KEY = "ollama"; };
     logSuffix = "ollama";
   };


### PR DESCRIPTION
## Summary

- Switches `litellm-ollama` from single-model CLI flags to a config file with two named models
- One proxy on port 4000 serves both `gemma4-a4b` (quality) and `gemma4-e4b` (speed)
- Adds `claude-local-fast` alias alongside `claude-local`

| Alias | Model | Quality | Speed | Mem |
|-------|-------|---------|-------|-----|
| `claude-local` | gemma4-a4b (26.5B MoE) | 90 | ~3 tok/s | 80% |
| `claude-local-fast` | gemma4-e4b (8B dense) | 76 | ~10 tok/s | 25% |

🤖 Generated with [Claude Code](https://claude.com/claude-code)