### PR TITLE
fix(affine): bump heap 192→384MB to absorb bulk-write OOMs

### DIFF
--- a/rpi5/affine.nix
+++ b/rpi5/affine.nix
@@ -205,7 +205,9 @@ in
       PRISMA_QUERY_ENGINE_LIBRARY = "${appDir}/node_modules/@prisma/engines/libquery_engine-linux-arm64-openssl-3.0.x.so.node";
       PRISMA_SCHEMA_ENGINE_BINARY = "${appDir}/node_modules/@prisma/engines/schema-engine-linux-arm64-openssl-3.0.x";
       # RAM optimizations for single-user instance on 4GB RPi5
-      NODE_OPTIONS = "--max-old-space-size=192";
+      # 384MB: bulk doc-creation + parallel copilot.embedding.docs jobs OOM'd
+      # 11× at 192MB during slite import; 1× at 384MB. RSS settles ~580MB.
+      NODE_OPTIONS = "--max-old-space-size=384";
       MALLOC_ARENA_MAX = "2";
     };
     # Inject Google Calendar OAuth credentials from agenix into config.json


### PR DESCRIPTION
## Summary
- Raises AFFiNE V8 heap from 192MB → 384MB; observed 11× OOM at 192MB vs 1× at 384MB during 7074-doc slite import.
- 192MB starves bulk doc-creation + parallel `copilot.embedding.docs` jobs. RSS at 384MB settles ~580MB on the 4GB RPi5 — comfortably below pressure threshold given baseline ~3.5GB used.
- Already validated live via runtime systemd drop-in (`/run/systemd/system/affine.service.d/heap-override.conf`) — this PR persists it across reboots.

## Test plan
- [ ] `sudo nixos-rebuild switch --flake /home/nsimon/nic-os#rpi5 --max-jobs 1 -j 1` from main after merge
- [ ] Confirm `sudo systemctl show affine.service -p Environment | tr ' ' '\n' | grep max-old` reports `--max-old-space-size=384`
- [ ] Remove the runtime drop-in: `sudo rm /run/systemd/system/affine.service.d/heap-override.conf && sudo systemctl daemon-reload`
- [ ] Spot-check AFFiNE healthy: `curl -fsS http://localhost:13010/info`
- [ ] No new heap-limit aborts in `journalctl -u affine.service --since "1 hour ago" | grep -c "Reached heap limit"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)