### PR TITLE
fix(affine): fix link preview and image proxy for desktop app

### DIFF
--- a/rpi5/affine.nix
+++ b/rpi5/affine.nix
@@ -217,20 +217,6 @@ in
       RESULT="''${TEMPLATE//@GCAL_CLIENT_ID@/$CID}"
       RESULT="''${RESULT//@GCAL_CLIENT_SECRET@/$CSE}"
       echo "$RESULT" > "$CONF"
-
-      # Patch hardcoded cloud worker URLs in client JS bundle.
-      # The AFFiNE client has fallback endpoints pointing at
-      # affine-worker.toeverything.workers.dev which the desktop app's
-      # DI does not override, causing link-preview and image-proxy
-      # requests to hit the cloud instead of our local server.
-      EXTERNAL="https://${tailnetFqdn}:3010"
-      CLOUD="https://affine-worker.toeverything.workers.dev"
-      for f in ${appDir}/static/js/*.js; do
-        if grep -q "$CLOUD" "$f" 2>/dev/null; then
-          ${pkgs.gnused}/bin/sed -i "s|$CLOUD|$EXTERNAL|g" "$f"
-        fi
-      done
-
       exec ${nodejs}/bin/node ${appDir}/dist/main.js
     '';
     serviceConfig = {

--- a/rpi5/affine.nix
+++ b/rpi5/affine.nix
@@ -15,6 +15,10 @@ let
   affineConfigTemplate = builtins.toJSON {
     "$schema" = "https://github.com/toeverything/affine/releases/latest/download/config.schema.json";
     server.name = "NicOS AFFiNE";
+    # Desktop app sends Origin: assets://. which isn't in the default
+    # allowedOrigin list (localhost, 127.0.0.1), causing link-preview
+    # and image-proxy requests to be rejected with "Invalid header".
+    "worker.allowedOrigin" = [ "localhost" "127.0.0.1" "assets://." ];
     calendar.google = {
       enabled = true;
       clientId = "@GCAL_CLIENT_ID@";
@@ -213,6 +217,20 @@ in
       RESULT="''${TEMPLATE//@GCAL_CLIENT_ID@/$CID}"
       RESULT="''${RESULT//@GCAL_CLIENT_SECRET@/$CSE}"
       echo "$RESULT" > "$CONF"
+
+      # Patch hardcoded cloud worker URLs in client JS bundle.
+      # The AFFiNE client has fallback endpoints pointing at
+      # affine-worker.toeverything.workers.dev which the desktop app's
+      # DI does not override, causing link-preview and image-proxy
+      # requests to hit the cloud instead of our local server.
+      EXTERNAL="https://${tailnetFqdn}:3010"
+      CLOUD="https://affine-worker.toeverything.workers.dev"
+      for f in ${appDir}/static/js/*.js; do
+        if grep -q "$CLOUD" "$f" 2>/dev/null; then
+          ${pkgs.gnused}/bin/sed -i "s|$CLOUD|$EXTERNAL|g" "$f"
+        fi
+      done
+
       exec ${nodejs}/bin/node ${appDir}/dist/main.js
     '';
     serviceConfig = {


### PR DESCRIPTION
## Summary
- Patch hardcoded cloud worker URLs (`affine-worker.toeverything.workers.dev`) in client JS bundle on startup to point at local server — the desktop app's DI fails to override these fallback endpoints
- Add `assets://.` to `worker.allowedOrigin` in config.json — the Electron desktop app sends this as its Origin header, which the server was rejecting

## Test plan
- [x] Verified link-preview requests now reach the local server (previously no requests in logs)
- [x] Confirmed `assets://.` origin rejection was the remaining blocker
- [ ] Hard-refresh desktop app and paste a URL to confirm unfurling works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)