### PR TITLE
perf(dawarich): reduce RAM usage (~200→~100 MB)

### DIFF
--- a/rpi5/dawarich.nix
+++ b/rpi5/dawarich.nix
@@ -21,10 +21,16 @@ in
     secretKeyBaseFile = null;
 
     # Reduce Sidekiq threads for RPi5 memory constraints
-    sidekiqThreads = 3;
+    sidekiqThreads = 1;
 
     environment = {
       TIME_ZONE = "Europe/Paris";
+      # Single-process Puma (no forked workers) — saves ~50 MB on RPi5
+      WEB_CONCURRENCY = "0";
+      # Match reduced thread count for web process
+      RAILS_MAX_THREADS = "2";
+      # Limit jemalloc memory arenas
+      MALLOC_ARENA_MAX = "2";
     };
   };
 
@@ -34,7 +40,7 @@ in
   systemd.services.dawarich-init-db.serviceConfig.PrivateUsers = lib.mkForce false;
   systemd.services.dawarich-init-credentials.serviceConfig.PrivateUsers = lib.mkForce false;
 
-  # Memory limits
-  systemd.services.dawarich-web.serviceConfig.MemoryMax = "512M";
-  systemd.services.dawarich-sidekiq-all.serviceConfig.MemoryMax = "512M";
+  # Memory limits — tightened for single-process mode
+  systemd.services.dawarich-web.serviceConfig.MemoryMax = "256M";
+  systemd.services.dawarich-sidekiq-all.serviceConfig.MemoryMax = "256M";
 }


### PR DESCRIPTION
## Summary
- Sidekiq threads 3→1, Puma single-process mode (WEB_CONCURRENCY=0), web threads 5→2
- Add MALLOC_ARENA_MAX=2 to curb jemalloc fragmentation
- Tighten MemoryMax 512M→256M per service
- Expected savings: ~80-110 MB on RPi5 (4 GB)

## Test plan
- [ ] `nixos-rebuild switch` succeeds
- [ ] Dawarich web UI loads
- [ ] Sidekiq processes jobs (check import/geocoding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)