### PR TITLE
fix: git config path and claude-settings key order

### DIFF
--- a/home/dotfiles/claude-settings.json
+++ b/home/dotfiles/claude-settings.json
@@ -1,9 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
-  "effortLevel": "medium",
-  "voiceEnabled": true,
-  "skipDangerousModePermissionPrompt": true,
-  "trustAll": true,
   "permissions": {
     "allow": [
       "Bash(*)",
@@ -22,15 +18,19 @@
   "hooks": {
     "Notification": [
       {
+        "matcher": "",
         "hooks": [
           {
+            "type": "command",
             "command": "$HOME/.claude/hooks/telegram-notify",
-            "timeout": 10,
-            "type": "command"
+            "timeout": 10
           }
-        ],
-        "matcher": ""
+        ]
       }
     ]
-  }
+  },
+  "effortLevel": "medium",
+  "voiceEnabled": true,
+  "skipDangerousModePermissionPrompt": true,
+  "trustAll": true
 }

--- a/home/dotfiles/zsh/functions.zsh
+++ b/home/dotfiles/zsh/functions.zsh
@@ -202,6 +202,6 @@ function get-version() {
 
 # Use personal identity only in real terminal sessions (agents have no TTY)
 if [[ -t 0 ]]; then
-  git() { GIT_CONFIG_GLOBAL=~/.config/git/config-personal command git "$@" }
+  git() { GIT_CONFIG_GLOBAL=~/.config/git/config command git "$@" }
   gh() { GH_TOKEN=$(command gh auth token --user nSimonFR 2>/dev/null) command gh "$@" }
 fi


### PR DESCRIPTION
## Summary

- Fix git wrapper using stale `config-personal` path → `~/.config/git/config`
- Normalize key order in `claude-settings.json` (no semantic change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)