### PR TITLE
feat: add Open WebUI with LiteLLM backend

### DIFF
--- a/rpi5/configuration.nix
+++ b/rpi5/configuration.nix
@@ -123,6 +123,7 @@ in
     ./affine.nix
     ./affine-mcp-gateway.nix
     ./litellm.nix
+    ./open-webui.nix
     ./backups.nix
     ./storj-backup.nix
     # Tailscale with server features (subnet routing, SSH, exit node)

--- a/rpi5/open-webui.nix
+++ b/rpi5/open-webui.nix
@@ -1,0 +1,38 @@
+{ pkgs, lib, ... }:
+{
+  services.open-webui = {
+    enable = true;
+    port = 8181;
+    host = "127.0.0.1";
+    environment = {
+      # Connect to LiteLLM gateway (OpenAI-compatible)
+      OPENAI_API_BASE_URL = "http://127.0.0.1:4001/v1";
+      OPENAI_API_KEY = "ollama";
+      # Disable direct Ollama connection (use LiteLLM instead)
+      ENABLE_OLLAMA_API = "false";
+      # Offload embeddings to LiteLLM → beast (saves ~500 MiB RAM)
+      RAG_EMBEDDING_ENGINE = "openai";
+      RAG_EMBEDDING_MODEL = "text-embedding-3-small";
+      RAG_OPENAI_API_BASE_URL = "http://127.0.0.1:4001/v1";
+      RAG_OPENAI_API_KEY = "ollama";
+      RAG_RERANKING_MODEL = "";
+      # Disable local Whisper STT (saves ~300 MiB RAM)
+      AUDIO_STT_ENGINE = "openai";
+      AUDIO_STT_OPENAI_API_BASE_URL = "http://127.0.0.1:4001/v1";
+      AUDIO_STT_OPENAI_API_KEY = "ollama";
+      # Auth & telemetry
+      WEBUI_AUTH = "true";
+      SCARF_NO_ANALYTICS = "True";
+      DO_NOT_TRACK = "True";
+      ANONYMIZED_TELEMETRY = "False";
+    };
+  };
+
+  # RPi5: no user namespace support
+  systemd.services.open-webui.serviceConfig.PrivateUsers = lib.mkForce false;
+  # Tight memory cap for 4 GiB RPi5
+  systemd.services.open-webui.serviceConfig.MemoryMax = "384M";
+  # Start after LiteLLM
+  systemd.services.open-webui.after = [ "litellm-gateway.service" ];
+  systemd.services.open-webui.wants = [ "litellm-gateway.service" ];
+}

--- a/rpi5/tailscale-serve.nix
+++ b/rpi5/tailscale-serve.nix
@@ -15,6 +15,7 @@ let
     { port = 7020;  backend = "http://127.0.0.1:17020"; } # affine MCP gateway (SSE)
     { port = 4001;  backend = "http://127.0.0.1:4001";  } # litellm gateway
     { port = 3100;  backend = "http://127.0.0.1:3100";  } # forgejo (git)
+    { port = 8181;  backend = "http://127.0.0.1:8181";  } # open-webui
   ];
 
   # Publicly-accessible services (tailscale funnel).


### PR DESCRIPTION
## Summary
- Add Open WebUI (v0.8.12) as a chat frontend using the NixOS `services.open-webui` module
- Points at existing LiteLLM gateway on port 4001 (OpenAI-compatible API)
- Offloads embeddings (`RAG_EMBEDDING_ENGINE=openai`) and STT to LiteLLM/beast to avoid loading ML models locally (~800 MiB RAM saved)
- Exposed via Tailscale Serve on port 8181
- `PrivateUsers = lib.mkForce false` for RPi5, `MemoryMax = 384M`

## Test plan
- [ ] `sudo nixos-rebuild switch --flake /home/nsimon/nic-os#rpi5 --max-jobs 1 -j 1`
- [ ] `systemctl status open-webui` is active
- [ ] `curl http://127.0.0.1:8181` returns HTML
- [ ] `https://rpi5.gate-mintaka.ts.net:8181` accessible, create first user
- [ ] Models from LiteLLM (gemma4, qwen3.5) visible in UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)