### PR TITLE
fix: remote-control watchdog + verbose flags

### DIFF
--- a/rpi5/claude-remote-control.nix
+++ b/rpi5/claude-remote-control.nix
@@ -25,7 +25,9 @@ let
   '';
 
   watchdogScript = pkgs.writeShellScript "claude-remote-control-watchdog" ''
-    if ! su -l ${username} -c '${pkgs.tmux}/bin/tmux has-session -t ${sessionName} 2>/dev/null'; then
+    # tmux server is per-user; point to the user's socket
+    TMUX_SOCKET="/tmp/tmux-$(id -u ${username})/default"
+    if ! ${pkgs.tmux}/bin/tmux -S "$TMUX_SOCKET" has-session -t ${sessionName} 2>/dev/null; then
       echo "tmux session ${sessionName} missing, restarting service"
       systemctl restart claude-remote-control.service
     fi

--- a/rpi5/claude-remote-control.nix
+++ b/rpi5/claude-remote-control.nix
@@ -18,7 +18,10 @@ let
         --spawn worktree \
         --no-create-session-in-dir \
         --capacity 8 \
-        --permission-mode bypassPermissions"
+        --permission-mode bypassPermissions \
+        --name rpi5 \
+        --verbose \
+        --debug-file /tmp/claude-rc-debug.log"
   '';
 
   watchdogScript = pkgs.writeShellScript "claude-remote-control-watchdog" ''


### PR DESCRIPTION
## Summary
- Fix watchdog to use tmux socket path instead of su
- Add --name, --verbose, --debug-file flags to remote-control

🤖 Generated with [Claude Code](https://claude.com/claude-code)