### PR TITLE
fix(claude-rc): escape shell vars in Nix string interpolation

### DIFF
--- a/rpi5/claude-remote-control.nix
+++ b/rpi5/claude-remote-control.nix
@@ -92,7 +92,7 @@ let
 
       if [ "$idle_sec" -gt "$MAX_INACTIVITY" ]; then
         idle_min=$(( idle_sec / 60 ))
-        echo "killing stale bridge session PID=$pid sid=$session_id (inactive ${idle_min}min > $((MAX_INACTIVITY/60))min)"
+        echo "killing stale bridge session PID=$pid sid=$session_id (inactive ''${idle_min}min > $((MAX_INACTIVITY/60))min)"
         kill "$pid" 2>/dev/null
         sleep 2
         kill -9 "$pid" 2>/dev/null || true

--- a/rpi5/claude-remote-control.nix
+++ b/rpi5/claude-remote-control.nix
@@ -80,7 +80,7 @@ let
       session_id="$(jq -r '.sessionId // ""' "$f")"
       [ -z "$session_id" ] && continue
 
-      conv_file="$(find "$PROJECTS_DIR" -name "${session_id}.jsonl" -print -quit 2>/dev/null)"
+      conv_file="$(find "$PROJECTS_DIR" -name "''${session_id}.jsonl" -print -quit 2>/dev/null)"
       if [ -n "$conv_file" ] && [ -f "$conv_file" ]; then
         last_mod="$(stat -c %Y "$conv_file")"
         idle_sec=$(( now - last_mod ))


### PR DESCRIPTION
## Summary
- Fix build failures from PR #163 where `${session_id}` and `${idle_min}` were interpreted as Nix variables instead of shell variables
- Uses `''${...}` escaping (standard Nix pattern for shell vars inside `''` strings)

## Test plan
- [x] `sudo nixos-rebuild switch` succeeds
- [x] Timer registered: `systemctl list-timers | grep claude-rc-session-cleanup`
- [x] Manual run cleaned up 12 orphaned worktrees, active session survived

🤖 Generated with [Claude Code](https://claude.com/claude-code)