### PR TITLE
feat(dawarich): enable Geoapify reverse geocoding

### DIFF
--- a/rpi5/dawarich.nix
+++ b/rpi5/dawarich.nix
@@ -51,4 +51,12 @@ in
   # Memory limits — tightened for single-process mode
   systemd.services.dawarich-web.serviceConfig.MemoryMax = "256M";
   systemd.services.dawarich-sidekiq-all.serviceConfig.MemoryMax = "256M";
+
+  # Geoapify reverse geocoding — drives visit suggestions (nightly sidekiq job)
+  # and on-demand address lookups in the web UI.
+  # Key is injected via EnvironmentFile to keep it out of the nix store.
+  systemd.services.dawarich-web.serviceConfig.EnvironmentFile =
+    "/run/agenix/dawarich-geoapify";
+  systemd.services.dawarich-sidekiq-all.serviceConfig.EnvironmentFile =
+    "/run/agenix/dawarich-geoapify";
 }

--- a/rpi5/secrets.nix
+++ b/rpi5/secrets.nix
@@ -63,5 +63,10 @@
       file = ./secrets/tavily-api-key.age;
       mode = "0444"; # DynamicUser (open-webui) needs to read it
     };
+    dawarich-geoapify = {
+      file  = ./secrets/dawarich-geoapify.age;
+      owner = "dawarich";
+      mode  = "0440";
+    };
 };
 }

--- a/rpi5/secrets/dawarich-geoapify.age
+++ b/rpi5/secrets/dawarich-geoapify.age
@@ -1,0 +1,7 @@
+age-encryption.org/v1
+-> X25519 x/xL1+GwuC/nwK6taep/onBwJ1x6QuP3xIvu0kDIIjA
+MzfVFj+dL0zPBUMe46lNKqIEi+EoeaR4cPQu4Xc2Akw
+-> ssh-ed25519 TRz3uQ F5L1+1SmZQT1d3s/gIqlah3VFjif8k6o/9ZXgvrfNH0
+EdFZfjvptvub62JCQWz0BsngdFeGB8s46U5zu+EBtK8
+--- B/jc0joFAGwOedNLimRm0Fi6Qe0KAA45MRxMsIBjRdk
+WЯ)ф@-(П√	щС│;╢OC1:.└GЫ╛щ╙ЛNj&│IАC]<]лtФq√ZюKg.я1RШSde'Г$R.ЁуJp≈Сz+Ц┬ме╫ыb

--- a/rpi5/secrets/secrets.nix
+++ b/rpi5/secrets/secrets.nix
@@ -16,4 +16,5 @@ in {
   "affine-gcal-oauth.age".publicKeys       = [ nsimon-age nsimon-ed25519 ];
   "tavily-api-key.age".publicKeys          = [ nsimon-age nsimon-ed25519 ];
   "for-sure-api-key.age".publicKeys        = [ nsimon-age nsimon-ed25519 ];
+  "dawarich-geoapify.age".publicKeys       = [ nsimon-age nsimon-ed25519 ];
 }


### PR DESCRIPTION
## Summary
- Enables Dawarich's visit-suggestion feature (cafes, parks, restaurants, etc.) by wiring a Geoapify API key into \`dawarich-web\` and \`dawarich-sidekiq-all\` via \`EnvironmentFile\`.
- Key stored as agenix secret (\`/run/agenix/dawarich-geoapify\`, owner \`dawarich\`, mode \`0440\`) — kept out of the nix store.
- Chose Geoapify over self-hosted Photon/Nominatim: those would need ~90 GB disk + multi-GB RAM (incompatible with RPi5). Free tier gives 3k req/day, which Sidekiq throttles automatically.

## Rationale
Dawarich's nightly \`ReverseGeocodingJob\` turns GPS visits into suggested named places using OSM POI data. Without a geocoder configured, all stops show as generic \"Suggested Place\". Geoapify returns richer POI categories than public Photon (which is search-optimized, not reverse-geo-optimized).

## Files
- \`rpi5/secrets/dawarich-geoapify.age\` — new agenix secret
- \`rpi5/secrets/secrets.nix\` — recipient list entry
- \`rpi5/secrets.nix\` — agenix registration
- \`rpi5/dawarich.nix\` — \`EnvironmentFile\` on both web + sidekiq services

## Test plan
- [ ] \`sudo nixos-rebuild switch --flake .#rpi5 --max-jobs 1 -j 1\` succeeds
- [ ] \`sudo ls -l /run/agenix/dawarich-geoapify\` → owner \`dawarich\`, mode \`0440\`
- [ ] \`sudo cat /proc/\$(pgrep -f 'sidekiq.*dawarich' | head -1)/environ | tr '\0' '\n' | grep GEOAPIFY\` → key present
- [ ] \`journalctl -u dawarich-sidekiq-all -f\` → reverse-geocode jobs run without 401/403
- [ ] Geoapify dashboard shows incoming API calls
- [ ] After a visit is recorded, check Dawarich UI for a suggested place on the map drawer

## Post-merge (manual)
- Trigger full-history backfill from Dawarich UI → Settings → re-run reverse geocoding (throttled by Sidekiq to respect 3k/day free tier).
- Consider linking Immich in Dawarich UI → Settings → Integrations for photos-on-map (no flake change needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)