### PR TITLE
feat: add dawarich (self-hosted location history)

### DIFF
--- a/rpi5/backups.nix
+++ b/rpi5/backups.nix
@@ -6,7 +6,7 @@
   services.postgresqlBackup = {
     enable = true;
     location = "/mnt/data/backups/postgresql";
-    databases = [ "affine" "sure_production" ];
+    databases = [ "affine" "dawarich" "sure_production" ];
     compression = "gzip";
     startAt = "*-*-* 03:00:00";
   };

--- a/rpi5/configuration.nix
+++ b/rpi5/configuration.nix
@@ -120,6 +120,7 @@ in
     ./sumeria-mitm.nix
     ./vaultwarden.nix
     ./forgejo.nix
+    ./dawarich.nix
     ./affine.nix
     ./affine-mcp-gateway.nix
     ./litellm.nix

--- a/rpi5/dawarich.nix
+++ b/rpi5/dawarich.nix
@@ -1,0 +1,40 @@
+# dawarich.nix — self-hosted location history (Google Timeline alternative)
+# Uses the native NixOS module (services.dawarich) — Rails + Sidekiq + PostGIS + Redis
+{ config, pkgs, lib, tailnetFqdn, ... }:
+let
+  internalPort = 13900;
+in
+{
+  services.dawarich = {
+    enable = true;
+    localDomain = tailnetFqdn;
+    webPort = internalPort;
+    configureNginx = false; # Tailscale Serve handles HTTPS
+
+    # Reuses existing PostgreSQL cluster; auto-adds "dawarich" DB + PostGIS extension
+    database.createLocally = true;
+
+    # Dedicated Redis instance via Unix socket (no port conflict with shared redis)
+    redis.createLocally = true;
+
+    # Auto-generate SECRET_KEY_BASE (stored at /var/lib/dawarich/secrets/secret-key-base)
+    secretKeyBaseFile = null;
+
+    # Reduce Sidekiq threads for RPi5 memory constraints
+    sidekiqThreads = 3;
+
+    environment = {
+      TIME_ZONE = "Europe/Paris";
+    };
+  };
+
+  # RPi5: PrivateUsers requires user namespaces, not supported on this kernel
+  systemd.services.dawarich-web.serviceConfig.PrivateUsers = lib.mkForce false;
+  systemd.services.dawarich-sidekiq-all.serviceConfig.PrivateUsers = lib.mkForce false;
+  systemd.services.dawarich-init-db.serviceConfig.PrivateUsers = lib.mkForce false;
+  systemd.services.dawarich-init-credentials.serviceConfig.PrivateUsers = lib.mkForce false;
+
+  # Memory limits
+  systemd.services.dawarich-web.serviceConfig.MemoryMax = "512M";
+  systemd.services.dawarich-sidekiq-all.serviceConfig.MemoryMax = "512M";
+}

--- a/rpi5/monitoring.nix
+++ b/rpi5/monitoring.nix
@@ -87,6 +87,8 @@ $FAILED"
 - openclaw (18789/health)"
         $CURL -sf --max-time 10 http://127.0.0.1:${toString beszelHubPort}/api/health > /dev/null 2>&1 || FAILURES="$FAILURES
 - beszel (${toString beszelHubPort}/api/health)"
+        $CURL -sf --max-time 10 http://127.0.0.1:13900/api/v1/health > /dev/null 2>&1 || FAILURES="$FAILURES
+- dawarich (13900/api/v1/health)"
         if [ -n "$FAILURES" ]; then
           ${telegramNotify} "<b>HTTP health check failed on rpi5</b>
 $FAILURES"

--- a/rpi5/services-registry.nix
+++ b/rpi5/services-registry.nix
@@ -17,6 +17,7 @@
     { port = 8123;  backend = "http://127.0.0.1:8123";  name = "Home Assistant"; icon = "home-assistant.svg"; category = "Services"; description = "Home automation"; }
     { port = 8085;  backend = "http://127.0.0.1:8085";  name = "Filebrowser";    icon = "filebrowser.svg";    category = "Services"; description = "File management"; }
     { port = 3100;  backend = "http://127.0.0.1:3100";  name = "Forgejo";        icon = "forgejo.svg";        category = "Services"; description = "Git hosting"; }
+    { port = 3900;  backend = "http://127.0.0.1:13900"; name = "Dawarich";       icon = "dawarich.svg";       category = "Services"; description = "Location history"; }
 
     # Apps: AFFiNE → Immich (in funnelEntries) → Sure → Open WebUI
     { port = 3010;  backend = "http://127.0.0.1:13010"; name = "AFFiNE";         icon = "affine.svg";         category = "Apps"; description = "Collaborative docs";
@@ -43,7 +44,6 @@
           { field = "transactions"; label = "Transactions"; format = "number"; }
         ];
       }; }
-    { port = 3900;  backend = "http://127.0.0.1:13900"; name = "Dawarich";       icon = "dawarich.svg";       category = "Apps"; description = "Location history"; }
     { port = 8181;  backend = "http://127.0.0.1:8181";  name = "Open WebUI";     icon = "open-webui.svg";     category = "Apps"; description = "LLM chat interface";
       widget = {
         type = "customapi";

--- a/rpi5/services-registry.nix
+++ b/rpi5/services-registry.nix
@@ -43,6 +43,7 @@
           { field = "transactions"; label = "Transactions"; format = "number"; }
         ];
       }; }
+    { port = 3900;  backend = "http://127.0.0.1:13900"; name = "Dawarich";       icon = "dawarich.svg";       category = "Apps"; description = "Location history"; }
     { port = 8181;  backend = "http://127.0.0.1:8181";  name = "Open WebUI";     icon = "open-webui.svg";     category = "Apps"; description = "LLM chat interface";
       widget = {
         type = "customapi";


### PR DESCRIPTION
## Summary
- Add `rpi5/dawarich.nix` using the native NixOS `services.dawarich` module (Rails + Sidekiq + PostGIS + Redis)
- Internal port `13900`, exposed via Tailscale Serve at `:3900` (Services category)
- RPi5 fixes: `PrivateUsers` mkForce false on web/sidekiq/init services, 512M memory limits
- Sidekiq throttled to 3 threads for RPi5
- Dawarich DB added to `postgresqlBackup` (daily 03:00 → restic)
- Health check (`/api/v1/health`) added to monitoring with Telegram alerting
- Homepage tile in Services category (no widget — Dawarich isn't a built-in homepage widget; would need API key + customapi)

## Test plan
- [x] `nixos-rebuild build` succeeds
- [x] `nixos-rebuild switch` activates cleanly
- [x] `dawarich-web`, `dawarich-sidekiq-all`, `redis-dawarich` all `active (running)`
- [x] `curl http://127.0.0.1:13900/` returns 200
- [x] `curl http://127.0.0.1:13900/api/v1/health` returns `{"status":"ok"}`
- [x] Tailscale Serve entry visible at `https://rpi5.gate-mintaka.ts.net:3900`
- [x] Homepage tile shows Dawarich in Services category
- [ ] Change default credentials (`demo@dawarich.app` / `password`) on first login