### PR TITLE
feat(sure): prefer beast with codex fallback

### DIFF
--- a/rpi5/sure.nix
+++ b/rpi5/sure.nix
@@ -9,7 +9,10 @@ let
   # overwriting the route when the admin page is saved.
   sureLlmEnv = {
     OPENAI_URI_BASE     = "http://127.0.0.1:4001/v1/";
-    OPENAI_MODEL        = "gpt-5.4";
+    # "auto" is a tiny-llm-gate virtual model that tries beast (Ollama
+    # gemma4:e4b) first and falls back to codex gpt-5.4 if beast is
+    # unreachable. See rpi5/tiny-llm-gate.nix `models."auto"`.
+    OPENAI_MODEL        = "auto";
     OPENAI_ACCESS_TOKEN = "unused"; # real auth lives in codex-proxy OAuth
   };
 in

--- a/rpi5/tiny-llm-gate.nix
+++ b/rpi5/tiny-llm-gate.nix
@@ -63,6 +63,18 @@ in
         "gpt-5.2"            = { provider = "codex"; upstream_model = "gpt-5.2"; };
         "gpt-5.3-codex"      = { provider = "codex"; upstream_model = "gpt-5.3-codex"; };
         "codex-auto-review"  = { provider = "codex"; upstream_model = "codex-auto-review"; };
+
+        # "auto" — local-first model: try gemma4:e4b on beast, fall back to
+        # codex gpt-5.4 if beast is unreachable (TCP refused / timeout) or
+        # returns 5xx. Used by Sure (via OPENAI_MODEL) to prefer free local
+        # inference when beast is awake while keeping the assistant working
+        # when it's asleep. tiny-llm-gate's fallback chain triggers on both
+        # transport errors and 5xx — see internal/server/openai.go.
+        "auto" = {
+          provider       = "ollama";
+          upstream_model = "gemma4:e4b";
+          fallback       = [ "gpt-5.4" ];
+        };
       };
 
       aliases = {


### PR DESCRIPTION
Add `auto` virtual model (ollama primary, codex fallback) and point Sure's OPENAI_MODEL at it. Sure now uses local gemma4:e4b when beast is awake and automatically falls back to codex when it's not.