### PR TITLE
fix: claude remote-control improvements

### DIFF
--- a/rpi5/claude-remote-control.nix
+++ b/rpi5/claude-remote-control.nix
@@ -18,11 +18,16 @@ let
         --spawn worktree \
         --no-create-session-in-dir \
         --capacity 8 \
-        --permission-mode bypassPermissions"
+        --permission-mode bypassPermissions \
+        --name rpi5 \
+        --verbose \
+        --debug-file /tmp/claude-rc-debug.log"
   '';
 
   watchdogScript = pkgs.writeShellScript "claude-remote-control-watchdog" ''
-    if ! su -l ${username} -c '${pkgs.tmux}/bin/tmux has-session -t ${sessionName} 2>/dev/null'; then
+    # tmux server is per-user; point to the user's socket
+    TMUX_SOCKET="/tmp/tmux-$(id -u ${username})/default"
+    if ! ${pkgs.tmux}/bin/tmux -S "$TMUX_SOCKET" has-session -t ${sessionName} 2>/dev/null; then
       echo "tmux session ${sessionName} missing, restarting service"
       systemctl restart claude-remote-control.service
     fi


### PR DESCRIPTION
## Summary
- Add `--name rpi5` so the environment is identifiable in the iOS app among stale ones
- Add `--verbose` and `--debug-file /tmp/claude-rc-debug.log` for troubleshooting
- Graceful Ctrl-C shutdown on rebuild to deregister from Anthropic API
- Watchdog timer (5min) to auto-restart if tmux session dies
- `~/.claude/bin/claude-rc` wrapper using overridden package (env vars, no --mcp-config breakage)
- `--no-create-session-in-dir` — only register endpoint, sessions on demand

## Test plan
- [x] Tested on rpi5, sessions spawn from iOS app

🤖 Generated with [Claude Code](https://claude.com/claude-code)