### PR TITLE
feat(rpi5): pi-mobile remote-control bridge service

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,7 +8,7 @@
           "ragenix",
           "nixpkgs"
         ],
-        "systems": "systems_6"
+        "systems": "systems_7"
       },
       "locked": {
         "lastModified": 1761656077,
@@ -65,6 +65,33 @@
         "type": "github"
       }
     },
+    "blueprint_2": {
+      "inputs": {
+        "nixpkgs": [
+          "pi-mobile",
+          "llm-agents",
+          "nixpkgs"
+        ],
+        "systems": [
+          "pi-mobile",
+          "llm-agents",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776249299,
+        "narHash": "sha256-Dt9t1TGRmJFc0xVYhttNBD6QsAgHOHCArqGa0AyjrJY=",
+        "owner": "numtide",
+        "repo": "blueprint",
+        "rev": "56131e8628f173d24a27f6d27c0215eff57e40dd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "blueprint",
+        "type": "github"
+      }
+    },
     "bun2nix": {
       "inputs": {
         "flake-parts": [
@@ -91,6 +118,45 @@
         "owner": "nix-community",
         "repo": "bun2nix",
         "rev": "6ef9f144616eedea90b364bb408ef2e1de7b310a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "staging-2.1.0",
+        "repo": "bun2nix",
+        "type": "github"
+      }
+    },
+    "bun2nix_2": {
+      "inputs": {
+        "flake-parts": [
+          "pi-mobile",
+          "llm-agents",
+          "flake-parts"
+        ],
+        "import-tree": "import-tree_2",
+        "nixpkgs": [
+          "pi-mobile",
+          "llm-agents",
+          "nixpkgs"
+        ],
+        "systems": [
+          "pi-mobile",
+          "llm-agents",
+          "systems"
+        ],
+        "treefmt-nix": [
+          "pi-mobile",
+          "llm-agents",
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777322186,
+        "narHash": "sha256-CFlRnym0RphrTymMUg7PfQgfdYdMd6BnMZQJhlwv0fI=",
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "rev": "8985e47786dd0bfa95b7c795f12aeafadd328eb8",
         "type": "github"
       },
       "original": {
@@ -325,6 +391,28 @@
     "flake-parts_5": {
       "inputs": {
         "nixpkgs-lib": [
+          "pi-mobile",
+          "llm-agents",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_6": {
+      "inputs": {
+        "nixpkgs-lib": [
           "sure-nix",
           "nixpkgs"
         ]
@@ -383,7 +471,7 @@
     },
     "flake-utils_3": {
       "inputs": {
-        "systems": "systems_7"
+        "systems": "systems_8"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -401,7 +489,7 @@
     },
     "flake-utils_4": {
       "inputs": {
-        "systems": "systems_8"
+        "systems": "systems_9"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -576,6 +664,21 @@
         "type": "github"
       }
     },
+    "import-tree_2": {
+      "locked": {
+        "lastModified": 1773693634,
+        "narHash": "sha256-BtZ2dtkBdSUnFPPFc+n0kcMbgaTxzFNPv2iaO326Ffg=",
+        "owner": "vic",
+        "repo": "import-tree",
+        "rev": "c41e7d58045f9057880b0d85e1152d6a4430dbf1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "vic",
+        "repo": "import-tree",
+        "type": "github"
+      }
+    },
     "llm-agents": {
       "inputs": {
         "blueprint": "blueprint",
@@ -593,6 +696,32 @@
         "owner": "numtide",
         "repo": "llm-agents.nix",
         "rev": "c8f7c7882804510f2b807021cac0a69c1aeb4829",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "llm-agents.nix",
+        "type": "github"
+      }
+    },
+    "llm-agents_2": {
+      "inputs": {
+        "blueprint": "blueprint_2",
+        "bun2nix": "bun2nix_2",
+        "flake-parts": "flake-parts_5",
+        "nixpkgs": [
+          "pi-mobile",
+          "nixpkgs"
+        ],
+        "systems": "systems_6",
+        "treefmt-nix": "treefmt-nix_5"
+      },
+      "locked": {
+        "lastModified": 1777354680,
+        "narHash": "sha256-jtMZ7U79JYGoE8NYIu8Y4bNr+EoQW5i6zMP6Mig7tCU=",
+        "owner": "numtide",
+        "repo": "llm-agents.nix",
+        "rev": "efa749415e2ee5015db3fda1d3d6d7484d8aa64c",
         "type": "github"
       },
       "original": {
@@ -935,6 +1064,38 @@
         "type": "github"
       }
     },
+    "nixpkgs_8": {
+      "locked": {
+        "lastModified": 1776877367,
+        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pi-mobile": {
+      "inputs": {
+        "llm-agents": "llm-agents_2",
+        "nixpkgs": "nixpkgs_8"
+      },
+      "locked": {
+        "lastModified": 1777373992,
+        "narHash": "sha256-QelzGngStvbz+gtWQInVKQ01LT1zXa5NBeTQ+rpOwfc=",
+        "path": "/home/nsimon/pi-mobile",
+        "type": "path"
+      },
+      "original": {
+        "path": "/home/nsimon/pi-mobile",
+        "type": "path"
+      }
+    },
     "picoclaw-src": {
       "flake": false,
       "locked": {
@@ -992,6 +1153,7 @@
         "nixos-raspberrypi": "nixos-raspberrypi",
         "nixpkgs": "nixpkgs_7",
         "nixpkgs-unstable": "nixpkgs-unstable",
+        "pi-mobile": "pi-mobile",
         "picoclaw-src": "picoclaw-src",
         "ragenix": "ragenix",
         "sure-nix": "sure-nix",
@@ -1022,7 +1184,7 @@
     },
     "sure-nix": {
       "inputs": {
-        "flake-parts": "flake-parts_5",
+        "flake-parts": "flake-parts_6",
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -1161,6 +1323,21 @@
         "type": "github"
       }
     },
+    "systems_9": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "tiny-llm-gate": {
       "inputs": {
         "flake-utils": "flake-utils_4",
@@ -1244,6 +1421,28 @@
       "inputs": {
         "nixpkgs": [
           "nix-citizen",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_5": {
+      "inputs": {
+        "nixpkgs": [
+          "pi-mobile",
+          "llm-agents",
           "nixpkgs"
         ]
       },

--- a/flake.lock
+++ b/flake.lock
@@ -1086,14 +1086,17 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1777373992,
-        "narHash": "sha256-QelzGngStvbz+gtWQInVKQ01LT1zXa5NBeTQ+rpOwfc=",
-        "path": "/home/nsimon/pi-mobile",
-        "type": "path"
+        "lastModified": 1777375531,
+        "narHash": "sha256-pt76ZEon4CFs6h58o2j2pSsxaFrmd9me6bG2uGBmxWM=",
+        "owner": "nSimonFR",
+        "repo": "pi-mobile",
+        "rev": "9b83d37d9032961e1435676ea2ab633be59a9409",
+        "type": "github"
       },
       "original": {
-        "path": "/home/nsimon/pi-mobile",
-        "type": "path"
+        "owner": "nSimonFR",
+        "repo": "pi-mobile",
+        "type": "github"
       }
     },
     "picoclaw-src": {

--- a/flake.nix
+++ b/flake.nix
@@ -65,6 +65,12 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    # Local checkout — switch to `github:nSimonFR/pi-mobile` after first push.
+    # NOTE: do NOT `inputs.nixpkgs.follows = "nixpkgs"` here — pi-mobile's
+    # llm-agents.nix sibling packages (notably `apm`) need nixpkgs-unstable's
+    # buildPythonApplication API and break on release-25.11.
+    pi-mobile.url = "path:/home/nsimon/pi-mobile";
+
     llmfit = {
       url = "github:AlexsJones/llmfit";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -170,6 +176,7 @@
           inputs.home-manager.nixosModules.home-manager
           inputs.sure-nix.nixosModules.sure
           inputs.for-sure.nixosModules.default
+          inputs.pi-mobile.nixosModules.pi-mobile
           {
             home-manager = {
               useGlobalPkgs = true;

--- a/flake.nix
+++ b/flake.nix
@@ -65,11 +65,10 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    # Local checkout — switch to `github:nSimonFR/pi-mobile` after first push.
     # NOTE: do NOT `inputs.nixpkgs.follows = "nixpkgs"` here — pi-mobile's
     # llm-agents.nix sibling packages (notably `apm`) need nixpkgs-unstable's
     # buildPythonApplication API and break on release-25.11.
-    pi-mobile.url = "path:/home/nsimon/pi-mobile";
+    pi-mobile.url = "github:nSimonFR/pi-mobile";
 
     llmfit = {
       url = "github:AlexsJones/llmfit";

--- a/rpi5/configuration.nix
+++ b/rpi5/configuration.nix
@@ -127,6 +127,7 @@ in
     ./tiny-llm-gate.nix
     ./aperture-sync.nix
     ./claude-remote-control.nix
+    ./pi-mobile.nix
     ./open-webui.nix
     ./homepage.nix
     ./backups.nix

--- a/rpi5/pi-mobile.nix
+++ b/rpi5/pi-mobile.nix
@@ -1,0 +1,12 @@
+{ username, ... }:
+{
+  # WS bridge onto a single `pi --mode rpc` process, with a permission-gate
+  # extension that surfaces every tool call as an extension_ui_request the
+  # mobile client must approve. Loopback only — exposed on the tailnet via
+  # services-registry.nix entry (port 4344 → 127.0.0.1:8341).
+  services.pi-mobile = {
+    enable = true;
+    port = 8341;
+    user = username;
+  };
+}

--- a/rpi5/services-registry.nix
+++ b/rpi5/services-registry.nix
@@ -63,6 +63,7 @@
     { port = 4001;  backend = "http://127.0.0.1:4001";  name = "tiny-llm-gate";  icon = "mdi-brain";          category = "Backend"; description = "LLM gateway (OpenAI + Gemini)"; }
     { port = 4040;  backend = "http://127.0.0.1:4040";  name = "Codex Proxy";    icon = "mdi-code-braces";    category = "Backend"; description = "ChatGPT OAuth proxy (token counts + tool_calls)"; }
     { port = 7020;  backend = "http://127.0.0.1:4001/mcp/affine"; name = "AFFiNE MCP"; icon = "mdi-api";       category = "Backend"; description = "AFFiNE MCP gateway (via tiny-llm-gate)"; }
+    { port = 4344;  backend = "http://127.0.0.1:8341"; name = "Pi Mobile";   icon = "mdi-cellphone-link"; category = "Backend"; description = "pi-coding-agent remote control bridge"; }
 
     # Infrastructure — not shown on dashboard
     { port = 8082;  backend = "http://127.0.0.1:8082";  name = "Homepage";       icon = "homepage.svg";       category = "Infrastructure"; description = "Service dashboard"; }


### PR DESCRIPTION
## Summary

Wires up the new [`nSimonFR/pi-mobile`](https://github.com/nSimonFR/pi-mobile) project as a flake input + systemd service on rpi5. Self-hosted equivalent of Claude Code Remote Control for `pi-coding-agent`.

- New flake input `pi-mobile` (`path:/home/nsimon/pi-mobile`, switching to GitHub URL once #1 lands). Cannot follow `nixpkgs` because a sibling `apm` package in `llm-agents.nix` needs `nixpkgs-unstable`'s `buildPythonApplication` API.
- `rpi5/pi-mobile.nix` enables `services.pi-mobile` on `127.0.0.1:8341`.
- `services-registry.nix` adds Tailscale Serve entry: `4344 → 127.0.0.1:8341` (Backend tier).

Live and verified: `pi-mobile.service` running, `wss://rpi5.<tailnet>.ts.net:4344/` returns real `get_state` responses from `pi` via WebSocket.

## Test plan

- [x] `nixos-rebuild switch` succeeded (clean activation, only `pi-mobile.service` and `nextcloud-update-db.service` started)
- [x] `systemctl status pi-mobile` → active, bun + pi child process running
- [x] Local WS round-trip: `ws://127.0.0.1:8341/` returns `get_state` from real pi
- [x] Tailnet HTTPS round-trip: `wss://rpi5.gate-mintaka.ts.net:4344/` returns same
- [ ] End-to-end with permission gate (prompt that triggers a tool) — manual, deferred

## Companion

Bridge code + tests + flake live in [nSimonFR/pi-mobile#1](https://github.com/nSimonFR/pi-mobile/pull/1). After both merge, this PR's flake input switches from `path:` to `github:nSimonFR/pi-mobile`.