### PR TITLE
fix(affine): bypass Aperture for Gemini embeddings, point at tiny-llm-gate

### DIFF
--- a/rpi5/affine.nix
+++ b/rpi5/affine.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, pgHost, pgPort, redisHost, redisPort, tailnetFqdn, apertureUrl, ... }:
+{ pkgs, lib, pgHost, pgPort, redisHost, redisPort, tailnetFqdn, tinyLlmGateUrl, ... }:
 let
   version = "0.26.6";
   port = 13010;  # internal; Tailscale Serve proxies 3010 → 13010
@@ -42,6 +42,17 @@ let
       # factory to use Gemini, which does advertise embedding capability.
       # Chat, structured output (session title generation), AND embeddings
       # all route through the same Gemini provider.
+      #
+      # Why bypass Aperture: Aperture's compatibility flags only cover the
+      # chat-shaped actions (`gemini_generate_content` → :generateContent /
+      # :streamGenerateContent). It rejects `:embedContent` with HTTP 400
+      # `unsupported Gemini action: embedContent`, which @ai-sdk/google
+      # silently parses into an empty embedding array → AFFiNE's
+      # `CopilotEmbeddingJob` reports `Expected 1 embeddings, got 0` for
+      # every doc and the workspace embedding queue stalls. Until Aperture
+      # ships an embedding-shaped compatibility flag, we hit tiny-llm-gate
+      # directly. Trade-off: AFFiNE AI traffic (chat + embeddings) bypasses
+      # Aperture's observability layer.
       "providers.gemini" = {
         apiKey = "ollama";
         # baseURL MUST include /v1beta. AFFiNE's Gemini provider uses the
@@ -51,7 +62,7 @@ let
         # must end in `/v1beta` too — otherwise AFFiNE hits
         # http://127.0.0.1:4001/models/... which tiny-llm-gate's router
         # returns 404 for.
-        baseURL = "${apertureUrl}/v1beta";
+        baseURL = "${tinyLlmGateUrl}/v1beta";
       };
     };
   };


### PR DESCRIPTION
## Summary
- Aperture rejects Gemini `:embedContent` with HTTP 400 `unsupported Gemini action: embedContent` — its `gemini_generate_content` flag only covers chat-shaped actions. `@ai-sdk/google` silently turns that into an empty embedding array, AFFiNE reports `Expected 1 embeddings, got 0` per doc, and the workspace embedding queue stalled at **263/7537 (3.5%)**.
- Switch `affine.nix` copilot Gemini provider to `tinyLlmGateUrl` (`http://127.0.0.1:4001/v1beta`) — tiny-llm-gate fully implements `:embedContent` / `:batchEmbedContents`. Trade-off: AFFiNE AI traffic now bypasses Aperture's observability layer until Tailscale ships an embedding-shape compatibility flag.

## Caveat
AFFiNE persists copilot config in the `app_configs` Postgres table; `config.json` is only a first-boot seed. Existing deploys (i.e. this rpi5) need a manual `UPDATE app_configs ... WHERE id = 'copilot.providers.gemini'` + `affine.service` restart. Already applied here — queue went 263 → 1258 docs in ~2 minutes with zero errors. New memory `known_issue_affine_db_config_precedence.md` captures the gotcha.

## Test plan
- [x] `nixos-rebuild switch` succeeds
- [x] `affine.service` healthy on `:13010/info`
- [x] `app_configs` row updated to tiny-llm-gate URL
- [x] `journalctl -u affine.service` shows zero `Expected 1 embeddings, got 0` errors after restart
- [x] `SELECT COUNT(DISTINCT doc_id) FROM ai_workspace_embeddings WHERE workspace_id='26f28a9e-…'` climbs steadily (verified 263 → 1258 in 2 min)
- [ ] Queue drains fully (~14 min at observed rate) — running in background

🤖 Generated with [Claude Code](https://claude.com/claude-code)