### PR TITLE
fix(tiny-llm-gate): bump to v0.3.1 for chatgpt-account-id header

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -996,16 +996,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1776764336,
-        "narHash": "sha256-Y0TYycE80xD6sc7UEj2Vfyy24bSB2gI4rnHPXpn9FLc=",
+        "lastModified": 1776765945,
+        "narHash": "sha256-3mpfcHBZU+uTXaB3b3VLLdixRKK5X3Id3G2w5SACQyQ=",
         "owner": "nSimonFR",
         "repo": "tiny-llm-gate",
-        "rev": "5f4dd9c3b301582d602d7c69abeb0af39c455c16",
+        "rev": "ca0aa812ba990b1d2e8969d6ca0bed1876542f6b",
         "type": "github"
       },
       "original": {
         "owner": "nSimonFR",
-        "ref": "v0.3.0",
+        "ref": "v0.3.1",
         "repo": "tiny-llm-gate",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -73,7 +73,7 @@
     # tiny-llm-gate: memory-conscious replacement for LiteLLM.
     # Pinned to a tag; bump the ref to roll forward.
     tiny-llm-gate = {
-      url = "github:nSimonFR/tiny-llm-gate/v0.3.0";
+      url = "github:nSimonFR/tiny-llm-gate/v0.3.1";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };


### PR DESCRIPTION
Upstream fix: the direct-to-Codex OAuth path needs `chatgpt-account-id` header, not just Bearer token. See nSimonFR/tiny-llm-gate#v0.3.1.