### PR TITLE
fix(postgres): bump max_connections 30 → 60

### DIFF
--- a/rpi5/databases.nix
+++ b/rpi5/databases.nix
@@ -21,7 +21,7 @@ in
       effective_cache_size = "512MB";
       work_mem             = "2MB";
       maintenance_work_mem = "32MB";
-      max_connections      = 30;   # only ~20 in use across all services
+      max_connections      = 60;   # Immich alone holds ~19 idle (per-worker Prisma pools); 30 was saturating the pool
     };
   };
 


### PR DESCRIPTION
## Summary
- Sure was throwing `ActiveRecord::DatabaseConnectionError` with *\"remaining connection slots are reserved for roles with the SUPERUSER attribute\"* → generic Rails 500 page in the browser.
- Root cause: `max_connections = 30`, only `30 - 3 (superuser_reserved) = 27` slots for non-superuser apps. Immich alone holds ~19 idle (per-worker Prisma pools), affine 4, forgejo 2, sure 1, dawarich 1 → saturated.
- The old comment *\"only ~20 in use across all services\"* under-counted Immich's real pool footprint.

Each extra PG backend costs ~5–10 MB RSS; 60 connections adds ~150–300 MB worst-case overhead, which is acceptable on the 4 GB RPi given typical non-peak usage.

## Test plan
- [x] `nixos-rebuild switch` on rpi5 succeeded; postgres restarted cleanly
- [x] `SHOW max_connections;` returns `60`
- [x] `sure-web` / `sure-worker` back to `active (running)`
- [ ] Monitor `sure-web` logs for a few minutes — no more `DatabaseConnectionError`