### PR TITLE
chore(sure): drop Telegram alert on Sumeria token expiry

### DIFF
--- a/rpi5/sure.nix
+++ b/rpi5/sure.nix
@@ -1,4 +1,4 @@
-{ config, pkgs, lib, pgHost, pgPort, redisHost, redisPort, telegramChatId, apertureUrl, ... }:
+{ config, pkgs, lib, pgHost, pgPort, redisHost, redisPort, apertureUrl, ... }:
 let
   port = 13334; # internal port; Tailscale Serve exposes this as HTTPS :3333 on the tailnet
 
@@ -31,8 +31,6 @@ in
     apiKeyFile            = "/run/agenix/for-sure-api-key";
     swile.accountName     = "Swile";
     sumeria.tokenFile     = config.services.sumeria-mitm.tokenFile;
-    telegram.botTokenFile = "/run/agenix/telegram-bot-token";
-    telegram.chatId       = toString telegramChatId;
   };
 
 


### PR DESCRIPTION
## Summary
- Drop the `telegram.botTokenFile` / `telegram.chatId` wiring from `services.for-sure` in `rpi5/sure.nix`.
- Remove the now-unused `telegramChatId` from the module signature.

The for-sure connector emits a Telegram message on Sumeria 401/refresh failure via `notify.ts`. Both options default to `null` upstream and the connector short-circuits when `TELEGRAM_BOT_TOKEN_FILE` is unset, so no agenix/secret cleanup is required.

## Test plan
- [ ] `sudo nixos-rebuild switch --flake /home/nsimon/nic-os#rpi5 --max-jobs 1 -j 1` evaluates and activates cleanly
- [ ] `systemctl show for-sure.service -p Environment` no longer lists `TELEGRAM_BOT_TOKEN_FILE` / `TELEGRAM_CHAT_ID`
- [ ] Force a Sumeria 401 (e.g. invalidate the captured token) and confirm no Telegram message is sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)