### PR TITLE
fix: set HOME for open-webui to fix NLTK crash

### DIFF
--- a/rpi5/open-webui.nix
+++ b/rpi5/open-webui.nix
@@ -50,6 +50,8 @@ in
     (let cfg = { port = 8181; host = "127.0.0.1"; package = pkgs.open-webui; }; in
      "${pkgs.writeShellScript "open-webui-wrapper" ''
        export PYTHONPATH="${torchgenFix}:''${PYTHONPATH:-}"
+       # NLTK needs a resolvable HOME for its download directory
+       export HOME=/var/lib/open-webui
        # Inject Tavily API key from dedicated agenix secret
        if [ -f /run/agenix/tavily-api-key ]; then
          export TAVILY_API_KEY=$(cat /run/agenix/tavily-api-key)


### PR DESCRIPTION
## Summary
- open-webui was crashing on startup because NLTK's downloader couldn't resolve a home directory (`os.path.expanduser("~/")` returns literal `~/` when no HOME is set)
- Set `HOME=/var/lib/open-webui` in the wrapper script, pointing to the existing systemd state directory

## Test plan
- [x] Rebuilt NixOS, open-webui now starts successfully
- [x] Zero failed services after rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)