### PR TITLE
fix(sure): psql variable interpolation needs stdin, not -c

### DIFF
--- a/rpi5/sure.nix
+++ b/rpi5/sure.nix
@@ -50,7 +50,9 @@ in
     };
     script = ''
       password=$(cat /run/agenix/sure-pg-password)
-      ${pkgs.postgresql}/bin/psql -v pw="$password" -c "ALTER USER sure_user WITH PASSWORD :'pw';"
+      # psql variable interpolation (:'pw') requires stdin/-f input; it is silently
+      # skipped with -c, producing "syntax error at or near :". Pipe via stdin.
+      ${pkgs.postgresql}/bin/psql -v pw="$password" <<< "ALTER USER sure_user WITH PASSWORD :'pw';"
       ${pkgs.postgresql}/bin/psql -c "ALTER DATABASE sure_production OWNER TO sure_user;"
     '';
   };


### PR DESCRIPTION
## Summary
`sure-pg-setup.service` has been failing since PostgreSQL 17 with:
```
ERROR:  syntax error at or near ":"
LINE 1: ALTER USER sure_user WITH PASSWORD :'pw';
```

psql's `:'varname'` interpolation only runs on stdin / `-f` input; with `-c` the command bypasses client-side preprocessing and `:'pw'` reaches the server literal. Piping the statement via heredoc-string fixes it.

## Root cause verification
```bash
psql -v pw=test <<< "SELECT :'pw';"   # → test
psql -v pw=test -c "SELECT :'pw';"    # → ERROR: syntax error at or near ":"
```

## Test plan
- [x] Rebuilt on rpi5 → `sure-pg-setup.service` completed: `ALTER ROLE` / `ALTER DATABASE`
- [x] `sure-web` and `sure-worker` now start (they `require` sure-pg-setup)
- [x] `systemctl is-active sure-pg-setup sure-web sure-worker` → all active

🤖 Generated with [Claude Code](https://claude.com/claude-code)