### PR TITLE
feat: add dawarich (self-hosted location history) service

### DIFF
--- a/rpi5/backups.nix
+++ b/rpi5/backups.nix
@@ -6,7 +6,7 @@
   services.postgresqlBackup = {
     enable = true;
     location = "/mnt/data/backups/postgresql";
-    databases = [ "affine" "sure_production" ];
+    databases = [ "affine" "dawarich" "sure_production" ];
     compression = "gzip";
     startAt = "*-*-* 03:00:00";
   };

--- a/rpi5/configuration.nix
+++ b/rpi5/configuration.nix
@@ -120,6 +120,7 @@ in
     ./sumeria-mitm.nix
     ./vaultwarden.nix
     ./forgejo.nix
+    ./dawarich.nix
     ./affine.nix
     ./affine-mcp-gateway.nix
     ./litellm.nix

--- a/rpi5/dawarich.nix
+++ b/rpi5/dawarich.nix
@@ -1,0 +1,40 @@
+# dawarich.nix — self-hosted location history (Google Timeline alternative)
+# Uses the native NixOS module (services.dawarich) — Rails + Sidekiq + PostGIS + Redis
+{ config, pkgs, lib, tailnetFqdn, ... }:
+let
+  internalPort = 13900;
+in
+{
+  services.dawarich = {
+    enable = true;
+    localDomain = tailnetFqdn;
+    webPort = internalPort;
+    configureNginx = false; # Tailscale Serve handles HTTPS
+
+    # Reuses existing PostgreSQL cluster; auto-adds "dawarich" DB + PostGIS extension
+    database.createLocally = true;
+
+    # Dedicated Redis instance via Unix socket (no port conflict with shared redis)
+    redis.createLocally = true;
+
+    # Auto-generate SECRET_KEY_BASE (stored at /var/lib/dawarich/secrets/secret-key-base)
+    secretKeyBaseFile = null;
+
+    # Reduce Sidekiq threads for RPi5 memory constraints
+    sidekiqThreads = 3;
+
+    environment = {
+      TIME_ZONE = "Europe/Paris";
+    };
+  };
+
+  # RPi5: PrivateUsers requires user namespaces, not supported on this kernel
+  systemd.services.dawarich-web.serviceConfig.PrivateUsers = lib.mkForce false;
+  systemd.services.dawarich-sidekiq-all.serviceConfig.PrivateUsers = lib.mkForce false;
+  systemd.services.dawarich-init-db.serviceConfig.PrivateUsers = lib.mkForce false;
+  systemd.services.dawarich-init-credentials.serviceConfig.PrivateUsers = lib.mkForce false;
+
+  # Memory limits
+  systemd.services.dawarich-web.serviceConfig.MemoryMax = "512M";
+  systemd.services.dawarich-sidekiq-all.serviceConfig.MemoryMax = "512M";
+}

--- a/rpi5/monitoring.nix
+++ b/rpi5/monitoring.nix
@@ -87,6 +87,8 @@ $FAILED"
 - openclaw (18789/health)"
         $CURL -sf --max-time 10 http://127.0.0.1:${toString beszelHubPort}/api/health > /dev/null 2>&1 || FAILURES="$FAILURES
 - beszel (${toString beszelHubPort}/api/health)"
+        $CURL -sf --max-time 10 http://127.0.0.1:13900/api/v1/health > /dev/null 2>&1 || FAILURES="$FAILURES
+- dawarich (13900/api/v1/health)"
         if [ -n "$FAILURES" ]; then
           ${telegramNotify} "<b>HTTP health check failed on rpi5</b>
 $FAILURES"

--- a/rpi5/services-registry.nix
+++ b/rpi5/services-registry.nix
@@ -43,6 +43,7 @@
           { field = "transactions"; label = "Transactions"; format = "number"; }
         ];
       }; }
+    { port = 3900;  backend = "http://127.0.0.1:13900"; name = "Dawarich";       icon = "dawarich.svg";       category = "Apps"; description = "Location history"; }
     { port = 8181;  backend = "http://127.0.0.1:8181";  name = "Open WebUI";     icon = "open-webui.svg";     category = "Apps"; description = "LLM chat interface";
       widget = {
         type = "customapi";


### PR DESCRIPTION
## Summary
- Deploy [Dawarich](https://dawarich.app) (self-hosted Google Timeline alternative) as a native NixOS service on rpi5
- Web UI on Tailscale port 3900 (internal 13900), reuses existing PostgreSQL cluster with auto-added PostGIS extension, dedicated Redis via Unix socket
- Added to homepage dashboard, HTTP health checks, and daily pg_dump backups

## Implementation notes
- Uses the native `services.dawarich` NixOS module (v1.6.1 in nixpkgs) — no Docker
- `PrivateUsers = mkForce false` on all 4 units (same RPi5 user-namespace fix as firefly-iii)
- Sidekiq threads reduced to 3, MemoryMax 512M per unit for RPi5 memory constraints
- `SECRET_KEY_BASE` auto-generated at `/var/lib/dawarich/secrets/secret-key-base` — no agenix secret needed
- nginx disabled (`configureNginx = false`) — Tailscale Serve handles HTTPS

## Test plan
- [ ] `sudo nixos-rebuild switch --flake /home/nsimon/nic-os#rpi5 --max-jobs 1 -j 1` succeeds
- [ ] `systemctl status dawarich-web dawarich-sidekiq-all redis-dawarich` — all active
- [ ] `curl http://127.0.0.1:13900/api/v1/health` returns `{"status":"ok"}`
- [ ] Web UI accessible at `https://rpi5.gate-mintaka.ts.net:3900`
- [ ] Homepage tile appears under the Apps category at `https://rpi5.gate-mintaka.ts.net:8082`
- [ ] Default login works (`demo@dawarich.app` / `password`) — change credentials immediately
- [ ] Register a tracking app (OwnTracks/Overland) with the API key and verify points are ingested

🤖 Generated with [Claude Code](https://claude.com/claude-code)