### PR TITLE
fix: bump vaultwarden to 1.35.7 for bw CLI 2026.x compat

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -736,11 +736,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1775888245,
-        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
+        "lastModified": 1776329215,
+        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "13043924aaa7375ce482ebe2494338e058282925",
+        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
         "type": "github"
       },
       "original": {

--- a/rpi5/overlays.nix
+++ b/rpi5/overlays.nix
@@ -12,6 +12,9 @@
         };
         uv = unstablePkgs.uv;
         tailscale = unstablePkgs.tailscale;
+        # Vaultwarden 1.35.5+ adds AccountKeys to API key login response,
+        # required for Bitwarden CLI 2026.x compatibility (vaultwarden#6912).
+        vaultwarden = unstablePkgs.vaultwarden;
         # nixpkgs 25.11 ships HA 2025.11.x; HA refuses to start if .HA_VERSION
         # in the data dir is newer than the binary (no downgrade allowed).
         # Track unstable so the package version always meets or exceeds what was


### PR DESCRIPTION
## Summary
- Pulls vaultwarden from nixpkgs-unstable (1.35.7) instead of release-25.11 (1.35.4)
- Vaultwarden 1.35.5+ adds `AccountKeys` to the API key login response, required for Bitwarden CLI 2026.x (dani-garcia/vaultwarden#6912)
- Fixes the Raycast Bitwarden extension infinite "clearing session and retrying" loop caused by crypto incompatibility between bundled bw 2026.2.0 and Vaultwarden 1.35.4

## Test plan
- [ ] Deploy to rpi5 and verify Vaultwarden starts
- [ ] Verify Raycast Bitwarden extension can unlock vault
- [ ] Verify `bw` CLI can still unlock from terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)