### PR TITLE
fix(home): remove non-functional Flatpak runtime override

### DIFF
--- a/nixos/home.nix
+++ b/nixos/home.nix
@@ -25,28 +25,11 @@
       --filesystem=/run/current-system:ro \
       --filesystem=/home/${username}/mangohud-logs \
       --filesystem=/home/${username}/.cache/nvidia-shader-cache/star-citizen \
+      --filesystem=xdg-config/MangoHud:ro \
+      --nofilesystem=/run/opengl-driver \
       --env=__GL_SHADER_DISK_CACHE_PATH=/home/${username}/.cache/nvidia-shader-cache/star-citizen \
       --talk-name=com.feralinteractive.GameMode
 
-    # Pin GNOME Platform 49 runtime: the RSI Launcher Flatpak ships GNOME 48 (EOL)
-    # which bundles libwayland-client 1.23.1. The host runs wayland 1.24.0 and the
-    # mismatch causes the Wayland client to segfault — wine creates surfaces but
-    # no window appears in the compositor. GNOME 49 ships wayland 1.24.0.
-    # `flatpak override` doesn't support [Application] section, so write it directly.
-    $DRY_RUN_CMD ${pkgs.coreutils}/bin/install -Dm644 /dev/stdin \
-      /home/${username}/.local/share/flatpak/overrides/io.github.mactan_sc.RSILauncher <<FLATPAK_OVERRIDE
-    [Application]
-    runtime=org.gnome.Platform/x86_64/49
-
-    [Context]
-    filesystems=/nix/store:ro;/run/current-system:ro;/home/${username}/mangohud-logs;/home/${username}/.cache/nvidia-shader-cache/star-citizen;xdg-config/MangoHud:ro;!/run/opengl-driver;
-
-    [Session Bus Policy]
-    com.feralinteractive.GameMode=talk
-
-    [Environment]
-    __GL_SHADER_DISK_CACHE_PATH=/home/${username}/.cache/nvidia-shader-cache/star-citizen
-    FLATPAK_OVERRIDE
   '';
 
   services.flatpak.remotes = [


### PR DESCRIPTION
## Summary
- Remove the `[Application] runtime=` heredoc from RSI Launcher Flatpak overrides — Flatpak silently ignores this section, it was never working
- The heredoc was also clobbering the `flatpak override` command output on every activation
- Move `xdg-config/MangoHud:ro` and `--nofilesystem=/run/opengl-driver` into the `flatpak override` command (were only in the removed heredoc)

## Context
Investigated SC invisible window issue. The GNOME 49 runtime pin was a red herring — actual root cause was corrupted Wine prefix state from force-kills. `wineboot -u` fixes it.

## Test plan
- [ ] `nh os switch` + `nh home switch` succeeds
- [ ] Flatpak override file generated correctly by `flatpak override` command
- [ ] RSI Launcher launches and window appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)