### PR TITLE
feat(rpi5): add steipete gogcli and goplaces CLIs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -403,6 +403,40 @@
         "type": "github"
       }
     },
+    "gogcli-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1776722970,
+        "narHash": "sha256-UN1dW3VX7N3fymn8y40Xd0sIznihjeeLtb1nHOEMDcY=",
+        "owner": "steipete",
+        "repo": "gogcli",
+        "rev": "5cd913e28780d330f27aaaabc7bfb6413491850a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "steipete",
+        "ref": "v0.13.0",
+        "repo": "gogcli",
+        "type": "github"
+      }
+    },
+    "goplaces-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1771044968,
+        "narHash": "sha256-D54ybZznbc0EXNh/SqyIvfn5x3krI3G9fbXTTj1BaEs=",
+        "owner": "steipete",
+        "repo": "goplaces",
+        "rev": "46fa4a132305d3e942573ef6813ef05ff4a3e5da",
+        "type": "github"
+      },
+      "original": {
+        "owner": "steipete",
+        "ref": "v0.3.0",
+        "repo": "goplaces",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
@@ -825,6 +859,8 @@
       "inputs": {
         "darwin": "darwin",
         "for-sure": "for-sure",
+        "gogcli-src": "gogcli-src",
+        "goplaces-src": "goplaces-src",
         "home-manager": "home-manager",
         "llmfit": "llmfit",
         "mac-app-util": "mac-app-util",

--- a/flake.nix
+++ b/flake.nix
@@ -70,6 +70,17 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    # steipete CLI tools: bump with
+    #   sudo nix flake lock --update-input gogcli-src --update-input goplaces-src
+    gogcli-src = {
+      url = "github:steipete/gogcli/v0.13.0";
+      flake = false;
+    };
+    goplaces-src = {
+      url = "github:steipete/goplaces/v0.3.0";
+      flake = false;
+    };
+
     # tiny-llm-gate: memory-conscious replacement for LiteLLM.
     # Pinned to a tag; bump the ref to roll forward.
     tiny-llm-gate = {

--- a/rpi5/gogcli.nix
+++ b/rpi5/gogcli.nix
@@ -1,0 +1,33 @@
+{
+  lib,
+  buildGo126Module,
+  gogcli-src,
+  version ? "0.13.0",
+  vendorHash ? "sha256-BNVY9Wx+bQA/hxT0tHo5anBSNnMHSLWs9cedoaMhQTc=",
+}:
+
+buildGo126Module {
+  pname = "gogcli";
+  inherit version vendorHash;
+
+  src = gogcli-src;
+
+  subPackages = [ "cmd/gog" ];
+
+  # nixpkgs has Go 1.26.1; gogcli requires 1.26.2 — trivial patch
+  postPatch = ''
+    substituteInPlace go.mod --replace-fail 'go 1.26.2' 'go 1.26.1'
+  '';
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  meta = with lib; {
+    description = "Google Suite CLI: Gmail, GCal, GDrive, GContacts";
+    homepage = "https://gogcli.sh";
+    license = licenses.mit;
+    mainProgram = "gog";
+  };
+}

--- a/rpi5/goplaces.nix
+++ b/rpi5/goplaces.nix
@@ -1,0 +1,28 @@
+{
+  lib,
+  buildGoModule,
+  goplaces-src,
+  version ? "0.3.0",
+  vendorHash ? "sha256-OFTjLtKwYSy4tM+D12mqI28M73YJdG4DyqPkXS7ZKUg=",
+}:
+
+buildGoModule {
+  pname = "goplaces";
+  inherit version vendorHash;
+
+  src = goplaces-src;
+
+  subPackages = [ "cmd/goplaces" ];
+
+  ldflags = [
+    "-s"
+    "-w"
+  ];
+
+  meta = with lib; {
+    description = "Modern Google Places CLI in Go";
+    homepage = "https://github.com/steipete/goplaces";
+    license = licenses.mit;
+    mainProgram = "goplaces";
+  };
+}

--- a/rpi5/home.nix
+++ b/rpi5/home.nix
@@ -12,6 +12,8 @@
   home.packages = with pkgs; [
     nodejs_22
     pnpm
+    (callPackage ./gogcli.nix { gogcli-src = inputs.gogcli-src; })
+    (callPackage ./goplaces.nix { goplaces-src = inputs.goplaces-src; })
   ];
 
   home = {


### PR DESCRIPTION
## Summary
- Package **gogcli** v0.13.0 (`gog` binary) and **goplaces** v0.3.0 as `buildGoModule` Nix derivations
- Add both to rpi5 home-manager packages so they're in PATH (and available to PicoClaw)
- gogcli needs `buildGo126Module` + minor go.mod patch (nixpkgs has Go 1.26.1, upstream requires 1.26.2)

## Test plan
- [x] Both packages build successfully on aarch64-linux
- [ ] `nixos-rebuild switch` succeeds
- [ ] `gog --help` and `goplaces --help` work from shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)