### PR TITLE
feat(home-assistant): enable telegram_bot integration

### DIFF
--- a/rpi5/home-assistant.nix
+++ b/rpi5/home-assistant.nix
@@ -76,6 +76,10 @@ in
       "sfr_box"      # sfrbox_api
       "mobile_app"
       "google_translate" # gtts
+      # Installs python-telegram-bot so the telegram_bot config-flow handler
+      # loads in the UI. Configuration itself is done via Settings → Devices &
+      # Services (YAML setup was removed in HA 2025.7).
+      "telegram_bot"
     ];
   };
 


### PR DESCRIPTION
## Summary
Adds `telegram_bot` to `extraComponents` so `python-telegram-bot` is installed in the HA Python env and the UI config-flow handler loads.

Since HA 2025.7, `telegram_bot` is UI-config-only (YAML setup was removed). Actual configuration (bot token + allowed chat IDs) is done manually once via **Settings → Devices & Services → Add Integration → Telegram bot** (polling mode), and persisted in HA's `.storage/core.config_entries`. This change only provides the runtime deps so the UI flow works.

Without this, the UI throws: `Config flow could not be loaded: Invalid handler specified`.

## Test plan
- [x] `nixos-rebuild switch` clean
- [x] HA restart clean, no new errors
- [ ] UI: Settings → Devices & Services → Add Integration → Telegram bot loads without "Invalid handler"
- [ ] Create bot config entry with polling + token (from `/run/agenix/telegram-bot-token`) + chat_id 82389391
- [ ] Verify `notify.telegram_bot_*` entity is created
- [ ] Update existing SDB automations to fire `telegram_bot.send_message` (automations.yaml is runtime state, not part of this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)