### PR TITLE
fix(systemd): auto-restart user@ on failure to survive OOM

### DIFF
--- a/rpi5/configuration.nix
+++ b/rpi5/configuration.nix
@@ -366,4 +366,19 @@ in
   # Tailscale Serve + Funnel are now managed declaratively via TS_SERVE_CONFIG.
   # See tailscale-serve.nix.
 
+  # OOM cascade on 2026-05-01 09:36-09:39 killed user@1001 (no Restart= in the
+  # nixpkgs template), leaving every --user service (picoclaw / Telegram bot,
+  # gpg-agent, user dbus) dead until manually restarted. Auto-recover instead.
+  # StartLimitBurst caps respawns so a real memory leak doesn't loop forever.
+  systemd.services."user@" = {
+    serviceConfig = {
+      Restart = "on-failure";
+      RestartSec = "5s";
+    };
+    unitConfig = {
+      StartLimitIntervalSec = "5min";
+      StartLimitBurst = 3;
+    };
+  };
+
 }


### PR DESCRIPTION
## Summary

- OOM cascade on 2026-05-01 09:36–09:39 killed \`user@1001\` (nsimon's user manager). The nixpkgs \`user@.service\` template ships without \`Restart=\`, so it stayed \`failed (signal=KILL)\` indefinitely.
- Every lingering \`--user\` service died with it: picoclaw (Telegram bot), \`gpg-agent\`, user \`dbus-daemon\`. Bot was offline ~45 min before manual recovery.
- Adds \`Restart=on-failure\` + \`RestartSec=5s\` and a 3-burst-per-5-min cap so a future OOM kill self-heals without looping forever on a real memory leak.

## Trigger sequence (journalctl)
\`\`\`
09:36:50  open-webui invokes oom-killer
09:36:52  picoclaw killed
09:38:14  picoclaw killed (2nd) + gpg-agent
09:38:20  user dbus-daemon killed
09:39:13  picoclaw killed (3rd)
09:39:18  user@1001 systemd manager killed → Active: failed
\`\`\`

## Test plan

- [x] Recovery confirmed today: \`sudo systemctl start user@1001.service\` → picoclaw.service active.
- [ ] After rebuild: \`systemctl cat user@.service | grep -E 'Restart|StartLimit'\` shows the directives.
- [ ] After rebuild: \`sudo systemctl kill --signal=KILL user@1001.service\` and verify it auto-restarts within ~5 s and picoclaw comes back.
- [ ] Burst limit: 4 kills in 60 s lands in failed (not infinite respawn loop).

## Out of scope
- Memory ceilings on \`open-webui\` and \`immich-machine-learning\` (the actual cascade triggers) — separate sizing conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)