### PR TITLE
chore: bump tiny-llm-gate to v0.3.5 (fix streaming tool calls)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1032,16 +1032,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1776790052,
-        "narHash": "sha256-QVc5fQSljzknH5RhMQ7U2WRy7WrYm9uAOcJYoAo5pYM=",
+        "lastModified": 1776806647,
+        "narHash": "sha256-aZhhH/y2bHf7MyK5GyABQq9umGyJsPUPEs7r8t8Tsxk=",
         "owner": "nSimonFR",
         "repo": "tiny-llm-gate",
-        "rev": "feff1928522cd0e8a6759a840ec1134c3285634b",
+        "rev": "97c46153a22c82043c9c563975d8ea6fe0fb43d4",
         "type": "github"
       },
       "original": {
         "owner": "nSimonFR",
-        "ref": "v0.3.4",
+        "ref": "v0.3.5",
         "repo": "tiny-llm-gate",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1032,16 +1032,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1776806647,
-        "narHash": "sha256-aZhhH/y2bHf7MyK5GyABQq9umGyJsPUPEs7r8t8Tsxk=",
+        "lastModified": 1776807928,
+        "narHash": "sha256-hicYfvxc9LJ5NKvqjN82AUc+krDVNsP3oF2LZRI6P2k=",
         "owner": "nSimonFR",
         "repo": "tiny-llm-gate",
-        "rev": "97c46153a22c82043c9c563975d8ea6fe0fb43d4",
+        "rev": "925b5d424c276c3341496f2b4c3f526bf32f0fb9",
         "type": "github"
       },
       "original": {
         "owner": "nSimonFR",
-        "ref": "v0.3.5",
+        "ref": "v0.3.6",
         "repo": "tiny-llm-gate",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1032,16 +1032,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1776807928,
-        "narHash": "sha256-hicYfvxc9LJ5NKvqjN82AUc+krDVNsP3oF2LZRI6P2k=",
+        "lastModified": 1776845679,
+        "narHash": "sha256-PTH766qcsEQWoJdDHCPHA3Qjr+5B/hI6VHcAPO/X8wo=",
         "owner": "nSimonFR",
         "repo": "tiny-llm-gate",
-        "rev": "925b5d424c276c3341496f2b4c3f526bf32f0fb9",
+        "rev": "1ca4fa936954cc5b99a7fbeb25fd3a073d6f5ac4",
         "type": "github"
       },
       "original": {
         "owner": "nSimonFR",
-        "ref": "v0.3.6",
+        "ref": "v0.3.7",
         "repo": "tiny-llm-gate",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -84,7 +84,7 @@
     # tiny-llm-gate: memory-conscious replacement for LiteLLM.
     # Pinned to a tag; bump the ref to roll forward.
     tiny-llm-gate = {
-      url = "github:nSimonFR/tiny-llm-gate/v0.3.6";
+      url = "github:nSimonFR/tiny-llm-gate/v0.3.7";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };

--- a/flake.nix
+++ b/flake.nix
@@ -84,7 +84,7 @@
     # tiny-llm-gate: memory-conscious replacement for LiteLLM.
     # Pinned to a tag; bump the ref to roll forward.
     tiny-llm-gate = {
-      url = "github:nSimonFR/tiny-llm-gate/v0.3.4";
+      url = "github:nSimonFR/tiny-llm-gate/v0.3.5";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };

--- a/flake.nix
+++ b/flake.nix
@@ -84,7 +84,7 @@
     # tiny-llm-gate: memory-conscious replacement for LiteLLM.
     # Pinned to a tag; bump the ref to roll forward.
     tiny-llm-gate = {
-      url = "github:nSimonFR/tiny-llm-gate/v0.3.5";
+      url = "github:nSimonFR/tiny-llm-gate/v0.3.6";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };


### PR DESCRIPTION
## Summary
- Bumps tiny-llm-gate from v0.3.4 to v0.3.5
- Fixes AFFiNE local AI leaking raw `{"type":"tool-call",...}` JSON into chat when the LLM uses tools (e.g. `doc_semantic_search`)
- Root cause: OpenAI streaming sends tool calls incrementally (name first, args in fragments); the old code emitted incomplete Gemini FunctionCall parts with empty args, causing Vercel AI SDK to render raw protocol objects

## Test plan
- [x] NixOS rebuild succeeded, `tiny-llm-gate.service` restarted
- [ ] Trigger AFFiNE AI tool use (e.g. ask about a doc) and verify no raw JSON leaks into chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)