### PR TITLE
fix(affine): gemini baseURL must include /v1beta

### DIFF
--- a/rpi5/affine.nix
+++ b/rpi5/affine.nix
@@ -40,7 +40,14 @@ let
       # all route through the same Gemini provider.
       "providers.gemini" = {
         apiKey = "ollama";
-        baseURL = "http://127.0.0.1:4001";
+        # baseURL MUST include /v1beta. AFFiNE's Gemini provider uses the
+        # Vercel `@ai-sdk/google` library which appends `/models/{id}:action`
+        # directly to the configured baseURL. Google's public default is
+        # `https://generativelanguage.googleapis.com/v1beta`, so our override
+        # must end in `/v1beta` too — otherwise AFFiNE hits
+        # http://127.0.0.1:4001/models/... which tiny-llm-gate's router
+        # returns 404 for.
+        baseURL = "http://127.0.0.1:4001/v1beta";
       };
     };
   };

--- a/rpi5/claude-remote-control.nix
+++ b/rpi5/claude-remote-control.nix
@@ -2,6 +2,16 @@
 let
   sessionName = "claude-rc";
   claudeRc = "/home/${username}/.claude/bin/claude-rc";
+  sessionsDir = "/home/${username}/.claude/sessions";
+  projectsDir = "/home/${username}/.claude/projects";
+  worktreesDir = "/home/${username}/nic-os/.claude/worktrees";
+
+  # Seconds of conversation inactivity before a bridge session is reaped.
+  # Uses the conversation JSONL file mtime (updated on every user/assistant
+  # message) — much more accurate than process age since a session can be
+  # idle but resumable. 2 hours means: if nobody has talked to this session
+  # for 2h, it's safe to reclaim.
+  maxInactivitySec = "7200"; # 2h
 
   stopScript = pkgs.writeShellScript "claude-remote-control-stop" ''
     # Send SIGTERM to the claude process inside tmux, giving it time
@@ -31,6 +41,91 @@ let
       echo "tmux session ${sessionName} missing, restarting service"
       systemctl restart claude-remote-control.service
     fi
+  '';
+
+  # Kill stale bridge sessions and clean up orphaned worktrees.
+  # Works around: anthropics/claude-code#29313, #26725
+  #
+  # The bug: deleting a session from claude.ai/code does NOT signal
+  # the remote process to exit. The heartbeat API keeps returning
+  # state=active forever. So we detect staleness via conversation
+  # file inactivity (JSONL mtime) which is updated on every real
+  # user/assistant message — much more reliable than process age.
+  cleanupScript = pkgs.writeShellScript "claude-rc-session-cleanup" ''
+    export PATH="${pkgs.jq}/bin:${pkgs.git}/bin:${pkgs.procps}/bin:${pkgs.findutils}/bin:$PATH"
+    SESSIONS_DIR="${sessionsDir}"
+    PROJECTS_DIR="${projectsDir}"
+    WORKTREES_DIR="${worktreesDir}"
+    MAX_INACTIVITY="${maxInactivitySec}"
+    now="$(date +%s)"
+    killed=0
+
+    for f in "$SESSIONS_DIR"/*.json; do
+      [ -f "$f" ] || continue
+      pid="$(basename "$f" .json)"
+      entrypoint="$(jq -r '.entrypoint // ""' "$f")"
+
+      # Only target bridge sessions (spawned by remote-control for web UI)
+      [ "$entrypoint" = "sdk-cli" ] || continue
+
+      # Skip if process is already dead — just clean up the file
+      [ -d "/proc/$pid" ] || {
+        echo "removing stale session file for dead PID $pid"
+        rm -f "$f"
+        killed=$((killed + 1))
+        continue
+      }
+
+      # Find the conversation JSONL file to check last real activity
+      session_id="$(jq -r '.sessionId // ""' "$f")"
+      [ -z "$session_id" ] && continue
+
+      conv_file="$(find "$PROJECTS_DIR" -name "${session_id}.jsonl" -print -quit 2>/dev/null)"
+      if [ -n "$conv_file" ] && [ -f "$conv_file" ]; then
+        last_mod="$(stat -c %Y "$conv_file")"
+        idle_sec=$(( now - last_mod ))
+      else
+        # No conversation file means it never got a message — use process age
+        idle_sec="$(ps -o etimes= -p "$pid" 2>/dev/null | tr -d ' ')"
+        [ -z "$idle_sec" ] && continue
+      fi
+
+      if [ "$idle_sec" -gt "$MAX_INACTIVITY" ]; then
+        idle_min=$(( idle_sec / 60 ))
+        echo "killing stale bridge session PID=$pid sid=$session_id (inactive ${idle_min}min > $((MAX_INACTIVITY/60))min)"
+        kill "$pid" 2>/dev/null
+        sleep 2
+        kill -9 "$pid" 2>/dev/null || true
+        rm -f "$f"
+        killed=$((killed + 1))
+      fi
+    done
+
+    # Clean up orphaned worktrees (bridge-cse_* dirs whose process is gone)
+    if [ -d "$WORKTREES_DIR" ]; then
+      for wt in "$WORKTREES_DIR"/bridge-cse_*; do
+        [ -d "$wt" ] || continue
+        wt_name="$(basename "$wt")"
+        # Check if any running claude process uses this worktree
+        in_use=0
+        for f in "$SESSIONS_DIR"/*.json; do
+          [ -f "$f" ] || continue
+          pid="$(basename "$f" .json)"
+          [ -d "/proc/$pid" ] || continue
+          cwd="$(jq -r '.cwd // ""' "$f")"
+          case "$cwd" in
+            *"$wt_name"*) in_use=1; break ;;
+          esac
+        done
+        if [ "$in_use" = "0" ]; then
+          echo "removing orphaned worktree: $wt_name"
+          git -C /home/${username}/nic-os worktree remove --force "$wt" 2>/dev/null || rm -rf "$wt"
+        fi
+      done
+      git -C /home/${username}/nic-os worktree prune 2>/dev/null || true
+    fi
+
+    [ "$killed" -gt 0 ] && echo "cleaned up $killed stale session(s)" || echo "no stale sessions found"
   '';
 in
 {
@@ -70,6 +165,30 @@ in
     timerConfig = {
       OnBootSec = "2min";
       OnUnitActiveSec = "5min";
+    };
+  };
+
+  # Periodic cleanup of stale bridge sessions that the web UI failed to terminate.
+  # Workaround for anthropics/claude-code#29313 and #26725.
+  systemd.services.claude-rc-session-cleanup = {
+    description = "Claude RC stale session cleanup";
+    serviceConfig = {
+      Type = "oneshot";
+      User = username;
+      Group = "users";
+      ExecStart = cleanupScript;
+      Environment = [
+        "HOME=/home/${username}"
+      ];
+    };
+  };
+
+  systemd.timers.claude-rc-session-cleanup = {
+    description = "Claude RC stale session cleanup timer";
+    wantedBy = [ "timers.target" ];
+    timerConfig = {
+      OnBootSec = "10min";
+      OnUnitActiveSec = "30min";
     };
   };
 }


### PR DESCRIPTION
AFFiNE's @ai-sdk/google appends /models/{id}:action to baseURL expecting Google's convention. Our baseURL was missing /v1beta, so AFFiNE hit 404 on tiny-llm-gate's router.