### PR TITLE
refactor(redis): consolidate immich & dawarich onto shared Redis

### DIFF
--- a/rpi5/dawarich.nix
+++ b/rpi5/dawarich.nix
@@ -1,6 +1,6 @@
 # dawarich.nix — self-hosted location history (Google Timeline alternative)
 # Uses the native NixOS module (services.dawarich) — Rails + Sidekiq + PostGIS + Redis
-{ config, pkgs, lib, tailnetFqdn, ... }:
+{ config, pkgs, lib, tailnetFqdn, redisHost, redisPort, ... }:
 let
   internalPort = 13900;
 in
@@ -14,8 +14,13 @@ in
     # Reuses existing PostgreSQL cluster; auto-adds "dawarich" DB + PostGIS extension
     database.createLocally = true;
 
-    # Dedicated Redis instance via Unix socket (no port conflict with shared redis)
-    redis.createLocally = true;
+    # Use the shared Redis (databases.nix) on DB 3 via TCP instead of a
+    # dedicated redis-dawarich instance. Saves ~7 MB RAM + one systemd unit.
+    redis = {
+      createLocally = false;
+      host          = redisHost;
+      port          = redisPort;
+    };
 
     # Auto-generate SECRET_KEY_BASE (stored at /var/lib/dawarich/secrets/secret-key-base)
     secretKeyBaseFile = null;
@@ -31,6 +36,9 @@ in
       RAILS_MAX_THREADS = "2";
       # Limit jemalloc memory arenas
       MALLOC_ARENA_MAX = "2";
+      # Override upstream's REDIS_URL (which has no DB index) to isolate
+      # Dawarich's keyspace on DB 3 of the shared Redis.
+      REDIS_URL = "redis://${redisHost}:${toString redisPort}/3";
     };
   };
 

--- a/rpi5/immich.nix
+++ b/rpi5/immich.nix
@@ -1,4 +1,4 @@
-{ pkgs, unstablePkgs, ... }:
+{ pkgs, unstablePkgs, redisHost, redisPort, ... }:
 {
   services.immich = {
     enable        = true;
@@ -7,6 +7,15 @@
     host          = "127.0.0.1";
     mediaLocation = "/mnt/data/immich";
     machine-learning.enable = true;
+
+    # Use the shared Redis (databases.nix) on DB 1 via TCP instead of a
+    # dedicated redis-immich instance. Saves ~7 MB RAM + one systemd unit.
+    redis = {
+      enable = false;
+      host   = redisHost;
+      port   = redisPort;
+    };
+    environment.REDIS_DBINDEX = "1";
   };
 
   # Ensure Immich starts after HDD is mounted.


### PR DESCRIPTION
## Summary

- Point Immich and Dawarich at the existing shared Redis (`127.0.0.1:6379`) on dedicated DBs instead of spinning up their own instances.
- Removes the `redis-immich` and `redis-dawarich` systemd units, freeing ~15 MB RAM on the RPi5.
- DB allocation: 0=Affine · 1=Immich · 2=Sure · 3=Dawarich.

## Changes

- **`rpi5/immich.nix`**: `services.immich.redis.enable = false`, point `host`/`port` at shared Redis, inject `REDIS_DBINDEX=1` via `environment`.
- **`rpi5/dawarich.nix`**: `services.dawarich.redis.createLocally = false`, point `host`/`port` at shared Redis, override `REDIS_URL` via `environment` to include the `/3` DB index (upstream's `redisEnv` builds a URL without a DB index; `cfg.environment` is merged last and wins).
- Both use TCP — mirrors how Sure already connects to the shared Redis. Avoids the unix-socket `SupplementaryGroups` plumbing.

No changes to `rpi5/databases.nix` (shared Redis already listens on TCP).

## Verification

- `nixos-rebuild build --flake .#rpi5` — evaluates & builds cleanly (exit 0, only pre-existing eval warnings).
- `nix eval .#nixosConfigurations.rpi5.config.services.redis.servers` → only `shared` remains.
- Built `/etc/systemd/system` contains `redis-shared.service` only (no `redis-immich` / `redis-dawarich`).
- Resolved env confirms: Immich gets `REDIS_HOSTNAME=127.0.0.1`, `REDIS_PORT=6379`, `REDIS_DBINDEX=1`; Dawarich gets `REDIS_URL=redis://127.0.0.1:6379/3`.

NOT yet activated (`nixos-rebuild build`, not `switch`).

## Test plan

- [ ] `sudo nixos-rebuild switch --flake /home/nsimon/nic-os#rpi5 --max-jobs 1 -j 1` (commit merged to main first)
- [ ] `systemctl status redis-shared redis-immich redis-dawarich` — confirm only `redis-shared` exists, others gone
- [ ] `journalctl -u immich-server -u dawarich-web -n 100` — no Redis connect errors
- [ ] `redis-cli -n 1 DBSIZE` and `redis-cli -n 3 DBSIZE` — should populate as services work
- [ ] Hit Immich web UI (photo upload/thumbnail) and Dawarich (import points → triggers Sidekiq) to exercise both DBs
- [ ] `free -h` — expect ~15 MB less used

## Risks & rollback

- In-flight Sidekiq jobs and cached data in the dedicated redis-{immich,dawarich} instances are dropped on cutover (Sidekiq queues start empty on DB 1/3; Rails caches rebuild). Personal-use, no SLA — fine.
- Dawarich's Ruby Redis client needs to honor the `/3` suffix on `REDIS_URL`. `redis-rb` / Sidekiq do.
- Rollback: `git revert` this commit → `nixos-rebuild switch` recreates dedicated instances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)