### PR TITLE
refactor(nextcloud): datadir to /mnt/data/nextcloud + bind /mnt/data/cloud

### DIFF
--- a/rpi5/nextcloud.nix
+++ b/rpi5/nextcloud.nix
@@ -1,7 +1,10 @@
 # nextcloud.nix — Nextcloud serving Files (replaces filebrowser) + Contacts +
-# Calendar + Tasks via DAV. Nextcloud's home is /mnt/data/cloud (the HDD); the
-# nixpkgs module places config at <home>/config/ and data at <home>/data/, so
-# user files live at /mnt/data/cloud/data/nsimon/files/{ADMINISTRATIVE,...}.
+# Calendar + Tasks via DAV. Nextcloud's home is /mnt/data/nextcloud (the HDD);
+# the nixpkgs module places config at <home>/config/ and data at <home>/data/,
+# so user files live at /mnt/data/nextcloud/data/nsimon/files/{ADMINISTRATIVE,
+# ...}. /mnt/data/cloud is a bind-mount of that user-files dir, exposing a
+# clean view (no Nextcloud config/, data/, appdata_* internals) to the
+# Tailscale Drive share defined in tailscale-serve.nix.
 # Calendars/addressbooks stay in PostgreSQL.
 #
 # Same shape as paperless.nix: shared system PostgreSQL + shared Redis,
@@ -14,10 +17,11 @@ let
   port = 8091;
   servePort = 8085; # external tailnet port (used in trusted_domains)
 
-  # Datadir on the data HDD (was filebrowser's root). Nextcloud manages this
-  # tree exclusively: per-user files at /mnt/data/cloud/<user>/files/, plus
-  # internal markers (.htaccess, .ocdata, appdata_*).
-  datadir = "/mnt/data/cloud";
+  # Datadir on the data HDD. Nextcloud manages this tree exclusively:
+  # per-user files at /mnt/data/nextcloud/data/<user>/files/, plus internal
+  # markers (.htaccess, .ocdata, appdata_*). /mnt/data/cloud is bind-mounted
+  # to this user's files dir below — see the systemd.mounts block.
+  datadir = "/mnt/data/nextcloud";
 
   # Shared Redis DB index. 0=AFFiNE, 1=Immich, 2=Sure, 3=Dawarich, 4=Paperless.
   redisDb = 5;
@@ -118,10 +122,10 @@ in
     # install assistant + integration_openai (not bundled with the package).
     appstoreEnable = true;
 
-    # Storage path on the data HDD (was filebrowser's root). The nixpkgs
-    # module treats datadir as Nextcloud's *home*: it creates
-    # /mnt/data/cloud/config/ (config.php) and /mnt/data/cloud/data/
-    # (.htaccess, .ncdata, appdata_*, per-user files at data/<user>/files/).
+    # Storage path on the data HDD. The nixpkgs module treats datadir as
+    # Nextcloud's *home*: it creates /mnt/data/nextcloud/config/ (config.php)
+    # and /mnt/data/nextcloud/data/ (.htaccess, .ncdata, appdata_*, per-user
+    # files at data/<user>/files/).
     inherit datadir;
 
     # First-boot install creates the admin and writes config.php. After that,
@@ -264,4 +268,28 @@ in
       done
     '';
   };
+
+  # ── Bind-mount /mnt/data/cloud → user-files dir ────────────────────────────
+  # Tailscale Drive shares /mnt/data/cloud (see tailscale-serve.nix). Bind-
+  # mounting the user-files dir there gives Drive clients a clean view of
+  # just the user's files — no config/, data/, appdata_* leaking out.
+  # Same shape as the SSD overlay in immich.nix: tmpfiles pre-creates the
+  # mountpoint, systemd.mounts wires the bind into local-fs.target.
+  systemd.tmpfiles.rules = [
+    # The datadir parent must be root-owned. The Nextcloud module's tmpfiles
+    # only manage <datadir>/config and <datadir>/data — when the parent is
+    # owned by a non-privileged user, systemd-tmpfiles refuses to apply the
+    # `L+ override.config.php` rule with "unsafe path transition", which
+    # silently leaves the symlink stale and breaks `occ` boot ("data dir
+    # invalid"). Owning the parent root:root removes the escalation.
+    "d /mnt/data/nextcloud 0755 root root -"
+    "d /mnt/data/cloud 0755 root root -"
+  ];
+  systemd.mounts = [{
+    where = "/mnt/data/cloud";
+    what  = "${datadir}/data/nsimon/files";
+    type  = "none";
+    options = "bind";
+    wantedBy = [ "local-fs.target" ];
+  }];
 }

--- a/rpi5/paperless.nix
+++ b/rpi5/paperless.nix
@@ -10,7 +10,7 @@ let
   # Bills / invoices drop-zone. Top-level folder inside the user's Nextcloud
   # files tree. The nixpkgs nextcloud module nests data inside the home as
   # `<home>/data/<user>/files/...`, hence the `/data/` segment.
-  consumeDir = "/mnt/data/cloud/data/nsimon/files/PAPERLESS";
+  consumeDir = "/mnt/data/nextcloud/data/nsimon/files/PAPERLESS";
 in
 {
   # ── PostgreSQL: paperless_production database + paperless_user ────────────
@@ -139,9 +139,9 @@ in
   systemd.services.paperless-consumer.serviceConfig.PrivateUsers    = lib.mkForce false;
   systemd.services.paperless-web.serviceConfig.PrivateUsers         = lib.mkForce false;
 
-  # The Nextcloud module creates /mnt/data/cloud and /mnt/data/cloud/data with
-  # mode 0750 (nextcloud:nextcloud), so the paperless user can't traverse them
-  # to reach the consume dir under <datadir>/data/nsimon/files/PAPERLESS.
+  # The Nextcloud module creates /mnt/data/nextcloud and /mnt/data/nextcloud/data
+  # with mode 0750 (nextcloud:nextcloud), so the paperless user can't traverse
+  # them to reach the consume dir under <datadir>/data/nsimon/files/PAPERLESS.
   # Group membership grants the missing x bit without loosening perms.
   users.users.paperless.extraGroups = [ "nextcloud" ];
 
@@ -150,12 +150,12 @@ in
   # can traverse (mode 0755). The leaf itself is paperless-owned so the
   # consumer can write/delete. tmpfiles is a no-op if the path already exists.
   systemd.tmpfiles.settings."10-paperless-consume" = {
-    "/mnt/data/cloud/data/nsimon".d = {
+    "/mnt/data/nextcloud/data/nsimon".d = {
       user  = "nextcloud";
       group = "nextcloud";
       mode  = "0755";
     };
-    "/mnt/data/cloud/data/nsimon/files".d = {
+    "/mnt/data/nextcloud/data/nsimon/files".d = {
       user  = "nextcloud";
       group = "nextcloud";
       mode  = "0755";

--- a/rpi5/tailscale-serve.nix
+++ b/rpi5/tailscale-serve.nix
@@ -28,10 +28,15 @@ in
       ${ts} serve reset || true
       ${serveUp}
       ${funnelUp}
-      # /mnt/data/cloud is now Nextcloud's home (config/ + data/); user files
-      # live at <home>/data/<user>/files/. Share that path so clients see the
-      # user's actual files, not Nextcloud markers/appdata.
-      ${ts} drive share cloud /mnt/data/cloud/data/nsimon/files || true
+      # /mnt/data/cloud is a bind-mount of Nextcloud's user-files dir
+      # (see rpi5/nextcloud.nix systemd.mounts) — share that so clients see
+      # a clean view of the user's files, not Nextcloud's config/, data/,
+      # appdata_* internals.
+      # `drive share <name> <path>` silently no-ops if a share with the
+      # same name already exists at a different path — unshare first so
+      # path changes always take effect on rebuild.
+      ${ts} drive unshare cloud || true
+      ${ts} drive share cloud /mnt/data/cloud || true
     '';
     preStop = ''
       ${serveDown}


### PR DESCRIPTION
## Summary
- Cleaner separation of Nextcloud's home from the user-files view exposed via Tailscale Drive:
  - Nextcloud's home (`config/`, `data/`, `appdata_*`) lives at `/mnt/data/nextcloud`
  - `/mnt/data/cloud` is now a bind-mount of `<datadir>/data/nsimon/files`
  - Tailscale Drive `cloud` shares `/mnt/data/cloud` — clients see only the user's files, no Nextcloud internals
- Rolls in the unshare-before-share fix from #207 so future TS Drive path changes are picked up on rebuild without manual intervention
- Adds an explicit tmpfiles rule for the datadir parent (root:root) — without it, `systemd-tmpfiles` silently skips the `L+ override.config.php` rule with "unsafe path transition" when the parent is non-root-owned, leaving the symlink stale and breaking `occ` boot

## One-time live migration (NOT in this PR — performed on rpi5)
1. Cleanup orphan debris at `/mnt/data/cloud/` root (empty ADMINISTRATIVE/, .DS_Store, AppleDouble forks, misplaced `TRUSK SLITE.zip`)
2. `mv /mnt/data/cloud /mnt/data/nextcloud`
3. `mkdir /mnt/data/cloud` (empty bind-mount target)
4. `chown root:root /mnt/data/nextcloud` (so tmpfiles can apply the override symlink)
5. `sed -i 's|/mnt/data/cloud/data|/mnt/data/nextcloud/data|' /mnt/data/nextcloud/config/config.php`
6. `UPDATE oc_storages SET id = 'local::/mnt/data/nextcloud/data/' WHERE id = 'local::/mnt/data/cloud/data/';`
7. `nixos-rebuild switch` — bind mount + new tailscale share path activate

## Test plan
- [x] `mount | grep /mnt/data/cloud` shows the bind active
- [x] `sudo ls /mnt/data/cloud` lists user folders (ADMINISTRATIVE, BACKUPS, DOCUMENTS, PAPERLESS, PHOTOS, Recipes)
- [x] `tailscale drive list` shows `cloud /mnt/data/cloud root`
- [x] Nextcloud web UI returns 302 on `/`
- [x] `sudo nextcloud-occ status` reports installed/version OK
- [x] Paperless can traverse to `/mnt/data/nextcloud/data/nsimon/files/PAPERLESS`
- [x] `oc_storages.numeric_id=3` row migrated to `local::/mnt/data/nextcloud/data/`
- [x] `config.php` `datadirectory` updated, `passwordsalt`/`secret`/`instanceid` preserved (no salt rewrite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)