### PR TITLE
feat(home/claude): log Bash tool commands to a private history file

### DIFF
--- a/home/claude.nix
+++ b/home/claude.nix
@@ -85,4 +85,11 @@ in
     executable = true;
   };
 
+  # PostToolUse hook on Bash: append each command to ~/.claude/bash_history.log
+  # (zsh EXTENDED_HISTORY format) so it stays out of ~/.zsh_history and atuin.
+  home.file.".claude/hooks/bash-history" = {
+    source = ./scripts/claude-bash-history.sh;
+    executable = true;
+  };
+
 }

--- a/home/dotfiles/claude-settings.json
+++ b/home/dotfiles/claude-settings.json
@@ -38,6 +38,16 @@
             "timeout": 30
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/bash-history",
+            "timeout": 5
+          }
+        ]
       }
     ]
   },

--- a/home/scripts/claude-bash-history.sh
+++ b/home/scripts/claude-bash-history.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# PostToolUse hook for the Bash tool. Appends each command to a private log
+# (~/.claude/bash_history.log) in zsh EXTENDED_HISTORY format. Lives outside
+# ~/.zsh_history so atuin's zsh-history importer never sees these entries.
+# Always exits 0 — must not block Claude Code.
+LOG="${HOME}/.claude/bash_history.log"
+mkdir -p "$(dirname "$LOG")" 2>/dev/null
+cmd=$(jq -r '.tool_input.command // empty' 2>/dev/null) || exit 0
+[ -z "$cmd" ] && exit 0
+ts=$(date +%s)
+escaped=${cmd//$'\n'/$'\\\n'}
+printf ': %s:0;%s\n' "$ts" "$escaped" >> "$LOG" 2>/dev/null
+exit 0


### PR DESCRIPTION
## Summary
- Adds a PostToolUse hook on the `Bash` tool: each command Claude runs is appended to `~/.claude/bash_history.log` in zsh EXTENDED_HISTORY format (`: <epoch>:0;<cmd>`, multiline commands escaped with `\<LF>`).
- Lives **outside** `~/.zsh_history` so atuin's zsh-history importer never sees these entries — Claude's automation no longer pollutes interactive shell recall.
- Hook is best-effort and always exits 0; will not block Claude Code if `jq` is missing or the log path is unwritable.

## Files
- `home/scripts/claude-bash-history.sh` — 13-line shell script.
- `home/claude.nix` — installs the script at `~/.claude/hooks/bash-history`.
- `home/dotfiles/claude-settings.json` — adds the `PostToolUse` `"matcher": "Bash"` entry.

## Test plan
- [x] Offline smoke test: piped sample hook payloads (single-line, multiline, empty `tool_input.command`) into the script — log entries match zsh format, multiline escaped with `\<LF>`, empty payload skipped, exit 0 in all cases.
- [ ] After merge: `home-manager switch --flake .#"nsimon@rpi5"` on rpi5, then run any Bash tool call from Claude Code and verify `~/.claude/bash_history.log` grows.
- [ ] Confirm `~/.zsh_history` is untouched and `atuin search` still excludes Claude's commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)