### PR TITLE
Ensure Home Assistant loads automations.yaml

### DIFF
--- a/rpi5/home-assistant.nix
+++ b/rpi5/home-assistant.nix
@@ -88,6 +88,29 @@ in
     fi
   '';
 
+  # Ensure editor-created automations saved to automations.yaml are actually
+  # loaded by Home Assistant. Existing user configuration is preserved; we only
+  # append the include if it is missing.
+  system.activationScripts.hassEnsureAutomationInclude.text = ''
+    if [ ! -d /var/lib/hass ]; then
+      exit 0
+    fi
+
+    if [ ! -e /var/lib/hass/configuration.yaml ]; then
+      cat > /var/lib/hass/configuration.yaml <<'EOF'
+    automation: !include automations.yaml
+    EOF
+    elif ! grep -Eq '^[[:space:]]*automation:[[:space:]]*!include[[:space:]]+automations\.yaml([[:space:]]|$)' /var/lib/hass/configuration.yaml; then
+      printf '\nautomation: !include automations.yaml\n' >> /var/lib/hass/configuration.yaml
+    fi
+
+    if [ ! -e /var/lib/hass/automations.yaml ]; then
+      : > /var/lib/hass/automations.yaml
+    fi
+
+    chown hass:hass /var/lib/hass/configuration.yaml /var/lib/hass/automations.yaml
+  '';
+
   # Remove real directories under custom_components left by Docker-era HA.
   # The nixpkgs home-assistant pre-start uses `ln -fns` which cannot overwrite
   # real directories — only symlinks. This runs before the service starts.


### PR DESCRIPTION
## Summary\n- ensure  includes \n- create  if missing\n- preserve existing Home Assistant config and only append the include when absent\n\n## Verification\n- rebuilt with /nix/store/jnglp426nlg309zqcyk6l3625jmzyjzy-nixos-generations-builder.sh: -g 4 -f /boot/firmware -c /nix/store/107m2lkc2k815g6nlinclz1l94yrydsm-nixos-system-rpi5-25.11.20260409.0d5a853
installing nixos-generation-independent firmware...
copying raspberry pi firmware...
copying config.txt...
raspberry pi firmware installed
installing nixos generations...
* nixos generation 'default' -> /boot/firmware/nixos/default
/nix/store/yl1938mfdi32ad0ra2gdyj3gf0mmbwi3-6p0fzdpi2k1gvnqyjclc1yfw8zcdv9if-kernelboot-gen-builder-patched.sh: -c /nix/store/107m2lkc2k815g6nlinclz1l94yrydsm-nixos-system-rpi5-25.11.20260409.0d5a853 -n default -d /boot/firmware/nixos/default.tmp.244985
kernel...device tree.../nix/store/6aicgmh3fqg7bm7r5p65ga5ylf75hm2v-install-device-tree.sh: -c /nix/store/107m2lkc2k815g6nlinclz1l94yrydsm-nixos-system-rpi5-25.11.20260409.0d5a853 -d /boot/firmware/nixos/default.tmp.244985
installing device tree files: generation's kernel's /nix/store/h8chb5f08qha3mnzrk498g5lh88cq5xn-linux_rpi-bcm2712-6.12.47-stable_20250916/dtbs

kernel boot files installed for nixos generation 'default'
* nixos generation '404-default' -> /boot/firmware/nixos/404-default
/nix/store/yl1938mfdi32ad0ra2gdyj3gf0mmbwi3-6p0fzdpi2k1gvnqyjclc1yfw8zcdv9if-kernelboot-gen-builder-patched.sh: -c /nix/var/nix/profiles/system-404-link -n 404-default -d /boot/firmware/nixos/404-default.tmp.244985
kernel...device tree.../nix/store/6aicgmh3fqg7bm7r5p65ga5ylf75hm2v-install-device-tree.sh: -c /nix/var/nix/profiles/system-404-link -d /boot/firmware/nixos/404-default.tmp.244985
installing device tree files: generation's kernel's /nix/store/h8chb5f08qha3mnzrk498g5lh88cq5xn-linux_rpi-bcm2712-6.12.47-stable_20250916/dtbs

kernel boot files installed for nixos generation '404-default'
* nixos generation '403-default' -> /boot/firmware/nixos/403-default
* nixos generation '402-default' -> /boot/firmware/nixos/402-default
* nixos generation '401-default' -> /boot/firmware/nixos/401-default
removing obsolete generations in /boot/firmware/nixos...
* /boot/firmware/nixos/400-default is obsolete
removed '/boot/firmware/nixos/400-default/system-link'
removed '/boot/firmware/nixos/400-default/kernel-link'
removed '/boot/firmware/nixos/400-default/cmdline.txt'
removed '/boot/firmware/nixos/400-default/kernel.img'
removed '/boot/firmware/nixos/400-default/initrd'
removed '/boot/firmware/nixos/400-default/overlays/adafruit-st7735r.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/act-led.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/adafruit18.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/allo-boss-dac-pcm512x-audio.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/adau1977-adc.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/adau7002-simple.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/ads1015.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/ads1115.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/ads7846.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/adv7282m.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/adv728x-m.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/akkordion-iqdacplus.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/allo-boss2-dac-audio.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/allo-piano-dac-pcm512x-audio.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/allo-digione.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/allo-katana-dac-audio.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/arducam-64mp.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/anyspi.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/allo-piano-dac-plus-pcm512x-audio.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/apds9960.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/applepi-dac.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/audioinjector-isolated-soundcard.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/arducam-pivariety.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/at86rf233.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/audioinjector-addons.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/audioinjector-bare-i2s.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/audioinjector-wm8731-audio.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/audioinjector-ultra.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/hdmi-backlight-hwhack-gpio.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/audiosense-pi.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/audremap.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/audremap-pi5.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/balena-fin.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/bcm2712d0.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/camera-mux-2port.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/camera-mux-4port.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/cap1106.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/chipcap2.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/chipdip-dac.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/cirrus-wm5102.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/cma.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/cm-swap-i2c0.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/crystalfontz-cfa050_pi_m.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/cutiepi-panel.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/dacberry400.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/dht11.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/dionaudio-kiwi.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/dionaudio-loco.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/dionaudio-loco-v2.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/disable-bt.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/disable-bt-pi5.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/disable-emmc2.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/disable-wifi.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/disable-wifi-pi5.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/dpi18cpadhi.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/dpi18.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/dpi24.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/draws.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/dwc2.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/dwc-otg-deprecated.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/edt-ft5406.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/enc28j60.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/enc28j60-spi2.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/exc3000.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/ezsound-6x8iso.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/fbtft.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/fe-pi-audio.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/fsm-demo.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/gc9a01.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/ghost-amp.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/goodix.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/googlevoicehat-soundcard.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/gpio-charger.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/gpio-fan.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/gpio-hog.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/gpio-ir.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/gpio-ir-tx.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/gpio-key.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/gpio-led.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/gpio-no-bank0-irq.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/gpio-no-irq.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/gpio-poweroff.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/gpio-shutdown.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/hat_map.dtb'
removed '/boot/firmware/nixos/400-default/overlays/hd44780-i2c-lcd.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/hd44780-lcd.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/iqaudio-digi-wm8804-audio.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/hifiberry-adc8x.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/hifiberry-adc.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/hifiberry-amp100.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/hifiberry-amp3.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/hifiberry-amp4pro.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/hifiberry-amp.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/hifiberry-dac8x.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/hifiberry-dac.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/hifiberry-dacplusadc.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/hifiberry-dacplusadcpro.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/hifiberry-dacplusdsp.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/hifiberry-dacplus.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/hifiberry-dacplushd.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/hifiberry-dacplus-pro.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/hifiberry-dacplus-std.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/hifiberry-digi.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/hifiberry-digi-pro.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/highperi.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/hy28a.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/hy28b-2017.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/hy28b.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/i2c0.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/i2c0-pi5.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/i2c1.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/i2c1-pi5.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/i2c2-pi5.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/i2c3.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/i2c3-pi5.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/i2c4.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/i2c5.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/i2c6.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/i2c-bcm2708.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/i2c-fan.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/i2c-gpio.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/i2c-mux.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/i2c-pwm-pca9685a.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/i2c-rtc.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/i2c-rtc-gpio.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/i2c-sensor.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/i2s-dac.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/i2s-gpio28-31.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/i2s-master-dac.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/ilitek251x.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/imx219.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/imx258.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/imx283.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/imx290.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/imx296.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/imx327.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/imx335.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/imx378.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/imx415.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/imx462.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/imx477.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/imx500.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/imx500-pi5.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/imx519.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/imx708.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/interludeaudio-analog.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/interludeaudio-digital.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/iqaudio-codec.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/iqaudio-dac.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/iqaudio-dacplus.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/jedec-spi-nor.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/iqs550.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/irs1125.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/i-sabre-q2m.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/pineboards-hatdrive-poe-plus.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/justboom-both.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/justboom-dac.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/justboom-digi.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/ltc294x.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/max98357a.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/maxtherm.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/mbed-dac.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/mcp23017.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/mcp23s17.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/mcp2515-can0.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/mcp2515-can1.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/mcp2515.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/mcp251xfd.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/mcp3008.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/mcp3202.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/mcp342x.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/media-center.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/merus-amp.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/midi-uart0.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/midi-uart0-pi5.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/midi-uart1.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/midi-uart1-pi5.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/midi-uart2.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/midi-uart2-pi5.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/midi-uart3.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/midi-uart3-pi5.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/midi-uart4.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/midi-uart4-pi5.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/midi-uart5.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/minipitft13.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/miniuart-bt.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/mipi-dbi-spi.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/mira220.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/mlx90640.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/mmc.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/mz61581.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/ov2311.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/ov5647.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/ov64a40.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/ov7251.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/ov9281.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/overlay_map.dtb'
removed '/boot/firmware/nixos/400-default/overlays/papirus.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/pca953x.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/pcf857x.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/pcie-32bit-dma.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/pcie-32bit-dma-pi5.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/pciex1-compat-pi5.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/pibell.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/pifacedigital.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/pifi-40.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/pifi-dac-hd.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/pifi-dac-zero.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/pifi-mini-210.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/piglow.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/pimidi.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/pineboards-hat-ai.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/pisound-micro.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/piscreen2r.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/piscreen.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/pisound.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/pitft28-capacitive.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/pisound-pi5.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/pitft22.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/rotary-encoder.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/README'
removed '/boot/firmware/nixos/400-default/overlays/pitft28-resistive.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/pitft35-resistive.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/pivision.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/pps-gpio.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/proto-codec.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/pwm1.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/pwm-2chan.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/pwm.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/pwm-gpio.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/pwm-gpio-fan.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/pwm-ir-tx.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/pwm-pio.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/qca7000.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/qca7000-uart0.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/ramoops.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/ramoops-pi4.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/rootmaster.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/rra-digidac1-wm8741-audio.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/rpi-backlight.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/rpi-codeczero.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/rpi-dacplus.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/rpi-dacpro.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/rpi-digiampplus.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/rpi-ft5406.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/rpi-fw-uart.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/rpi-poe.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/rpi-poe-plus.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/rpi-power-hat-b.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/rpi-power-hat-t.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/rpi-sense.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/rpi-sense-v2.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/rpi-tv.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/sc16is750-i2c.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/sainsmart18.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/vc4-kms-dpi-hyperpixel4sq.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/sc16is752-i2c.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/sc16is75x-spi.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/sdhost.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/sdio.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/sdio-pi5.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/seeed-can-fd-hat-v1.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/seeed-can-fd-hat-v2.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/sh1106-spi.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/si446x-spi0.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/smi-dev.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/smi.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/smi-nand.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/spi0-0cs.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/spi0-1cs.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/spi0-1cs-inverted.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/spi0-2cs.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/spi1-1cs.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/spi1-2cs.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/spi1-3cs.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/spi2-1cs.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/spi2-1cs-pi5.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/spi2-2cs.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/spi2-2cs-pi5.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/spi2-3cs.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/spi3-1cs.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/spi3-1cs-pi5.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/spi3-2cs.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/spi3-2cs-pi5.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/spi4-1cs.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/spi4-2cs.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/spi5-1cs.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/spi5-1cs-pi5.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/spi5-2cs.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/spi5-2cs-pi5.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/spi6-1cs.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/spi6-2cs.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/spi-gpio35-39.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/spi-gpio40-45.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/spi-rtc.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/ssd1306.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/ssd1306-spi.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/ssd1327-spi.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/ssd1331-spi.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/ssd1351-spi.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/sunfounder-pipower3.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/sunfounder-pironman5.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/superaudioboard.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/sx150x.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/tc358743-audio.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/tc358743.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/tc358743-pi5.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/tinylcd35.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/tpm-slb9670.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/tpm-slb9673.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/uart0.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/uart0-pi5.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/uart1.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/uart1-pi5.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/uart2.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/uart2-pi5.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/uart3.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/uart3-pi5.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/uart4.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/uart4-pi5.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/uart5.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/udrc.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/ugreen-dabboard.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/upstream.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/upstream-pi4.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/vc4-fkms-v3d.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/vc4-fkms-v3d-pi4.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/vc4-kms-dpi-generic.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/vc4-kms-dpi-hyperpixel2r.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/vc4-kms-dpi-hyperpixel4.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/vc4-kms-dsi-ili9881-5inch.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/vc4-kms-dpi-panel.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/vc4-kms-dsi-7inch.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/vc4-kms-dsi-generic.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/w1-gpio-pullup.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/vga666.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/vc4-kms-dsi-ili9881-7inch.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/vc4-kms-dsi-lt070me05000.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/vc4-kms-dsi-lt070me05000-v2.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/vc4-kms-dsi-waveshare-800x480.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/vc4-kms-dsi-waveshare-panel.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/vc4-kms-dsi-waveshare-panel-v2.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/vc4-kms-kippah-7inch.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/vc4-kms-v3d.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/vc4-kms-v3d-pi4.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/vc4-kms-v3d-pi5.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/vc4-kms-vga666.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/vl805.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/w1-gpio.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/w1-gpio-pi5.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/waveshare-can-fd-hat-mode-a.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/w1-gpio-pullup-pi5.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/w5500.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/watterott-display.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/wm8960-soundcard.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/wifimac.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/waveshare-can-fd-hat-mode-b.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/wittypi.dtbo'
removed '/boot/firmware/nixos/400-default/overlays/ws2812-pio.dtbo'
removed directory '/boot/firmware/nixos/400-default/overlays'
removed '/boot/firmware/nixos/400-default/bcm2710-rpi-2-b.dtb'
removed '/boot/firmware/nixos/400-default/bcm2710-rpi-3-b.dtb'
removed '/boot/firmware/nixos/400-default/bcm2710-rpi-3-b-plus.dtb'
removed '/boot/firmware/nixos/400-default/bcm2710-rpi-cm0.dtb'
removed '/boot/firmware/nixos/400-default/bcm2710-rpi-cm3.dtb'
removed '/boot/firmware/nixos/400-default/bcm2710-rpi-zero-2.dtb'
removed '/boot/firmware/nixos/400-default/bcm2710-rpi-zero-2-w.dtb'
removed '/boot/firmware/nixos/400-default/bcm2711-rpi-400.dtb'
removed '/boot/firmware/nixos/400-default/bcm2711-rpi-4-b.dtb'
removed '/boot/firmware/nixos/400-default/bcm2711-rpi-cm4.dtb'
removed '/boot/firmware/nixos/400-default/bcm2711-rpi-cm4-io.dtb'
removed '/boot/firmware/nixos/400-default/bcm2711-rpi-cm4s.dtb'
removed '/boot/firmware/nixos/400-default/bcm2712d0-rpi-5-b.dtb'
removed '/boot/firmware/nixos/400-default/bcm2712-d-rpi-5-b.dtb'
removed '/boot/firmware/nixos/400-default/bcm2712-rpi-500.dtb'
removed '/boot/firmware/nixos/400-default/bcm2712-rpi-5-b.dtb'
removed '/boot/firmware/nixos/400-default/bcm2712-rpi-cm5-cm4io.dtb'
removed '/boot/firmware/nixos/400-default/bcm2712-rpi-cm5-cm5io.dtb'
removed '/boot/firmware/nixos/400-default/bcm2712-rpi-cm5l-cm4io.dtb'
removed '/boot/firmware/nixos/400-default/bcm2712-rpi-cm5l-cm5io.dtb'
removed '/boot/firmware/nixos/400-default/bcm2837-rpi-3-a-plus.dtb'
removed '/boot/firmware/nixos/400-default/bcm2837-rpi-3-b.dtb'
removed '/boot/firmware/nixos/400-default/bcm2837-rpi-3-b-plus.dtb'
removed '/boot/firmware/nixos/400-default/bcm2837-rpi-cm3-io3.dtb'
removed '/boot/firmware/nixos/400-default/bcm2837-rpi-zero-2-w.dtb'
removed directory '/boot/firmware/nixos/400-default'
generational bootloader installed
[agenix] creating new generation in /run/agenix.d/15
[agenix] decrypting secrets...
decrypting '/nix/store/jvg49jr7l3kjvzb8bmlchigm2zfs92as-affine-token.age' to '/run/agenix.d/15/affine-token'...
decrypting '/nix/store/saf7nsklrb9nqbsybs1z15g2ha78ihw5-for-sure-api-key.age' to '/run/agenix.d/15/for-sure-api-key'...
decrypting '/nix/store/9qhpjhnhar6lqs4zj7zfin8jywgdiq28-affine-gcal-oauth.age' to '/run/agenix.d/15/affine-gcal-oauth'...
decrypting '/nix/store/kb97shr1vji9djdlbxgzq5g9xgxq4xpj-immich-api-key.age' to '/run/agenix.d/15/immich-api-key'...
decrypting '/nix/store/4dncr7mywcf1zq50jp6wrsv6iawnilky-langfuse-keys.age' to '/run/agenix.d/15/langfuse-keys'...
decrypting '/nix/store/4ak2jw7cni0clmbi9a5p5rm2p9jqd2jf-linky-prm.age' to '/run/agenix.d/15/linky-prm'...
decrypting '/nix/store/zwlww0daapjnvm1y2lx6q526fkz2xx39-linky-token.age' to '/run/agenix.d/15/linky-token'...
decrypting '/nix/store/6lldh8sl2a6rzyplwhxh1sbaky4gq5f3-openclaw-codex-auth.age' to '/run/agenix.d/15/openclaw-codex-auth'...
decrypting '/nix/store/3y9v9ny9ddk8f4hazb09idva8kmz1akb-openclaw.env.age' to '/run/agenix.d/15/openclaw-env'...
decrypting '/nix/store/ca6ds8qnp96cg5ypyy1k4rcnr7jrklsk-restic-password.age' to '/run/agenix.d/15/restic-password'...
decrypting '/nix/store/515g0wd5k4sa8fwdgi013rqmkyg8sd7j-rclone-storj.age' to '/run/agenix.d/15/rclone-storj'...
decrypting '/nix/store/vrrb4jx76p94xkjpynfzlz5awf82z7z5-supervisor-token.age' to '/run/agenix.d/15/supervisor-token'...
decrypting '/nix/store/x5czmg47n22l4f18zin7fivsi9lc8jg4-sure-pg-password.age' to '/run/agenix.d/15/sure-pg-password'...
decrypting '/nix/store/fy6sbxv956a53z5z0w5dmjc38dgavi7j-sure-app-env.age' to '/run/agenix.d/15/sure-app-env'...
decrypting '/nix/store/8k9wx061k7dsxbwbcm4vyzrfidxcg6nd-vaultwarden-admin-token.age' to '/run/agenix.d/15/vaultwarden-admin-token'...
decrypting '/nix/store/5717rabjxglhwnp7kzsbcmhzl0fknxiq-telegram-bot-token.age' to '/run/agenix.d/15/telegram-bot-token'...
[agenix] symlinking new secrets to /run/agenix (generation 15)...
[agenix] removing old secrets (generation 14)...
[agenix] chowning...
setting up /etc...
/nix/store/107m2lkc2k815g6nlinclz1l94yrydsm-nixos-system-rpi5-25.11.20260409.0d5a853\n- confirmed  now includes \n- confirmed SDB towel warmup automations materialize as live  entities in Home Assistant\n- manually triggered the stop automation and verified  switches to \n