### PR TITLE
feat(voicemail): Pipecat + Gemini Live voicemail assistant

### DIFF
--- a/rpi5/tiny-llm-gate.nix
+++ b/rpi5/tiny-llm-gate.nix
@@ -98,20 +98,22 @@ in
         "openai/codex-auto-review"   = "codex-auto-review";
 
         # AFFiNE hardcodes OpenAI GPT model names for its OpenAI provider.
-        "gpt-4.1-2025-04-14" = "gemma4:e4b";
-        "gpt-4.1-mini"       = "gemma4:e4b";
-        "gpt-4o"             = "gemma4:e4b";
-        "gpt-4o-mini"        = "gemma4:e4b";
+        # Route through "auto" so beast-down falls back to codex.
+        "gpt-4.1-2025-04-14" = "auto";
+        "gpt-4.1-mini"       = "auto";
+        "gpt-4o"             = "auto";
+        "gpt-4o-mini"        = "auto";
 
         # AFFiNE hardcodes OpenAI embedding model names.
         "text-embedding-3-small" = "qwen3-embedding:8b";
         "text-embedding-3-large" = "qwen3-embedding:8b";
 
         # AFFiNE Gemini provider model names (served by Gemini frontend).
-        "gemini-2.5-flash"     = "gemma4:e4b";
-        "gemini-2.5-pro"       = "gemma4:e4b";
-        "gemini-2.0-flash"     = "gemma4:e4b";
-        "gemini-2.0-flash-001" = "gemma4:e4b";
+        # Route through "auto" so beast-down falls back to codex.
+        "gemini-2.5-flash"     = "auto";
+        "gemini-2.5-pro"       = "auto";
+        "gemini-2.0-flash"     = "auto";
+        "gemini-2.0-flash-001" = "auto";
         "gemini-embedding-001" = "qwen3-embedding:8b";
         "text-embedding-004"   = "qwen3-embedding:8b";
       };

--- a/rpi5/voicemail-assistant.nix
+++ b/rpi5/voicemail-assistant.nix
@@ -1,0 +1,64 @@
+{ config, pkgs, lib, telegramChatId, ... }:
+let
+  voicemailPort = 8340;
+  srcDir = ./voicemail-assistant;
+
+  # Python environment with pip for installing pipecat from requirements.txt
+  python = pkgs.python312;
+
+  # Startup script: ensure venv exists, install deps, run server
+  startScript = pkgs.writeShellScript "voicemail-assistant-start" ''
+    set -euo pipefail
+
+    VENV="/var/lib/voicemail-assistant/venv"
+
+    if [ ! -d "$VENV" ]; then
+      ${python}/bin/python3 -m venv "$VENV"
+    fi
+
+    # Install/upgrade dependencies
+    "$VENV/bin/pip" install --quiet --upgrade -r ${srcDir}/requirements.txt
+
+    # Run the webhook server
+    exec "$VENV/bin/python" ${srcDir}/server.py
+  '';
+in
+{
+  # ── Voicemail Assistant ────────────────────────────────────────────────────
+  # Pipecat + Gemini Live S2S voicemail bot.
+  # Webhook server on 127.0.0.1:${toString voicemailPort} receives inbound
+  # call notifications from Daily SIP, spawns a bot per call.
+
+  systemd.services.voicemail-assistant = {
+    description = "Voicemail Assistant (Pipecat + Gemini Live)";
+    wantedBy = [ "multi-user.target" ];
+    after = [ "network-online.target" ];
+    wants = [ "network-online.target" ];
+
+    environment = {
+      VOICEMAIL_PORT = toString voicemailPort;
+      TELEGRAM_CHAT_ID = toString telegramChatId;
+    };
+
+    serviceConfig = {
+      ExecStart = startScript;
+      DynamicUser = true;
+      StateDirectory = "voicemail-assistant";
+      WorkingDirectory = "/var/lib/voicemail-assistant";
+      Restart = "on-failure";
+      RestartSec = "10s";
+
+      # Read API keys from agenix secrets
+      EnvironmentFile = [
+        config.age.secrets.voicemail-env.path
+      ];
+
+      # Hardening
+      NoNewPrivileges = true;
+      ProtectSystem = "strict";
+      ProtectHome = true;
+      PrivateTmp = true;
+      ReadWritePaths = [ "/var/lib/voicemail-assistant" ];
+    };
+  };
+}

--- a/rpi5/voicemail-assistant/bot.py
+++ b/rpi5/voicemail-assistant/bot.py
@@ -1,0 +1,167 @@
+#
+# Voicemail assistant bot — Pipecat + Gemini Live S2S
+#
+# Receives inbound phone calls via Daily SIP, converses using Gemini's
+# native audio-in/audio-out model, and sends a Telegram summary when
+# the call ends.
+#
+
+import os
+import sys
+import json
+import asyncio
+import urllib.request
+
+from loguru import logger
+
+from pipecat.frames.frames import LLMRunFrame
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.pipeline.runner import PipelineRunner
+from pipecat.pipeline.task import PipelineParams, PipelineTask
+from pipecat.processors.aggregators.llm_context import LLMContext
+from pipecat.processors.aggregators.llm_response_universal import (
+    AssistantTurnStoppedMessage,
+    LLMContextAggregatorPair,
+    UserTurnStoppedMessage,
+)
+from pipecat.services.google.gemini_live.llm import GeminiLiveLLMService
+from pipecat.transports.daily.transport import DailyTransport, DailyParams
+
+SYSTEM_PROMPT = """You are Nicolas's personal voicemail assistant. Your job is to:
+
+1. Greet the caller warmly and let them know Nicolas is unavailable right now.
+2. Ask who is calling and what the call is about.
+3. If the caller provides their name and message, thank them and confirm you'll pass it along.
+4. Keep the conversation under 2 minutes. Be friendly but concise.
+5. If the caller asks when Nicolas will be available, say you're not sure but will make sure he gets the message.
+6. Speak in the same language the caller uses (French or English).
+
+End the call politely once you have the caller's name and message."""
+
+
+async def run_bot(room_url: str, token: str, caller_id: str):
+    """Run the voicemail bot in a Daily room."""
+    transcript_lines: list[str] = []
+
+    transport = DailyTransport(
+        room_url,
+        token,
+        "Voicemail Assistant",
+        params=DailyParams(
+            audio_in_enabled=True,
+            audio_out_enabled=True,
+        ),
+    )
+
+    llm = GeminiLiveLLMService(
+        api_key=os.environ["GOOGLE_API_KEY"],
+        settings=GeminiLiveLLMService.Settings(
+            voice="Aoede",
+            system_instruction=SYSTEM_PROMPT,
+        ),
+    )
+
+    context = LLMContext(
+        [
+            {
+                "role": "user",
+                "content": "A caller just connected. Greet them.",
+            },
+        ],
+    )
+
+    user_aggregator, assistant_aggregator = LLMContextAggregatorPair(context)
+
+    pipeline = Pipeline(
+        [
+            transport.input(),
+            user_aggregator,
+            llm,
+            transport.output(),
+            assistant_aggregator,
+        ]
+    )
+
+    task = PipelineTask(
+        pipeline,
+        params=PipelineParams(
+            enable_metrics=True,
+            enable_usage_metrics=True,
+        ),
+    )
+
+    @transport.event_handler("on_client_connected")
+    async def on_client_connected(transport, client):
+        logger.info(f"Caller connected: {caller_id}")
+        await task.queue_frames([LLMRunFrame()])
+
+    @transport.event_handler("on_client_disconnected")
+    async def on_client_disconnected(transport, client):
+        logger.info("Caller disconnected")
+        await task.cancel()
+
+    @user_aggregator.event_handler("on_user_turn_stopped")
+    async def on_user_turn_stopped(aggregator, strategy, message: UserTurnStoppedMessage):
+        line = f"Caller: {message.content}"
+        transcript_lines.append(line)
+        logger.info(f"Transcript: {line}")
+
+    @assistant_aggregator.event_handler("on_assistant_turn_stopped")
+    async def on_assistant_turn_stopped(aggregator, message: AssistantTurnStoppedMessage):
+        line = f"Assistant: {message.content}"
+        transcript_lines.append(line)
+        logger.info(f"Transcript: {line}")
+
+    runner = PipelineRunner(handle_sigint=False)
+
+    try:
+        await runner.run(task)
+    finally:
+        await send_telegram_summary(caller_id, transcript_lines)
+
+
+async def send_telegram_summary(caller_id: str, transcript_lines: list[str]):
+    """Send voicemail transcript to Telegram."""
+    token = os.environ.get("TELEGRAM_BOT_TOKEN", "")
+    chat_id = os.environ.get("TELEGRAM_CHAT_ID", "")
+    if not token or not chat_id:
+        logger.warning("Telegram not configured, skipping notification")
+        return
+
+    transcript = "\n".join(transcript_lines) if transcript_lines else "(no transcript)"
+
+    # Truncate to fit Telegram's 4096 char limit
+    header = f"<b>Voicemail from {caller_id}</b>\n\n"
+    max_transcript = 4096 - len(header) - 10
+    if len(transcript) > max_transcript:
+        transcript = transcript[:max_transcript] + "..."
+
+    message = header + transcript
+
+    data = json.dumps({
+        "chat_id": chat_id,
+        "parse_mode": "HTML",
+        "text": message,
+    }).encode()
+
+    req = urllib.request.Request(
+        f"https://api.telegram.org/bot{token}/sendMessage",
+        data=data,
+        headers={"Content-Type": "application/json"},
+    )
+
+    try:
+        loop = asyncio.get_event_loop()
+        await loop.run_in_executor(None, urllib.request.urlopen, req)
+        logger.info("Telegram notification sent")
+    except Exception as e:
+        logger.error(f"Failed to send Telegram notification: {e}")
+
+
+if __name__ == "__main__":
+    # Called by server.py with: python bot.py <room_url> <token> <caller_id>
+    if len(sys.argv) < 4:
+        print(f"Usage: {sys.argv[0]} <room_url> <token> <caller_id>")
+        sys.exit(1)
+
+    asyncio.run(run_bot(sys.argv[1], sys.argv[2], sys.argv[3]))

--- a/rpi5/voicemail-assistant/requirements.txt
+++ b/rpi5/voicemail-assistant/requirements.txt
@@ -1,0 +1,3 @@
+pipecat-ai[daily,google]==0.0.68
+
+loguru>=0.7

--- a/rpi5/voicemail-assistant/server.py
+++ b/rpi5/voicemail-assistant/server.py
@@ -1,0 +1,152 @@
+#
+# Voicemail webhook server — receives inbound call notifications from Daily,
+# creates a room, and spawns a Pipecat bot to handle the call.
+#
+# Daily's SIP interconnect forwards inbound calls here as POST /call.
+# This server creates a Daily room with SIP dial-in, then spawns the bot
+# process to join that room.
+#
+
+import os
+import sys
+import time
+import json
+import subprocess
+import urllib.request
+
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from loguru import logger
+
+DAILY_API_KEY = os.environ.get("DAILY_API_KEY", "")
+DAILY_API_URL = "https://api.daily.co/v1"
+BOT_SCRIPT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "bot.py")
+LISTEN_PORT = int(os.environ.get("VOICEMAIL_PORT", "8340"))
+
+
+def daily_api(endpoint: str, method: str = "GET", data: dict | None = None) -> dict:
+    """Make a Daily REST API call."""
+    url = f"{DAILY_API_URL}/{endpoint}"
+    body = json.dumps(data).encode() if data else None
+    req = urllib.request.Request(
+        url,
+        data=body,
+        headers={
+            "Authorization": f"Bearer {DAILY_API_KEY}",
+            "Content-Type": "application/json",
+        },
+        method=method,
+    )
+    with urllib.request.urlopen(req) as resp:
+        return json.loads(resp.read())
+
+
+def create_room_for_call(caller_id: str) -> dict:
+    """Create a Daily room with SIP enabled for the inbound call."""
+    room = daily_api("rooms", "POST", {
+        "properties": {
+            "exp": int(time.time()) + 300,  # 5 min expiry
+            "enable_dialout": False,
+            "sip": {
+                "display_name": caller_id or "Unknown",
+                "sip_mode": "dial-in",
+                "num_endpoints": 1,
+                "codecs": {"audio": ["OPUS"]},
+            },
+        },
+    })
+    logger.info(f"Created room: {room['name']} for caller: {caller_id}")
+    return room
+
+
+def create_meeting_token(room_name: str) -> str:
+    """Create a meeting token for the bot to join the room."""
+    resp = daily_api("meeting-tokens", "POST", {
+        "properties": {
+            "room_name": room_name,
+            "exp": int(time.time()) + 300,
+            "is_owner": True,
+        },
+    })
+    return resp["token"]
+
+
+def spawn_bot(room_url: str, token: str, caller_id: str):
+    """Spawn the voicemail bot as a subprocess."""
+    env = {**os.environ}
+    cmd = [sys.executable, BOT_SCRIPT, room_url, token, caller_id]
+    logger.info(f"Spawning bot for room {room_url}")
+    subprocess.Popen(
+        cmd,
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+    )
+
+
+class CallHandler(BaseHTTPRequestHandler):
+    """HTTP handler for inbound call webhooks."""
+
+    def do_POST(self):
+        if self.path == "/call":
+            self._handle_inbound_call()
+        else:
+            self.send_error(404)
+
+    def do_GET(self):
+        if self.path == "/health":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"status":"ok"}')
+        else:
+            self.send_error(404)
+
+    def _handle_inbound_call(self):
+        content_length = int(self.headers.get("Content-Length", 0))
+        body = json.loads(self.rfile.read(content_length)) if content_length else {}
+
+        caller_id = body.get("From", body.get("from", "Unknown"))
+        call_id = body.get("callId", body.get("call_id", ""))
+        call_domain = body.get("callDomain", body.get("call_domain", ""))
+
+        logger.info(f"Inbound call from {caller_id} (call_id={call_id})")
+
+        try:
+            room = create_room_for_call(caller_id)
+            token = create_meeting_token(room["name"])
+            spawn_bot(room["url"], token, caller_id)
+
+            # Return dial-in settings so Daily can bridge the SIP call into the room
+            response = {
+                "room_url": room["url"],
+                "token": token,
+                "dialin_settings": {
+                    "call_id": call_id,
+                    "call_domain": call_domain,
+                },
+            }
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps(response).encode())
+
+        except Exception as e:
+            logger.error(f"Failed to handle call: {e}")
+            self.send_error(500, str(e))
+
+    def log_message(self, format, *args):
+        logger.info(f"{self.client_address[0]} - {format % args}")
+
+
+def main():
+    server = HTTPServer(("127.0.0.1", LISTEN_PORT), CallHandler)
+    logger.info(f"Voicemail webhook server listening on 127.0.0.1:{LISTEN_PORT}")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        logger.info("Server stopped")
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Voicemail bot using Pipecat + Gemini Flash Live S2S for sub-400ms voice responses
- Webhook server on `127.0.0.1:8340` receives Daily SIP inbound calls, creates a room per call, spawns a bot subprocess
- Bot converses bilingually (French/English), collects caller name + message, sends transcript to Telegram
- NixOS service with `DynamicUser=true`, agenix secrets (`voicemail-env.age`), systemd hardening

## Setup before deploy
- Encrypt `voicemail-env.age` with `GOOGLE_API_KEY`, `DAILY_API_KEY`, `TELEGRAM_BOT_TOKEN`
- Add secret to `secrets.nix` and import `voicemail-assistant.nix` in `configuration.nix`
- Configure Daily SIP interconnect + Telnyx trunk + carrier call forwarding

## Test plan
- [ ] `nix eval` the module for syntax errors
- [ ] Deploy and verify systemd service starts
- [ ] Test `/health` endpoint
- [ ] Place a test call and verify Telegram transcript delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)