### PR TITLE
fix(affine): embed dimensions mismatch — bump tiny-llm-gate to v0.3.4

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -996,16 +996,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1776773385,
-        "narHash": "sha256-H42GHwTjFP70i8snrHK2DD7I7IBbm80OXK4mX+aLE4Q=",
+        "lastModified": 1776776242,
+        "narHash": "sha256-k6zzdoWA+6VR+twdO90H7BEaMInS3vb/zypO4lzUHK0=",
         "owner": "nSimonFR",
         "repo": "tiny-llm-gate",
-        "rev": "bf9884525b28b48cd3feafbfde9acd5cd949bee9",
+        "rev": "5b054c27a6a157cc811dc642d8d0407537523636",
         "type": "github"
       },
       "original": {
         "owner": "nSimonFR",
-        "ref": "v0.3.3",
+        "ref": "v0.3.4",
         "repo": "tiny-llm-gate",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -73,7 +73,7 @@
     # tiny-llm-gate: memory-conscious replacement for LiteLLM.
     # Pinned to a tag; bump the ref to roll forward.
     tiny-llm-gate = {
-      url = "github:nSimonFR/tiny-llm-gate/v0.3.3";
+      url = "github:nSimonFR/tiny-llm-gate/v0.3.4";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };

--- a/rpi5/tiny-llm-gate.nix
+++ b/rpi5/tiny-llm-gate.nix
@@ -47,7 +47,14 @@ in
         "gemma4:e4b"         = { provider = "ollama"; upstream_model = "gemma4:e4b"; };
         "gemma4:26b"         = { provider = "ollama"; upstream_model = "gemma4:26b"; };
         "qwen3.5:35b-a3b"    = { provider = "ollama"; upstream_model = "qwen3.5:35b-a3b"; };
-        "qwen3-embedding:8b" = { provider = "ollama"; upstream_model = "qwen3-embedding:8b"; };
+        "qwen3-embedding:8b" = {
+          provider = "ollama";
+          upstream_model = "qwen3-embedding:8b";
+          # AFFiNE's pgvector column is vector(1024). The @ai-sdk/google
+          # SDK doesn't reliably forward outputDimensionality, so
+          # tiny-llm-gate injects this default when the client omits it.
+          default_embed_dimensions = 1024;
+        };
 
         # -- Codex-proxy models (OpenAI subscription via OAuth) --
         "gpt-5.4" = {


### PR DESCRIPTION
## Summary
- Bumps tiny-llm-gate to v0.3.4 which adds `default_embed_dimensions` model config
- Sets `default_embed_dimensions = 1024` on `qwen3-embedding:8b` to match AFFiNE's pgvector column
- Fixes `ERROR: expected 1024 dimensions, not 4096` in workspace embedding

## Root cause
AFFiNE's `@ai-sdk/google` SDK (v2.0.52) does not reliably forward `outputDimensionality` to the Gemini embedding endpoint. `qwen3-embedding:8b` returns native 4096 dims, which doesn't fit the `vector(1024)` column.

## Test plan
- [x] `curl` embedContent without `outputDimensionality` → returns 1024 (was 4096)
- [x] `curl` embedContent with explicit `outputDimensionality=512` → returns 512 (client respected)
- [x] OpenAI `/v1/embeddings` without `dimensions` → returns 1024
- [x] `go test ./...` passes in tiny-llm-gate
- [x] NixOS rebuild + deploy successful
- [x] Zero embedding errors in AFFiNE logs post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)