### PR TITLE
feat(sumeria-mitm): use Tailscale App Connector instead of exit node

### DIFF
--- a/rpi5/configuration.nix
+++ b/rpi5/configuration.nix
@@ -133,6 +133,7 @@ in
       role = "server";
       enableSSH = true;
       advertiseExitNode = true;
+      advertiseConnector = true;
     })
   ];
 

--- a/rpi5/sumeria-mitm.nix
+++ b/rpi5/sumeria-mitm.nix
@@ -104,20 +104,22 @@ in
       environment.SUMERIA_TOKEN_FILE = cfg.tokenFile;
     };
 
-    # Redirect HTTPS from exit-node clients → mitmproxy. Scoped to specific IPs only.
+    # Redirect HTTPS from exit-node / app-connector clients → mitmproxy.
+    # `! -d 100.64.0.0/10` excludes tailnet-internal traffic (Tailscale Serve)
+    # so only public-destined traffic (app-connector routed) gets intercepted.
     # Also drop UDP 443 (QUIC/HTTP3) so apps fall back to TCP (HTTP2) which mitmproxy can intercept.
     networking.firewall.extraCommands = lib.mkIf (cfg.exitNodeClients != []) (
       lib.concatMapStringsSep "\n" (ip: ''
-        iptables -t nat -A PREROUTING -i tailscale0 -s ${ip} -p tcp --dport 443 -j REDIRECT --to-port ${toString cfg.port}
-        iptables -I FORWARD -i tailscale0 -s ${ip} -p udp --dport 443 -j DROP
-        iptables -t mangle -I PREROUTING -i tailscale0 -s ${ip} -p udp --dport 443 -j DROP
+        iptables -t nat -A PREROUTING -i tailscale0 -s ${ip} ! -d 100.64.0.0/10 -p tcp --dport 443 -j REDIRECT --to-port ${toString cfg.port}
+        iptables -I FORWARD -i tailscale0 -s ${ip} ! -d 100.64.0.0/10 -p udp --dport 443 -j DROP
+        iptables -t mangle -I PREROUTING -i tailscale0 -s ${ip} ! -d 100.64.0.0/10 -p udp --dport 443 -j DROP
       '') cfg.exitNodeClients
     );
     networking.firewall.extraStopCommands = lib.mkIf (cfg.exitNodeClients != []) (
       lib.concatMapStringsSep "\n" (ip: ''
-        iptables -t nat -D PREROUTING -i tailscale0 -s ${ip} -p tcp --dport 443 -j REDIRECT --to-port ${toString cfg.port} || true
-        iptables -D FORWARD -i tailscale0 -s ${ip} -p udp --dport 443 -j DROP || true
-        iptables -t mangle -D PREROUTING -i tailscale0 -s ${ip} -p udp --dport 443 -j DROP || true
+        iptables -t nat -D PREROUTING -i tailscale0 -s ${ip} ! -d 100.64.0.0/10 -p tcp --dport 443 -j REDIRECT --to-port ${toString cfg.port} || true
+        iptables -D FORWARD -i tailscale0 -s ${ip} ! -d 100.64.0.0/10 -p udp --dport 443 -j DROP || true
+        iptables -t mangle -D PREROUTING -i tailscale0 -s ${ip} ! -d 100.64.0.0/10 -p udp --dport 443 -j DROP || true
       '') cfg.exitNodeClients
     );
 

--- a/shared/tailscale.nix
+++ b/shared/tailscale.nix
@@ -16,6 +16,7 @@
   enableSSH ? false,
   advertiseRoutes ? [],
   advertiseExitNode ? false,
+  advertiseConnector ? false,
   acceptRoutes ? true,
   acceptDNS ? true,
   extraUpFlags ? []
@@ -38,6 +39,7 @@ let
     ++ (lib.optionals acceptDNS [ "--accept-dns" ])
     ++ (lib.optionals (advertiseRoutes != []) [ "--advertise-routes=${lib.concatStringsSep "," advertiseRoutes}" ])
     ++ (lib.optionals advertiseExitNode [ "--advertise-exit-node" ])
+    ++ (lib.optionals advertiseConnector [ "--advertise-connector" ])
     ++ extraUpFlags
   );
   


### PR DESCRIPTION
## Summary
- Add `--advertise-connector` to Tailscale flags so RPi5 serves as App Connector for `api.lydia-app.com`
- Adjust iptables rules to exclude tailnet-internal traffic (`! -d 100.64.0.0/10`)
- Goal: route only Sumeria API traffic through RPi5 without manual exit node toggle

## Status
**Draft — App Connector approach doesn't work for MITM.** Traffic goes through tailscaled's userspace netstack and never hits iptables. Will pivot to subnet routing in a follow-up PR.

## Test plan
- [x] NixOS rebuild succeeds
- [x] `tailscale appc-routes --all` shows learned route for `api.lydia-app.com`
- [ ] ~~Tokens captured without exit node~~ — blocked: zero packets hit iptables

🤖 Generated with [Claude Code](https://claude.com/claude-code)