### PR TITLE
fix(monitoring): show killed process name in earlyoom Telegram alert

### DIFF
--- a/rpi5/monitoring.nix
+++ b/rpi5/monitoring.nix
@@ -136,9 +136,11 @@ $FAILURES"
           RSS=$(${pkgs.gnused}/bin/sed -n 's/.*VmRSS \([0-9]\+ MiB\).*/\1/p' <<< "$KILL_LINE")
           CMD=$(${pkgs.gnused}/bin/sed -n 's/.*cmdline "\([^"]*\)".*/\1/p' <<< "$KILL_LINE" | ${pkgs.coreutils}/bin/cut -c1-160)
 
-          MSG="<b>earlyoom killed a process on rpi5</b>"
-          [ -n "$PROC" ] && MSG="$MSG
-- process: <code>$PROC</code>"
+          if [ -n "$PROC" ]; then
+            MSG="<b>earlyoom killed <code>$PROC</code> on rpi5</b>"
+          else
+            MSG="<b>earlyoom killed a process on rpi5</b>"
+          fi
           [ -n "$PID" ] && MSG="$MSG
 - pid: <code>$PID</code>"
           [ -n "$RSS" ] && MSG="$MSG


### PR DESCRIPTION
## Summary
- Promote the killed process name from a body line to the bold title in the earlyoom Telegram alert so it's visible in the notification preview without expanding the message.
- Title now reads `earlyoom killed <code>ffmpeg</code> on rpi5` instead of the generic `earlyoom killed a process on rpi5` followed by `- process: ffmpeg`.
- Falls back to the generic title when the regex fails to extract a name.

## Test plan
- [x] `nixos-rebuild switch` succeeds on rpi5
- [x] Rendered `/nix/store/...-earlyoom-alert` script contains the new title branch
- [ ] Next earlyoom kill produces a Telegram alert with the process name in the bold header

🤖 Generated with [Claude Code](https://claude.com/claude-code)