### PR TITLE
fix(claude-rc): bump session idle timeout from 2h to 24h

### DIFF
--- a/rpi5/claude-remote-control.nix
+++ b/rpi5/claude-remote-control.nix
@@ -35,9 +35,17 @@ let
   # Seconds of conversation inactivity before a bridge session is reaped.
   # Uses the conversation JSONL file mtime (updated on every user/assistant
   # message) — much more accurate than process age since a session can be
-  # idle but resumable. 2 hours means: if nobody has talked to this session
-  # for 2h, it's safe to reclaim.
-  maxInactivitySec = "7200"; # 2h
+  # idle but resumable.
+  #
+  # Tuning: JSONL mtime conflates "user is thinking / away for a while" with
+  # "session was orphaned by the mobile app and will never come back". With no
+  # cheap way to distinguish the two (heartbeat API still returns state=active
+  # for orphaned sessions — see anthropics/claude-code#28914 closed
+  # NOT_PLANNED), err on the side of preserving real work: 24h survives
+  # overnight pauses, lunch breaks, and weekend handoffs. Worst case for
+  # orphans: each holds ~70MB RSS + a worktree dir for up to a day. Bounded
+  # by maxSessions=8 in startScript, so ~560MB ceiling — fine on the rpi5.
+  maxInactivitySec = "86400"; # 24h
 
   stopScript = pkgs.writeShellScript "claude-remote-control-stop" ''
     # Send SIGTERM to the claude process inside tmux, giving it time


### PR DESCRIPTION
## Summary

- Bump `maxInactivitySec` in `rpi5/claude-remote-control.nix` from `7200` (2h) → `86400` (24h) so legitimately idle remote-control sessions survive overnight pauses, lunch breaks, and weekend handoffs.
- No code-path changes — same JSONL-mtime detection, just a larger threshold.

## Why not something smarter?

Tried log-based orphan detection (grep `[bridge:ws] sessionId=cse_*` from `/tmp/claude-rc-debug.log` for per-session silence). Empirically a quietly-idle but *bridge-attached* session can go **20+ minutes** without any WS traffic on the rpi5 — so any threshold short enough to reap genuine orphans within an acceptable window also risks killing real users who stepped away. Without a reliable per-session "is the mobile app still subscribed" signal — and with anthropics/claude-code#28914 closed `NOT_PLANNED` — the safest fix is to just be more patient about what counts as "idle".

## Tradeoff

Orphaned sessions (mobile app deleted them) now linger up to 24h instead of 2h before getting reaped. With `maxSessions=8` and ~70MB RSS each, that's a ~560MB worst-case ceiling on the rpi5. Acceptable.

## Test plan

- [x] `nix flake check` / `nixos-rebuild dry-build` succeeds with the new value
- [x] Cleanup script still parses correctly (built derivation runs without error against real `~/.claude/sessions/`)
- [ ] Deploy with `sudo nixos-rebuild switch` and verify next `claude-rc-session-cleanup` timer firing logs `inactive Xmin > 1440min` instead of `> 120min`
- [ ] Leave a session idle for >2h and confirm it survives

🤖 Generated with [Claude Code](https://claude.com/claude-code)