### PR TITLE
fix(tailscale-serve): unshare drive before reshare so path changes apply

### DIFF
--- a/rpi5/tailscale-serve.nix
+++ b/rpi5/tailscale-serve.nix
@@ -31,6 +31,10 @@ in
       # /mnt/data/cloud is now Nextcloud's home (config/ + data/); user files
       # live at <home>/data/<user>/files/. Share that path so clients see the
       # user's actual files, not Nextcloud markers/appdata.
+      # `drive share <name> <path>` silently no-ops if a share with the same
+      # name already exists at a different path — unshare first so path
+      # changes always take effect on rebuild.
+      ${ts} drive unshare cloud || true
       ${ts} drive share cloud /mnt/data/cloud/data/nsimon/files || true
     '';
     preStop = ''


### PR DESCRIPTION
## Summary
- `tailscale drive share <name> <path>` silently no-ops if a share already exists with that name at a different path
- After the Nextcloud datadir migration changed the share path from `/mnt/data/cloud` to `/mnt/data/cloud/data/nsimon/files`, the systemd unit re-ran on rebuild but the live share kept pointing at the old path — exposing Nextcloud's `config/`, `data/`, `appdata_*` internals to clients instead of the user's files
- Adds `tailscale drive unshare cloud || true` before the share line so future path changes always take effect

## Test plan
- [x] Verified manually on rpi5: `tailscale drive unshare cloud && tailscale drive share cloud /mnt/data/cloud/data/nsimon/files` fixed the live state
- [ ] After merge + rebuild: confirm `tailscale drive list` shows `/mnt/data/cloud/data/nsimon/files` after a fresh rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)