### PR TITLE
perf: add RAM limits and tuning for services on 4GB RPi5

### DIFF
--- a/rpi5/affine.nix
+++ b/rpi5/affine.nix
@@ -204,6 +204,9 @@ in
       AFFINE_STORAGE_PATH = "${dataDir}/storage";
       PRISMA_QUERY_ENGINE_LIBRARY = "${appDir}/node_modules/@prisma/engines/libquery_engine-linux-arm64-openssl-3.0.x.so.node";
       PRISMA_SCHEMA_ENGINE_BINARY = "${appDir}/node_modules/@prisma/engines/schema-engine-linux-arm64-openssl-3.0.x";
+      # RAM optimizations for single-user instance on 4GB RPi5
+      NODE_OPTIONS = "--max-old-space-size=192";
+      MALLOC_ARENA_MAX = "2";
     };
     # Inject Google Calendar OAuth credentials from agenix into config.json
     script = ''
@@ -247,6 +250,7 @@ in
       Restart = "on-failure";
       RestartSec = "5s";
       PrivateUsers = lib.mkForce false;
+      MemoryMax = "384M";
     };
   };
 

--- a/rpi5/blocky.nix
+++ b/rpi5/blocky.nix
@@ -103,13 +103,16 @@
       caching = {
         minTime = "5m";
         maxTime = "30m";
-        maxItemsCount = 0; # unlimited
+        maxItemsCount = 10000; # bound cache memory (~4 KB/entry ≈ 40 MB cap)
         prefetching = true;
         prefetchExpires = "2h";
         prefetchThreshold = 5;
       };
     };
   };
+
+  # ── Systemd hardening ───────────────────────────────────────────────
+  systemd.services.blocky.serviceConfig.MemoryMax = "128M";
 
   # ── Firewall: allow DNS from the local network ─────────────────────
   networking.firewall = {

--- a/rpi5/databases.nix
+++ b/rpi5/databases.nix
@@ -29,6 +29,15 @@ in
     enable = true;
     bind   = redisHost;
     port   = redisPort;
+
+    # ── Memory tuning for 4 GiB RPi5 ──────────────────────────────────
+    # Shared by AFFiNE (DB 0), Immich (DB 1), Dawarich (DB 3).
+    # Cap memory to prevent unbounded growth; LRU evicts least-recently-used
+    # keys across all DBs when the limit is hit.
+    settings = {
+      maxmemory          = "128mb";
+      maxmemory-policy   = "allkeys-lru";
+    };
   };
 
   # Export shared connection values so other modules reference them instead of hardcoding.

--- a/rpi5/home-assistant.nix
+++ b/rpi5/home-assistant.nix
@@ -124,6 +124,14 @@ in
     fi
   '';
 
+  # ── Home Assistant RAM optimizations (RPi5 4 GB) ──────────────────────
+  # Python/glibc creates one malloc arena per core by default; on a 4-core
+  # RPi5 that wastes ~64 MB of virtual address space.  Cap at 2 arenas.
+  systemd.services.home-assistant = {
+    environment.MALLOC_ARENA_MAX = "2";
+    serviceConfig.MemoryMax = "256M";
+  };
+
   # ── ha-linky: native systemd service ──────────────────────────────────
   users.users.ha-linky = {
     isSystemUser = true;

--- a/rpi5/immich.nix
+++ b/rpi5/immich.nix
@@ -22,9 +22,13 @@
   systemd.services.immich-server = {
     after = [ "mnt-data.mount" ];
     wants = [ "mnt-data.mount" ];
-    serviceConfig.ExecStartPre = [
-      "+${pkgs.coreutils}/bin/chown immich:immich /mnt/data/immich"
-    ];
+    environment.MALLOC_ARENA_MAX = "2";
+    serviceConfig = {
+      ExecStartPre = [
+        "+${pkgs.coreutils}/bin/chown immich:immich /mnt/data/immich"
+      ];
+      MemoryMax = "512M";
+    };
   };
 
   systemd.tmpfiles.rules = [
@@ -46,8 +50,12 @@
     wantedBy = [ "local-fs.target" ];
   }) [ "thumbs" "encoded-video" "profile" "backups" ];
 
-  systemd.services.immich-machine-learning.environment = {
-    MACHINE_LEARNING_MODEL_TTL = "60";
-    MACHINE_LEARNING_REQUEST_THREADS = "2";
+  systemd.services.immich-machine-learning = {
+    environment = {
+      MACHINE_LEARNING_MODEL_TTL = "60";
+      MACHINE_LEARNING_REQUEST_THREADS = "1";
+      MALLOC_ARENA_MAX = "2";
+    };
+    serviceConfig.MemoryMax = "1G";
   };
 }


### PR DESCRIPTION
## Summary
- **AFFiNE**: Node.js heap cap (`--max-old-space-size=192`), `MALLOC_ARENA_MAX=2`, `MemoryMax=384M`
- **Immich**: `MemoryMax` per service (server 512M, ML 1G), ML threads 2→1, `MALLOC_ARENA_MAX=2`
- **Home Assistant**: `MALLOC_ARENA_MAX=2`, `MemoryMax=256M`
- **Blocky**: DNS cache cap 10k entries (was unlimited), `MemoryMax=128M`
- **Redis**: `maxmemory=128mb` with `allkeys-lru` eviction (was unbounded)

Services already well-tuned (no changes): Sure, Dawarich, Forgejo, PostgreSQL.

## Test plan
- [x] `nixos-rebuild switch` succeeded
- [x] All 6 services active after rebuild
- [x] HTTP health checks pass (HA 200, Sure 302, AFFiNE 200, Immich 200)
- [x] Blocky DNS resolving after blocklist load
- [x] Redis `maxmemory` confirmed at 128MB
- [x] Swap usage dropped ~300 MiB immediately after rebuild
- [ ] 1-hour RAM comparison pending (monitoring scheduled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)