### PR TITLE
fix(affine,tiny-llm-gate): /v1beta baseURL + outputDimensionality forwarding

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -996,16 +996,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1776766166,
-        "narHash": "sha256-HNezN4O8jGyd0KlnM/Yc4EWBM+YWhoChLUvLK4BHI0k=",
+        "lastModified": 1776773385,
+        "narHash": "sha256-H42GHwTjFP70i8snrHK2DD7I7IBbm80OXK4mX+aLE4Q=",
         "owner": "nSimonFR",
         "repo": "tiny-llm-gate",
-        "rev": "89bc46cec23a69c0d5eceaa5f0c92b8764ce6a8c",
+        "rev": "bf9884525b28b48cd3feafbfde9acd5cd949bee9",
         "type": "github"
       },
       "original": {
         "owner": "nSimonFR",
-        "ref": "v0.3.2",
+        "ref": "v0.3.3",
         "repo": "tiny-llm-gate",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -73,7 +73,7 @@
     # tiny-llm-gate: memory-conscious replacement for LiteLLM.
     # Pinned to a tag; bump the ref to roll forward.
     tiny-llm-gate = {
-      url = "github:nSimonFR/tiny-llm-gate/v0.3.2";
+      url = "github:nSimonFR/tiny-llm-gate/v0.3.3";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };

--- a/rpi5/affine.nix
+++ b/rpi5/affine.nix
@@ -40,7 +40,14 @@ let
       # all route through the same Gemini provider.
       "providers.gemini" = {
         apiKey = "ollama";
-        baseURL = "http://127.0.0.1:4001";
+        # baseURL MUST include /v1beta. AFFiNE's Gemini provider uses the
+        # Vercel `@ai-sdk/google` library which appends `/models/{id}:action`
+        # directly to the configured baseURL. Google's public default is
+        # `https://generativelanguage.googleapis.com/v1beta`, so our override
+        # must end in `/v1beta` too — otherwise AFFiNE hits
+        # http://127.0.0.1:4001/models/... which tiny-llm-gate's router
+        # returns 404 for.
+        baseURL = "http://127.0.0.1:4001/v1beta";
       };
     };
   };


### PR DESCRIPTION
Two fixes that together unblock AFFiNE document embedding via tiny-llm-gate:

1. **AFFiNE config**: Gemini provider baseURL must end in `/v1beta` — `@ai-sdk/google` appends `/models/{id}:action` directly, expecting Google's URL convention.

2. **tiny-llm-gate v0.3.3**: forwards Gemini `outputDimensionality` as OpenAI `dimensions`, so qwen3-embedding:8b returns the requested 1024-dim vector that AFFiNE's `pgvector(1024)` column accepts.

Supersedes #162.