### PR TITLE
feat: auto-trigger Sure sync on Sumeria token refresh

### DIFF
--- a/rpi5/sumeria-mitm.nix
+++ b/rpi5/sumeria-mitm.nix
@@ -45,11 +45,21 @@ let
                     "public_token": h["public_token"],
                     "access_token": h["access-token"],
                 }
+                # Only write if tokens actually changed — avoids spamming the
+                # PathModified watcher (and downstream Sure sync) on every request
+                try:
+                    with open(TOKEN_FILE, "r") as f:
+                        existing = json.load(f)
+                    if existing == tokens:
+                        print(f"[sumeria-mitm] tokens unchanged, skipping write")
+                        return
+                except (FileNotFoundError, json.JSONDecodeError):
+                    pass  # first run or corrupt file — write anyway
                 tmp = TOKEN_FILE + ".tmp"
                 with open(tmp, "w") as f:
                     json.dump(tokens, f, indent=2)
                 os.rename(tmp, TOKEN_FILE)
-                print(f"[sumeria-mitm] tokens written to {TOKEN_FILE}")
+                print(f"[sumeria-mitm] NEW tokens written to {TOKEN_FILE}")
 
     addons = [SumeriaTokenExtractor()]
   '';

--- a/rpi5/sure.nix
+++ b/rpi5/sure.nix
@@ -103,4 +103,41 @@ in
     requires = [ "sure-pg-setup.service" ];
   };
 
+  # ── Sumeria token → Sure sync trigger ──────────────────────────────────────
+  # When the MITM captures new Sumeria tokens (file changes), automatically
+  # trigger a Sure sync so balances/transactions update without manual action.
+  # The MITM addon only writes on actual token change (not every request),
+  # so this fires at most once per ~3h token rotation.
+  systemd.paths.sumeria-sync-trigger = {
+    description = "Watch Sumeria token file for changes";
+    wantedBy    = [ "multi-user.target" ];
+    pathConfig.PathModified = config.services.sumeria-mitm.tokenFile;
+  };
+
+  systemd.services.sumeria-sync-trigger = {
+    description = "Trigger Sure sync after Sumeria token refresh";
+    after       = [ "sure-web.service" "sure-worker.service" ];
+    requires    = [ "sure-worker.service" ];
+    serviceConfig = {
+      Type             = "oneshot";
+      User             = config.services.sure.user;
+      Group            = config.services.sure.group;
+      WorkingDirectory = "${config.services.sure.package}/share/sure";
+      EnvironmentFile  = config.services.sure.environmentFile;
+    };
+    environment = {
+      RAILS_ENV          = "production";
+      DATABASE_URL       = config.services.sure.databaseUrl;
+      REDIS_URL          = config.services.sure.redisUrl;
+      BUNDLE_FORCE_RUBY_PLATFORM = "1";
+      HOME               = config.services.sure.dataDir;
+    };
+    script = ''
+      echo "[sumeria-sync] Sumeria tokens changed, triggering Sure sync..."
+      ${config.services.sure.package}/bin/sure-rails runner \
+        'LunchflowItem.find_each { |item| item.sync_later }'
+      echo "[sumeria-sync] Sync jobs queued"
+    '';
+  };
+
 }


### PR DESCRIPTION
## Summary
- MITM token extractor now compares tokens before writing — only writes on actual change (not every intercepted request)
- New `sumeria-sync-trigger.path` systemd unit watches the token file via `PathModified`
- When tokens change, a oneshot service runs `sure-rails runner` to queue Sidekiq sync jobs for all LunchflowItems
- Fires at most once per ~3h token rotation; Sure's `sync_later` also deduplicates within 5-min windows

## Test plan
- [ ] `nixos-rebuild switch` succeeds
- [ ] `systemctl status sumeria-sync-trigger.path` shows active/waiting
- [ ] Open Sumeria app with exit node → verify tokens written + sync triggered
- [ ] Open Sumeria again with same tokens → verify no write / no sync spam

🤖 Generated with [Claude Code](https://claude.com/claude-code)