### PR TITLE
fix(beast): prevent VRAM OOM from crashing Ghostty terminal

### DIFF
--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -578,6 +578,11 @@ in
     }).ollama-cuda;
     host = "0.0.0.0"; # Bind all interfaces — firewalled to tailscale0 + localhost
     loadModels = [ "gemma4:26b" "gemma4:e4b" "qwen3.5:35b-a3b" ];
+    environmentVariables = {
+      OLLAMA_GPU_OVERHEAD = "1073741824"; # Reserve 1GB VRAM for Hyprland/Ghostty (prevents VRAM OOM → terminal crash)
+      OLLAMA_FLASH_ATTENTION = "1"; # Reduce VRAM usage during inference via flash attention
+      OLLAMA_KV_CACHE_TYPE = "q8_0"; # Quantize KV cache to further reduce VRAM (vs default f16)
+    };
   };
 
   services.hardware.openrgb = {

--- a/nixos/dotfiles/hypr/hyprland.conf
+++ b/nixos/dotfiles/hypr/hyprland.conf
@@ -6,6 +6,9 @@ env = WLR_NO_HARDWARE_CURSORS, 1
 env = __GL_GSYNC_ALLOWED, 1
 env = __GL_VRR_ALLOWED, 1
 
+# GTK4 renderer: ngl handles VRAM pressure gracefully (gpu renderer SIGSEGVs on alloc failure)
+env = GSK_RENDERER, ngl
+
 # Qt/Application environment
 env = QT_STYLE_OVERRIDE, Adwaita-Dark
 env = QT_QPA_PLATFORMTHEME, qt5ct


### PR DESCRIPTION
## Summary
- Ollama was consuming nearly all 12GB VRAM on the RTX 3080 Ti, leaving Ghostty's GTK4 GPU renderer unable to allocate — causing SIGSEGV crashes (confirmed via coredumps from Apr 19)
- Reserve 1GB VRAM via `OLLAMA_GPU_OVERHEAD`, enable flash attention + q8_0 KV cache to reduce VRAM footprint
- Switch GTK4 renderer from `gpu` to `ngl` which handles allocation failures gracefully instead of crashing

## Test plan
- [ ] Rebuild on beast succeeds
- [ ] Ollama loads models with reduced VRAM (verify via `nvidia-smi`)
- [ ] Ghostty launches and renders without issues under `GSK_RENDERER=ngl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)