### PR TITLE
feat: claude remote-control server as systemd service

### DIFF
--- a/home/claude.nix
+++ b/home/claude.nix
@@ -88,23 +88,24 @@ let
 
     exit 0
   '';
+  claudeCodePkg = unstablePkgs.claude-code.overrideAttrs (old: {
+    nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ pkgs.makeWrapper ];
+    postFixup = (old.postFixup or "") + ''
+      wrapProgram $out/bin/claude \
+        --set GIT_SSH_COMMAND "ssh -i ~/.ssh/ai_id_ed25519 -o IdentityAgent=none" \
+        --set GIT_AUTHOR_NAME "nSimonFR-ai" \
+        --set GIT_AUTHOR_EMAIL "265587706+nSimonFR-ai@users.noreply.github.com" \
+        --set GIT_COMMITTER_NAME "nSimonFR-ai" \
+        --set GIT_COMMITTER_EMAIL "265587706+nSimonFR-ai@users.noreply.github.com" \
+        --run 'export GH_TOKEN="$(gh auth token --user nSimonFR-ai 2>/dev/null || true)"' \
+        --set GITHUB_TOKEN ""
+    '';
+  });
 in
 {
   programs.claude-code = {
     enable = true;
-    package = unstablePkgs.claude-code.overrideAttrs (old: {
-      nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ pkgs.makeWrapper ];
-      postFixup = (old.postFixup or "") + ''
-        wrapProgram $out/bin/claude \
-          --set GIT_SSH_COMMAND "ssh -i ~/.ssh/ai_id_ed25519 -o IdentityAgent=none" \
-          --set GIT_AUTHOR_NAME "nSimonFR-ai" \
-          --set GIT_AUTHOR_EMAIL "265587706+nSimonFR-ai@users.noreply.github.com" \
-          --set GIT_COMMITTER_NAME "nSimonFR-ai" \
-          --set GIT_COMMITTER_EMAIL "265587706+nSimonFR-ai@users.noreply.github.com" \
-          --run 'export GH_TOKEN="$(gh auth token --user nSimonFR-ai 2>/dev/null || true)"' \
-          --set GITHUB_TOKEN ""
-      '';
-    });
+    package = claudeCodePkg;
 
     # Settings delivered as a writable file via mkOutOfStoreSymlink
     # (points to the repo checkout, not the Nix store) so Claude Code
@@ -121,6 +122,16 @@ in
   home.file.".claude/hooks/telegram-notify" = {
     source = notifyScript;
     executable = true;
+  };
+
+  # Wrapper for `claude remote-control` that bypasses the HM-generated
+  # --mcp-config wrapper (its variadic <configs...> arg swallows subcommands).
+  # Uses the overrideAttrs package directly (has env vars, no --mcp-config).
+  home.file.".claude/bin/claude-rc" = {
+    executable = true;
+    source = pkgs.writeShellScript "claude-rc" ''
+      exec "${claudeCodePkg}/bin/claude" remote-control "$@"
+    '';
   };
 
 }

--- a/rpi5/claude-remote-control.nix
+++ b/rpi5/claude-remote-control.nix
@@ -1,25 +1,70 @@
-{ pkgs, ... }:
+{ pkgs, username, ... }:
 let
-  claudeBin = "/etc/profiles/per-user/nsimon/bin/claude";
+  sessionName = "claude-rc";
+  claudeRc = "/home/${username}/.claude/bin/claude-rc";
+
+  stopScript = pkgs.writeShellScript "claude-remote-control-stop" ''
+    # Send SIGTERM to the claude process inside tmux, giving it time
+    # to deregister from Anthropic's API before we kill the session.
+    ${pkgs.tmux}/bin/tmux send-keys -t ${sessionName} C-c 2>/dev/null || true
+    sleep 3
+    ${pkgs.tmux}/bin/tmux kill-session -t ${sessionName} 2>/dev/null || true
+  '';
+
+  startScript = pkgs.writeShellScript "claude-remote-control-start" ''
+    ${pkgs.tmux}/bin/tmux kill-session -t ${sessionName} 2>/dev/null || true
+    ${pkgs.tmux}/bin/tmux new-session -d -s ${sessionName} \
+      "${claudeRc} \
+        --spawn worktree \
+        --no-create-session-in-dir \
+        --capacity 8 \
+        --permission-mode bypassPermissions"
+  '';
+
+  watchdogScript = pkgs.writeShellScript "claude-remote-control-watchdog" ''
+    if ! su -l ${username} -c '${pkgs.tmux}/bin/tmux has-session -t ${sessionName} 2>/dev/null'; then
+      echo "tmux session ${sessionName} missing, restarting service"
+      systemctl restart claude-remote-control.service
+    fi
+  '';
 in
 {
   systemd.services.claude-remote-control = {
-    description = "Claude Code Remote Control server";
+    description = "Claude Code Remote Control server (tmux)";
     after = [ "network.target" ];
     wantedBy = [ "multi-user.target" ];
+    # Stop cleanly before rebuilds: nixos-rebuild triggers stop→start
+    stopIfChanged = true;
     serviceConfig = {
-      Type = "simple";
-      User = "nsimon";
+      Type = "oneshot";
+      RemainAfterExit = true;
+      User = username;
       Group = "users";
-      WorkingDirectory = "/home/nsimon";
-      ExecStart = "${claudeBin} remote-control";
-      Restart = "on-failure";
-      RestartSec = "10s";
-      # Claude Code needs access to home dir for config, keys, etc.
+      WorkingDirectory = "/home/${username}/nic-os";
+      ExecStart = startScript;
+      ExecStop = stopScript;
+      TimeoutStopSec = "10s";
       Environment = [
-        "HOME=/home/nsimon"
-        "PATH=/etc/profiles/per-user/nsimon/bin:/run/current-system/sw/bin:/usr/bin:/bin"
+        "HOME=/home/${username}"
+        "PATH=/etc/profiles/per-user/${username}/bin:/run/current-system/sw/bin:/usr/bin:/bin"
       ];
+    };
+  };
+
+  systemd.services.claude-remote-control-watchdog = {
+    description = "Claude Code Remote Control watchdog";
+    serviceConfig = {
+      Type = "oneshot";
+      ExecStart = watchdogScript;
+    };
+  };
+
+  systemd.timers.claude-remote-control-watchdog = {
+    description = "Claude Code Remote Control watchdog timer";
+    wantedBy = [ "timers.target" ];
+    timerConfig = {
+      OnBootSec = "2min";
+      OnUnitActiveSec = "5min";
     };
   };
 }


### PR DESCRIPTION
## Summary
- Adds `rpi5/claude-remote-control.nix` — systemd service running `claude remote-control --spawn worktree` via tmux
- Adds `~/.claude/bin/claude-rc` wrapper in `home/claude.nix` to bypass HM's `--mcp-config` wrapper that breaks the subcommand
- Sessions spawned on demand from Claude iOS app or claude.ai/code — each gets an isolated git worktree
- Graceful Ctrl-C shutdown on rebuild (deregisters from Anthropic API), 5min watchdog timer for auto-restart

## Config
- `--spawn worktree` / `--capacity 8` / `--no-create-session-in-dir` / `--permission-mode bypassPermissions`

## Test plan
- [x] `sudo nixos-rebuild switch` — service starts, tmux session alive
- [x] Remote-control server shows `Ready · Capacity: 0/8`
- [x] iOS app can connect and spawn sessions
- [x] Rebuild cleanly stops and restarts the service

🤖 Generated with [Claude Code](https://claude.com/claude-code)