### PR TITLE
Move Forgejo repositories to /mnt/data

### DIFF
--- a/rpi5/forgejo.nix
+++ b/rpi5/forgejo.nix
@@ -18,6 +18,8 @@ in
       createDatabase = true;
     };
 
+    repositoryRoot = "/mnt/data/repositories";
+
     settings = {
       server = {
         HTTP_ADDR          = "127.0.0.1";


### PR DESCRIPTION
## Summary
- Move Forgejo repository storage from `/var/lib/forgejo/repositories` (SD card) to `/mnt/data/repositories` (external drive)
- Frees ~2 GB on the SD card, repos stored alongside other large data (immich, backups)

## Test plan
- [x] Repos moved and ownership set to `forgejo:forgejo`
- [x] NixOS rebuild applied
- [x] Forgejo API returns repos from new location

🤖 Generated with [Claude Code](https://claude.com/claude-code)