### PR TITLE
fix(home): silence ssh + system deprecation warnings, bump tiny-llm-gate

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1032,16 +1032,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1776861502,
-        "narHash": "sha256-aTJswupmNjajN9U4bOe5SXSyV3TdP7JVhbES0kuicGo=",
+        "lastModified": 1777044338,
+        "narHash": "sha256-2M3X2vvhwgUnfXbSl9UcRDWgWccWE7uWSU0mQatuOCI=",
         "owner": "nSimonFR",
         "repo": "tiny-llm-gate",
-        "rev": "1e59539c4f8d9b93762a5d89ab4f30719f78b495",
+        "rev": "941c69aae205d2f615221d47e285cba8051ffd84",
         "type": "github"
       },
       "original": {
         "owner": "nSimonFR",
-        "ref": "v0.3.8",
+        "ref": "v0.7.0",
         "repo": "tiny-llm-gate",
         "type": "github"
       }

--- a/home/packages.nix
+++ b/home/packages.nix
@@ -79,7 +79,7 @@
       zsh
 
       # LLM-to-hardware matching CLI
-      inputs.llmfit.packages.${pkgs.system}.default
+      inputs.llmfit.packages.${pkgs.stdenv.hostPlatform.system}.default
 
       # Anthropic→Ollama proxy (used by the claude-local alias)
       pkgs.litellm

--- a/home/ssh.nix
+++ b/home/ssh.nix
@@ -2,6 +2,7 @@
 {
   programs.ssh = {
     enable = true;
+    enableDefaultConfig = false;
     matchBlocks = {
       "*" = {
         forwardAgent = true;

--- a/macos/applications-patch.nix
+++ b/macos/applications-patch.nix
@@ -5,7 +5,7 @@ let
     paths = config.home.packages;
     pathsToLink = [ "/Applications" ];
   };
-  mac-app-util = inputs.mac-app-util.packages.${pkgs.stdenv.system}.default;
+  mac-app-util = inputs.mac-app-util.packages.${pkgs.stdenv.hostPlatform.system}.default;
 in
 {
   # Home-manager does not link installed applications to the user environment. This means apps will not show up


### PR DESCRIPTION
## Summary
- `programs.ssh`: opt out of removed defaults via `enableDefaultConfig = false`
- `pkgs.system` / `pkgs.stdenv.system` → `pkgs.stdenv.hostPlatform.system`
- tiny-llm-gate input: v0.3.8 → v0.7.0 (auto-bumped during home-manager rebuild)

## Test plan
- [x] `home-manager switch --flake .#"nsimon@rpi5"` runs clean (no `programs.ssh` or `system` rename warnings)
- [ ] `nixos-rebuild switch --flake .#rpi5` succeeds with the new tiny-llm-gate rev

🤖 Generated with [Claude Code](https://claude.com/claude-code)