### PR TITLE
fix(homepage): move Beszel to Services, fix /home disk stat

### DIFF
--- a/rpi5/homepage.nix
+++ b/rpi5/homepage.nix
@@ -6,19 +6,8 @@ let
   # Hide Homepage and Infrastructure from the dashboard
   visibleEntries = builtins.filter (e: e.name != "Homepage" && e.category != "Infrastructure") allEntries;
 
-  # Explicit tile ordering per category (entries not listed here appear at the end)
-  tileOrder = {
-    "Apps" = [ "AFFiNE" "Immich" "Sure" "Open WebUI" ];
-    "Services" = [ "Vaultwarden" "Home Assistant" "Filebrowser" "Forgejo" "Beszel" "Dawarich" ];
-  };
-
-  sortEntries = cat: entries:
-    let
-      order = tileOrder.${cat} or [];
-      indexOf = name: let idx = lib.lists.findFirstIndex (n: n == name) (builtins.length order) order; in idx;
-    in builtins.sort (a: b: indexOf a.name < indexOf b.name) entries;
-
   # Ordered category list (controls display order on the dashboard)
+  # Tile order within each category is determined by list order in services-registry.nix.
   categoryOrder = [
     "Apps"
     "Services"
@@ -43,7 +32,7 @@ let
   # Build the services list: one attrset per category, each containing service tiles
   servicesByCategory = builtins.filter (group: group != null) (
     map (cat:
-      let entries = sortEntries cat (entriesForCategory cat);
+      let entries = entriesForCategory cat;
       in if entries == [] then null
       else {
         "${cat}" = map (e: {

--- a/rpi5/homepage.nix
+++ b/rpi5/homepage.nix
@@ -9,7 +9,7 @@ let
   # Explicit tile ordering per category (entries not listed here appear at the end)
   tileOrder = {
     "Apps" = [ "AFFiNE" "Immich" "Sure" "Open WebUI" ];
-    "Services" = [ "Vaultwarden" "Home Assistant" "Filebrowser" "Forgejo" ];
+    "Services" = [ "Vaultwarden" "Home Assistant" "Filebrowser" "Forgejo" "Beszel" "Dawarich" ];
   };
 
   sortEntries = cat: entries:
@@ -22,7 +22,6 @@ let
   categoryOrder = [
     "Apps"
     "Services"
-    "Monitoring"
     "Backend"
   ];
 
@@ -58,6 +57,8 @@ in
 {
   # Bind to localhost only — Tailscale Serve proxies from the tailnet interface
   # and would conflict on 0.0.0.0:8082.
+  # Allow statfs on /home so the resources widget can report disk usage
+  systemd.services.homepage-dashboard.serviceConfig.ProtectHome = lib.mkForce "read-only";
   systemd.services.homepage-dashboard.environment.HOSTNAME = "127.0.0.1";
   # Cap V8 heap — Next.js idles at ~61 MB; 128 MB gives headroom for widget rendering
   systemd.services.homepage-dashboard.environment.NODE_OPTIONS = "--max-old-space-size=128";
@@ -80,7 +81,6 @@ in
       mkdir -p /run/homepage-dashboard
       cat > /run/homepage-dashboard/env <<ENVEOF
       HOMEPAGE_VAR_IMMICH_KEY=$(cat ${config.age.secrets.immich-api-key.path})
-      HOMEPAGE_VAR_BESZEL_PASS=homepage-widget-pass
       HOMEPAGE_VAR_AFFINE_TOKEN=$(cat ${config.age.secrets.affine-token.path})
       HOMEPAGE_VAR_SURE_KEY=$(grep SURE_API_KEY ${config.age.secrets.picoclaw-env.path} | cut -d= -f2)
       ENVEOF
@@ -121,7 +121,6 @@ in
       layout = [
         { "Quick Links" = { style = "row"; columns = 3; header = false; }; }
         { "Apps"        = { style = "row"; columns = 4; }; }
-        { "Monitoring"  = { style = "row"; columns = 4; }; }
         { "Services"    = { style = "row"; columns = 4; }; }
         { "Backend"     = { style = "row"; columns = 4; }; }
       ];

--- a/rpi5/services-registry.nix
+++ b/rpi5/services-registry.nix
@@ -17,6 +17,7 @@
     { port = 8123;  backend = "http://127.0.0.1:8123";  name = "Home Assistant"; icon = "home-assistant.svg"; category = "Services"; description = "Home automation"; }
     { port = 8085;  backend = "http://127.0.0.1:8085";  name = "Filebrowser";    icon = "filebrowser.svg";    category = "Services"; description = "File management"; }
     { port = 3100;  backend = "http://127.0.0.1:3100";  name = "Forgejo";        icon = "forgejo.svg";        category = "Services"; description = "Git hosting"; }
+    { port = 3000;  backend = "http://127.0.0.1:8090";  name = "Beszel";         icon = "beszel.svg";         category = "Services"; description = "System monitoring"; }
     { port = 3900;  backend = "http://127.0.0.1:13900"; name = "Dawarich";       icon = "dawarich.svg";       category = "Services"; description = "Location history"; }
 
     # Apps: AFFiNE → Immich (in funnelEntries) → Sure → Open WebUI
@@ -54,10 +55,6 @@
           { field = "messages"; label = "Messages"; format = "number"; }
         ];
       }; }
-
-    # Monitoring
-    { port = 3000;  backend = "http://127.0.0.1:8090";  name = "Beszel";         icon = "beszel.svg";         category = "Monitoring"; description = "System monitoring";
-      widget = { type = "beszel"; url = "http://127.0.0.1:8090"; username = "homepage@nic-os.local"; password = "{{HOMEPAGE_VAR_BESZEL_PASS}}"; version = 2; }; }
 
     # Backend — API services
     { port = 443;   backend = "http://127.0.0.1:18789"; name = "PicoClaw";       icon = "mdi-robot";          category = "Backend"; description = "AI gateway"; }


### PR DESCRIPTION
## Summary
- Move Beszel from Monitoring category to Services (removes now-empty Monitoring section)
- Remove Beszel widget and its `HOMEPAGE_VAR_BESZEL_PASS` env var
- Fix resources widget `/home` disk showing API error by setting `ProtectHome=read-only` (DynamicUser sets `ProtectHome=yes` which hides `/home` from `systeminformation`)

## Test plan
- [ ] `sudo nixos-rebuild switch` and verify homepage loads
- [ ] Confirm Beszel tile appears under Services
- [ ] Confirm `/home` disk bar renders in the resources widget
- [ ] Confirm Monitoring section no longer appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)