### PR TITLE
fix(sumeria-mitm): daily route check at 04:00 instead of every 30min

### DIFF
--- a/rpi5/sumeria-mitm.nix
+++ b/rpi5/sumeria-mitm.nix
@@ -152,11 +152,11 @@ in
       };
     };
     systemd.timers.sumeria-route-update = {
-      description = "Periodic DNS check for api.lydia-app.com IP changes";
+      description = "Daily DNS check for api.lydia-app.com IP changes";
       wantedBy    = [ "timers.target" ];
       timerConfig = {
-        OnBootSec       = "1min";
-        OnUnitActiveSec = "30min";
+        OnCalendar = "*-*-* 04:00:00";
+        Persistent = true;
       };
     };
 


### PR DESCRIPTION
## Summary
- Change DNS monitoring timer from every 30 minutes to daily at 04:00
- `Persistent=true` ensures it catches up after reboot if the window was missed
- Google Cloud LB IPs are very stable — daily is sufficient

Stacks on #180.

🤖 Generated with [Claude Code](https://claude.com/claude-code)