### PR TITLE
feat(homepage): show all disks in resources widget

### DIFF
--- a/rpi5/homepage.nix
+++ b/rpi5/homepage.nix
@@ -145,7 +145,8 @@ in
         resources = {
           cpu = true;
           memory = true;
-          disk = "/";
+          disk = [ "/" "/home" "/mnt/data" ];
+          expanded = true;
         };
       }
       {


### PR DESCRIPTION
## Summary
- Display `/`, `/home`, and `/mnt/data` in the homepage resources widget (previously only `/`)
- Enable `expanded` mode so each disk is shown individually

## Test plan
- [ ] Rebuild and verify homepage dashboard shows all three disks in the top resources bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)