### PR TITLE
fix(affine): route model aliases through auto for codex fallback

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -996,11 +996,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776776242,
-        "narHash": "sha256-k6zzdoWA+6VR+twdO90H7BEaMInS3vb/zypO4lzUHK0=",
+        "lastModified": 1776778997,
+        "narHash": "sha256-p5e3ja1FgS9S6NzhYSsI5vgRrgwPCvW5UTUJx+fPr5U=",
         "owner": "nSimonFR",
         "repo": "tiny-llm-gate",
-        "rev": "5b054c27a6a157cc811dc642d8d0407537523636",
+        "rev": "d3aff98b9d5bc233b5c73325f5974eb944a35edb",
         "type": "github"
       },
       "original": {

--- a/rpi5/tiny-llm-gate.nix
+++ b/rpi5/tiny-llm-gate.nix
@@ -98,20 +98,22 @@ in
         "openai/codex-auto-review"   = "codex-auto-review";
 
         # AFFiNE hardcodes OpenAI GPT model names for its OpenAI provider.
-        "gpt-4.1-2025-04-14" = "gemma4:e4b";
-        "gpt-4.1-mini"       = "gemma4:e4b";
-        "gpt-4o"             = "gemma4:e4b";
-        "gpt-4o-mini"        = "gemma4:e4b";
+        # Route through "auto" so beast-down falls back to codex.
+        "gpt-4.1-2025-04-14" = "auto";
+        "gpt-4.1-mini"       = "auto";
+        "gpt-4o"             = "auto";
+        "gpt-4o-mini"        = "auto";
 
         # AFFiNE hardcodes OpenAI embedding model names.
         "text-embedding-3-small" = "qwen3-embedding:8b";
         "text-embedding-3-large" = "qwen3-embedding:8b";
 
         # AFFiNE Gemini provider model names (served by Gemini frontend).
-        "gemini-2.5-flash"     = "gemma4:e4b";
-        "gemini-2.5-pro"       = "gemma4:e4b";
-        "gemini-2.0-flash"     = "gemma4:e4b";
-        "gemini-2.0-flash-001" = "gemma4:e4b";
+        # Route through "auto" so beast-down falls back to codex.
+        "gemini-2.5-flash"     = "auto";
+        "gemini-2.5-pro"       = "auto";
+        "gemini-2.0-flash"     = "auto";
+        "gemini-2.0-flash-001" = "auto";
         "gemini-embedding-001" = "qwen3-embedding:8b";
         "text-embedding-004"   = "qwen3-embedding:8b";
       };


### PR DESCRIPTION
## Summary
- Routes Gemini and GPT model aliases through `auto` model (ollama→codex fallback)
- Fixes AFFiNE chat failing when beast is offline (no fallback on direct aliases)

## Test plan
- [x] Beast down → chat falls back to codex/gpt-5.4
- [x] Beast up → chat uses local ollama as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)