### PR TITLE
fix(tiny-llm-gate): break systemd ordering cycle with affine

### DIFF
--- a/rpi5/tiny-llm-gate.nix
+++ b/rpi5/tiny-llm-gate.nix
@@ -153,11 +153,18 @@ in
     };
   };
 
-  # Starts after codex-proxy and affine so upstreams are available, and
-  # after claude-oauth-extract so /run/claude-oauth/token exists before the
-  # Anthropic handler validates the token file at startup.
+  # Starts after codex-proxy and claude-oauth-extract so /run/claude-oauth/token
+  # exists before the Anthropic handler validates the token file at startup.
+  #
+  # Do NOT order after affine.service / affine-mcp.service: affine.service is
+  # itself ordered after tiny-llm-gate.service (AFFiNE's copilot calls into
+  # this gateway), and affine-mcp.service is ordered after affine.service —
+  # adding the reverse edges here forms an unbreakable systemd ordering cycle
+  # that leaves all three services dead at boot. The MCP bridge routes are
+  # static config: tiny-llm-gate registers them at startup and proxies
+  # lazily, so upstream readiness is not a startup-time requirement.
   systemd.services.tiny-llm-gate = {
-    after = [ "network.target" "openai-codex-proxy.service" "affine.service" "affine-mcp.service" "claude-oauth-extract.service" ];
-    wants = [ "openai-codex-proxy.service" "affine-mcp.service" "claude-oauth-extract.service" ];
+    after = [ "network.target" "openai-codex-proxy.service" "claude-oauth-extract.service" ];
+    wants = [ "openai-codex-proxy.service" "claude-oauth-extract.service" ];
   };
 }


### PR DESCRIPTION
## Summary
- tiny-llm-gate's `after` listed `affine.service` and `affine-mcp.service` so upstreams would be ready at first request, but those services are themselves ordered after tiny-llm-gate (AFFiNE's copilot calls into this gateway). That forms a cycle systemd cannot break, leaving **all three services dead** after any stop/start (e.g. nixos-rebuild switch).
- Drop the affine entries from `after` + `wants`. The MCP bridge routes are static config — tiny-llm-gate registers them at startup and proxies lazily, so upstream readiness isn't a startup-time requirement.

Logs from rpi5 (today's boot):
\`\`\`
tiny-llm-gate.service: Found ordering cycle: affine.service/start after tiny-llm-gate.service/start - after affine.service
tiny-llm-gate.service: Unable to break cycle starting with tiny-llm-gate.service/start
\`\`\`

## Test plan
- [ ] \`nix eval .#nixosConfigurations.rpi5.config.systemd.services.tiny-llm-gate.after\` shows no \`affine*\` entries (verified locally)
- [ ] \`sudo nixos-rebuild switch --flake .#rpi5\` succeeds
- [ ] After rebuild, \`systemctl is-active tiny-llm-gate affine affine-mcp\` all return \`active\`
- [ ] No \"Found ordering cycle\" lines in journalctl post-rebuild
- [ ] Claude Code through Aperture (\`ANTHROPIC_BASE_URL=https://ai.gate-mintaka.ts.net\`) still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)