### PR TITLE
feat(tiny-llm-gate): parallel deploy on :4002 alongside LiteLLM

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -318,6 +318,24 @@
         "type": "github"
       }
     },
+    "flake-utils_4": {
+      "inputs": {
+        "systems": "systems_7"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "for-sure": {
       "inputs": {
         "nixpkgs": [
@@ -819,6 +837,7 @@
         "picoclaw-src": "picoclaw-src",
         "ragenix": "ragenix",
         "sure-nix": "sure-nix",
+        "tiny-llm-gate": "tiny-llm-gate",
         "zen-browser": "zen-browser"
       }
     },
@@ -951,6 +970,43 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_7": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "tiny-llm-gate": {
+      "inputs": {
+        "flake-utils": "flake-utils_4",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776762667,
+        "narHash": "sha256-Br3FT4VGd7n1y20LsBRkLY0s/AKeSfyUlhXh9LDebjE=",
+        "owner": "nSimonFR",
+        "repo": "tiny-llm-gate",
+        "rev": "1ec2aaee5aad216f3d024426fe36a9d6d53ef756",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nSimonFR",
+        "ref": "v0.1.1",
+        "repo": "tiny-llm-gate",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,13 @@
       url = "github:AlexsJones/llmfit";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    # tiny-llm-gate: memory-conscious replacement for LiteLLM.
+    # Pinned to a tag; bump the ref to roll forward.
+    tiny-llm-gate = {
+      url = "github:nSimonFR/tiny-llm-gate/v0.1.1";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   nixConfig = {

--- a/rpi5/configuration.nix
+++ b/rpi5/configuration.nix
@@ -123,6 +123,7 @@ in
     ./affine.nix
     ./affine-mcp-gateway.nix
     ./litellm.nix
+    ./tiny-llm-gate.nix
     ./claude-remote-control.nix
     ./open-webui.nix
     ./homepage.nix

--- a/rpi5/tiny-llm-gate.nix
+++ b/rpi5/tiny-llm-gate.nix
@@ -1,0 +1,109 @@
+# tiny-llm-gate — memory-conscious replacement for LiteLLM.
+#
+# Phase: parallel deploy. Runs on port 4002 alongside LiteLLM on 4001 so the
+# two can be diff-tested against real client traffic. No client is rewired
+# yet — everything still hits LiteLLM. Once we've verified parity, a follow-up
+# PR will swap clients to :4002 and remove litellm.nix.
+{ pkgs, lib, inputs, beastOllamaUrl, ... }:
+let
+  port = 4002;
+  beastApi = "${beastOllamaUrl}/v1";
+  codexApi = "http://127.0.0.1:4040/v1";
+in
+{
+  imports = [ inputs.tiny-llm-gate.nixosModules.default ];
+
+  services.tiny-llm-gate = {
+    enable = true;
+    package = inputs.tiny-llm-gate.packages.${pkgs.stdenv.hostPlatform.system}.default;
+
+    # Parallel-deploy ceilings. Production settings once we cut over.
+    memoryMax = "40M";
+    goMemLimit = "25MiB";
+
+    settings = {
+      listen = "127.0.0.1:${toString port}";
+
+      providers = {
+        ollama = {
+          type = "openai";
+          base_url = beastApi;
+          api_key = "ollama";
+        };
+        codex = {
+          type = "openai";
+          base_url = codexApi;
+          api_key = "unused";
+        };
+      };
+
+      models = {
+        # -- Ollama chat models --
+        "gemma4:e4b"        = { provider = "ollama"; upstream_model = "gemma4:e4b"; };
+        "gemma4:26b"        = { provider = "ollama"; upstream_model = "gemma4:26b"; };
+        "qwen3.5:35b-a3b"   = { provider = "ollama"; upstream_model = "qwen3.5:35b-a3b"; };
+        "qwen3-embedding:8b" = { provider = "ollama"; upstream_model = "qwen3-embedding:8b"; };
+
+        # -- Codex-proxy models (OpenAI subscription via OAuth) --
+        # Fallbacks only on gpt-5.4 / gpt-5.4-mini to match LiteLLM's behaviour.
+        "gpt-5.4" = {
+          provider = "codex";
+          upstream_model = "gpt-5.4";
+          fallback = [ "gemma4:e4b" ];
+        };
+        "gpt-5.4-mini" = {
+          provider = "codex";
+          upstream_model = "gpt-5.4-mini";
+          fallback = [ "gemma4:e4b" ];
+        };
+        "gpt-5.2"             = { provider = "codex"; upstream_model = "gpt-5.2"; };
+        "gpt-5.3-codex"       = { provider = "codex"; upstream_model = "gpt-5.3-codex"; };
+        "codex-auto-review"   = { provider = "codex"; upstream_model = "codex-auto-review"; };
+      };
+
+      # All client-facing aliases. Note: LiteLLM splits these across
+      # `model_list` (name → real model) and `router_settings.model_group_alias`;
+      # tiny-llm-gate collapses them into one flat table.
+      aliases = {
+        # PicoClaw strips "openai/" prefix, but some older configs may still
+        # carry it — handle both.
+        "openai/gemma4:e4b"        = "gemma4:e4b";
+        "openai/gemma4:26b"        = "gemma4:26b";
+        "openai/qwen3.5:35b-a3b"   = "qwen3.5:35b-a3b";
+        "openai/qwen3-embedding:8b" = "qwen3-embedding:8b";
+        "openai/gpt-5.4"           = "gpt-5.4";
+        "openai/gpt-5.4-mini"      = "gpt-5.4-mini";
+        "openai/gpt-5.2"           = "gpt-5.2";
+        "openai/gpt-5.3-codex"     = "gpt-5.3-codex";
+        "openai/codex-auto-review" = "codex-auto-review";
+
+        # AFFiNE hardcodes OpenAI GPT model names for its OpenAI provider.
+        "gpt-4.1-2025-04-14" = "gemma4:e4b";
+        "gpt-4.1-mini"       = "gemma4:e4b";
+        "gpt-4o"             = "gemma4:e4b";
+        "gpt-4o-mini"        = "gemma4:e4b";
+
+        # AFFiNE hardcodes OpenAI embedding model names.
+        "text-embedding-3-small" = "qwen3-embedding:8b";
+        "text-embedding-3-large" = "qwen3-embedding:8b";
+
+        # AFFiNE Gemini provider model names. Phase 4 will move these under a
+        # dedicated Gemini frontend; for now they're routed through the OpenAI
+        # frontend (clients that send Gemini-native /v1beta/… payloads still
+        # go through LiteLLM on :4001).
+        "gemini-2.5-flash"     = "gemma4:e4b";
+        "gemini-2.5-pro"       = "gemma4:e4b";
+        "gemini-2.0-flash"     = "gemma4:e4b";
+        "gemini-2.0-flash-001" = "gemma4:e4b";
+        "gemini-embedding-001" = "qwen3-embedding:8b";
+        "text-embedding-004"   = "qwen3-embedding:8b";
+      };
+    };
+  };
+
+  # Ordering: depends on codex-proxy for its upstream, same as LiteLLM.
+  systemd.services.tiny-llm-gate = {
+    after = [ "network.target" "openai-codex-proxy.service" ];
+    wants = [ "openai-codex-proxy.service" ];
+  };
+}


### PR DESCRIPTION
## Summary
- Adds [tiny-llm-gate](https://github.com/nSimonFR/tiny-llm-gate) v0.1.1 as a Go-based, memory-conscious replacement for LiteLLM
- Parallel deploy only — no client rewired yet. Runs on :4002 alongside LiteLLM on :4001 so both can be exercised with real traffic for diff-testing
- Config mirrors `litellm.nix` 1:1 (same models, same aliases, same fallback chain `gpt-5.4 → gemma4:e4b`)
- Target: replace LiteLLM (~65 MB) + openai-codex-proxy (~63 MB) + affine-embed-proxy (~14 MB) with this single Go binary (~7 MB) once all phases land

## Sizing
- Binary: 6.5 MiB stripped
- RSS idle: 6.9 MiB, streaming: 8.4 MiB (measured on this RPi5)
- `MemoryMax = 40M`, `GOMEMLIMIT = 25MiB`

## Test plan
- [ ] `nixos-rebuild switch` succeeds (verified `build` locally)
- [ ] `curl http://127.0.0.1:4002/health` returns ok
- [ ] `curl http://127.0.0.1:4002/v1/models` lists every model/alias
- [ ] Non-streaming chat through :4002 to codex-proxy works
- [ ] Streaming chat through :4002 produces SSE chunks
- [ ] RSS stays under 20 MiB under normal traffic

Phase 2+ (follow-up PRs) will validate streaming with OpenWebUI and PicoClaw pointing at :4002; Phase 3 will absorb codex-proxy; Phase 4 absorbs affine-embed-proxy; Phase 5 is the cutover that removes LiteLLM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)