### PR TITLE
feat(atuin): bump to unstable (18.13.6) + daemon mode

### DIFF
--- a/home/dotfiles/atuin.toml
+++ b/home/dotfiles/atuin.toml
@@ -3,6 +3,7 @@ workspace = true
 filter_mode = "host"
 filter_mode_shell_up_key_binding = "host"
 enter_accept = false
+daemon.enabled = true
 
 [sync]
 records = true

--- a/home/dotfiles/atuin.toml
+++ b/home/dotfiles/atuin.toml
@@ -5,5 +5,8 @@ filter_mode_shell_up_key_binding = "host"
 enter_accept = false
 daemon.enabled = true
 
+[ai]
+enabled = true
+
 [sync]
 records = true

--- a/home/dotfiles/zsh/evals.zsh
+++ b/home/dotfiles/zsh/evals.zsh
@@ -1,4 +1,4 @@
-(( $+commands[atuin] )) && eval "$(atuin init zsh)"
+(( $+commands[atuin] )) && eval "$(atuin init zsh)" && eval "$(atuin ai init zsh)"
 # Initialize zoxide but only alias cd in truly interactive shells
 # This prevents errors in Claude Code and other non-interactive contexts
 if (( $+commands[zoxide] )); then

--- a/home/packages.nix
+++ b/home/packages.nix
@@ -16,7 +16,7 @@
 
       # CLI
       age
-      atuin
+      unstablePkgs.atuin
       bash
       btop
       coreutils-full


### PR DESCRIPTION
## Summary
- Pull atuin from `nixpkgs-unstable` (18.10.0 → 18.13.6) for all machines
- Enable daemon mode for in-memory nucleo search index
- Unlocks `atuin ai`, custom keybindings, PTY proxy

## Test plan
- [ ] Build home-manager config on rpi5
- [ ] Switch and verify `atuin --version` shows 18.13.6
- [ ] Test `atuin ai` feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)