### PR TITLE
fix(claude-code): use system rg to dodge jemalloc 16K-page abort

### DIFF
--- a/home/claude.nix
+++ b/home/claude.nix
@@ -14,8 +14,14 @@ let
   };
   claudeCodePkg = unstablePkgs.claude-code.overrideAttrs (old: {
     nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ pkgs.makeWrapper ];
+    # The vendored vendor/ripgrep/arm64-linux/rg in claude-code's npm package
+    # ships a jemalloc compiled for 4K pages and SIGABRTs on the rpi5's 16K-page
+    # kernel ("<jemalloc>: Unsupported system page size"). Force cli.js onto the
+    # system rg via USE_BUILTIN_RIPGREP=0 + PATH prefix.
     postFixup = (old.postFixup or "") + ''
       wrapProgram $out/bin/claude \
+        --prefix PATH : ${pkgs.ripgrep}/bin \
+        --set USE_BUILTIN_RIPGREP 0 \
         --set GIT_SSH_COMMAND "ssh -i ~/.ssh/ai_id_ed25519 -o IdentityAgent=none" \
         --set GIT_AUTHOR_NAME "nSimonFR-ai" \
         --set GIT_AUTHOR_EMAIL "265587706+nSimonFR-ai@users.noreply.github.com" \


### PR DESCRIPTION
## Summary
- The vendored `vendor/ripgrep/arm64-linux/rg` shipped inside `claude-code` 2.1.112 is built against jemalloc with `LG_PAGE=12` (4K pages) and aborts on every invocation under the rpi5's 16K-page aarch64 kernel: `<jemalloc>: Unsupported system page size` → SIGABRT (~200 entries in `coredumpctl` over a few hours, all spawned by `claude-remote-control.service`).
- `cli.js` already has a fallback: when `USE_BUILTIN_RIPGREP` is set to `0`/`false`/`no`/`off` it `which`-resolves `rg` from `$PATH` instead. So the override prepends `pkgs.ripgrep` onto `PATH` and pins the env in the `wrapProgram` call.

## Verification
A/B with the exact args the bridge invokes (`rg --files --hidden --follow --no-ignore --glob '*.md' /etc/claude-code/.claude/output-styles`):
| binary | exit | output |
|---|---|---|
| `pkgs.ripgrep` (system) | 2 | `IO error … No such file or directory` (clean error) |
| `vendor/ripgrep/arm64-linux/rg` (bundled) | 134 | `<jemalloc>: Unsupported system page size` (SIGABRT) |

The new wrapper at `/nix/store/0knm7…-claude-code-2.1.112/bin/claude` exports `USE_BUILTIN_RIPGREP=0` and `which rg` → `ripgrep-15.1.0/bin/rg`. `claude --version` runs cleanly.

## Test plan
- [x] `home-manager switch` succeeds; new claude-code derivation built
- [x] Wrapped binary exports `USE_BUILTIN_RIPGREP=0` and prepends `pkgs.ripgrep` onto `PATH`
- [x] System `rg` runs cleanly under the 16K-page kernel
- [ ] After merge: `sudo systemctl restart claude-remote-control.service` (will terminate any active bridge sessions); confirm no new `rg` SIGABRTs in `coredumpctl list --since "5 min ago"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)