### PR TITLE
feat(homepage): add BentoPDF bookmark to Quick Links

### DIFF
--- a/rpi5/homepage.nix
+++ b/rpi5/homepage.nix
@@ -133,6 +133,7 @@ in
           { "Tailscale Admin" = [{ icon = "tailscale.svg"; href = "https://login.tailscale.com/admin/machines"; }]; }
           { "nic-os PRs" = [{ icon = "github.svg"; href = "https://github.com/nSimonFR/nic-os/pulls"; }]; }
           { "IT Tools" = [{ icon = "si-hackthebox"; href = "https://it-tools.tech/"; }]; }
+          { "BentoPDF" = [{ icon = "mdi-file-pdf-box"; href = "https://bentopdf.com/"; }]; }
         ];
       }
     ];


### PR DESCRIPTION
## Summary
- Adds BentoPDF (https://bentopdf.com) as a Quick Links bookmark next to IT Tools — browser-based PDF toolkit (merge, split, OCR, compress, etc.) that runs client-side.
- Uses `mdi-file-pdf-box` Material Design icon.

## Test plan
- [x] Rebuilt on rpi5 — homepage-dashboard picks up the new bookmark
- [x] Verified `curl http://127.0.0.1:8082` shows both "IT Tools" and "BentoPDF" in the rendered output

## Notes
Unrelated pre-existing failure observed on the host: `sure-pg-setup.service` has been failing for 2+ hours with `ALTER USER sure_user WITH PASSWORD :'pw'` — the `-v pw="$password"` flag is present in source but the variable isn't being substituted at runtime. Worth a separate look; not caused by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)