### PR TITLE
fix(affine): re-patch Prisma rpath on rebuild — survive nix GC

### DIFF
--- a/rpi5/affine.nix
+++ b/rpi5/affine.nix
@@ -150,10 +150,35 @@ in
   };
 
   # ── Prisma migrations ─────────────────────────────────────────────────
-  systemd.services.affine-migrate = {
-    description = "AFFiNE database migrations";
+  # Re-patch the Prisma binaries' rpaths to the current openssl_3 / glibc /
+  # cc.cc.lib store paths. The AFFiNE Docker image's prisma binaries are
+  # patched once at install time by the `affine-update` script, but those
+  # store paths get garbage-collected, leaving runtime lookups failing with
+  # `libssl.so.3 not found` / `Schema engine error`. Re-patching on every
+  # rebuild makes the binaries GC-safe without re-fetching the image.
+  systemd.services.affine-prisma-patch = {
+    description = "Re-patch AFFiNE Prisma binaries with current nixpkgs rpath";
     after = [ "affine-pg-setup.service" ];
     requires = [ "affine-pg-setup.service" ];
+    before = [ "affine-migrate.service" ];
+    wantedBy = [ "affine-migrate.service" ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+    };
+    script = ''
+      set -eu
+      QE="${appDir}/node_modules/@prisma/engines/libquery_engine-linux-arm64-openssl-3.0.x.so.node"
+      SE="${appDir}/node_modules/@prisma/engines/schema-engine-linux-arm64-openssl-3.0.x"
+      ${pkgs.patchelf}/bin/patchelf --set-rpath "${rpath}" "$QE"
+      ${pkgs.patchelf}/bin/patchelf --set-interpreter "${interpreter}" --set-rpath "${rpath}" "$SE"
+    '';
+  };
+
+  systemd.services.affine-migrate = {
+    description = "AFFiNE database migrations";
+    after = [ "affine-pg-setup.service" "affine-prisma-patch.service" ];
+    requires = [ "affine-pg-setup.service" "affine-prisma-patch.service" ];
     wantedBy = [ "multi-user.target" ];
     serviceConfig = {
       Type = "oneshot";
@@ -188,8 +213,8 @@ in
 
   systemd.services.affine = {
     description = "AFFiNE";
-    after = [ "network.target" "affine-migrate.service" "redis-shared.service" "tiny-llm-gate.service" ];
-    requires = [ "affine-migrate.service" ];
+    after = [ "network.target" "affine-migrate.service" "affine-prisma-patch.service" "redis-shared.service" "tiny-llm-gate.service" ];
+    requires = [ "affine-migrate.service" "affine-prisma-patch.service" ];
     wants = [ "redis-shared.service" ];
     wantedBy = [ "multi-user.target" ];
     environment = {


### PR DESCRIPTION
## Summary

- After PR #197 merge + `nixos-rebuild switch` today, `affine-migrate.service` started failing with the truncated `Error: Schema engine error:` — root cause: the prisma binaries' rpaths (set once by `affine-update`) pointed at openssl-3.0.19 / glibc store paths that have since been GC'd. `ldd schema-engine-linux-arm64-openssl-3.0.x` reports `libssl.so.3 => not found` / `libcrypto.so.3 => not found`. With migrate dead, `affine.service` was blocked too (Requires=).
- Add a new `affine-prisma-patch.service` oneshot that re-runs `patchelf --set-rpath "${rpath}"` against current nixpkgs (`openssl_3 + glibc + cc.cc.lib`) before `affine-migrate` and `affine`. The unit's script string embeds the rpath, so any nixpkgs bump that changes the openssl_3 store path makes the unit definition change → systemd restarts the patcher → binaries get re-bound. No image re-fetch needed.
- Tried `LD_LIBRARY_PATH = rpath` first; it bleeds into the parent Node.js process (built against openssl 3.4.x) and fails immediately with `version 'OPENSSL_3.4.0' not found` against the older 3.0.19 we'd be force-loading. Patching only the prisma binaries sidesteps that.

## Verification

Live on rpi5 after `nixos-rebuild switch`:

```
$ systemctl is-active affine-prisma-patch affine-migrate affine affine-mcp tiny-llm-gate
active
active
active
active
active
```

`affine-mcp.service` (the PR #197 sidecar) responds on 127.0.0.1:7021/mcp with the expected MCP protocol error to a non-initialize request.

## Test plan

- [ ] After next `nixpkgs` bump that rolls openssl_3, confirm `affine-prisma-patch.service` re-runs (script changes ⇒ unit restarts) and AFFiNE comes up clean without manual `affine-update`.
- [ ] In Claude Code: `/wiki-ingest <url>` end-to-end through tiny-llm-gate :4001/mcp/affine → DAWNCR0W :7021 → AFFiNE GraphQL :13010.

🤖 Generated with [Claude Code](https://claude.com/claude-code)