### PR TITLE
feat(beast): add SMART disk monitoring to beszel-agent

### DIFF
--- a/nixos/beszel-agent.nix
+++ b/nixos/beszel-agent.nix
@@ -8,6 +8,7 @@ in
     wantedBy = [ "multi-user.target" ];
     after = [ "network-online.target" ];
     wants = [ "network-online.target" ];
+    path = [ pkgs.smartmontools ];
     serviceConfig = {
       ExecStart = "${pkgs.beszel}/bin/beszel-agent";
       DynamicUser = true;
@@ -18,8 +19,18 @@ in
       Environment = [
         "PORT=${toString beszelAgentPort}"
         "FILESYSTEM=/dev/nvme0n1p2,/dev/nvme1n1p3,/dev/sda2,/dev/sdc2"
+        "SMART_INTERVAL=1h"
       ];
       ProtectProc = "default";
+      AmbientCapabilities    = [ "CAP_SYS_RAWIO" "CAP_SYS_ADMIN" ];
+      CapabilityBoundingSet  = [ "CAP_SYS_RAWIO" "CAP_SYS_ADMIN" ];
+      DeviceAllow            = [
+        "/dev/nvme0n1 r"
+        "/dev/nvme1n1 r"
+        "/dev/sda r"
+        "/dev/sdc r"
+      ];
+      SupplementaryGroups    = [ "disk" ];
     };
   };
 }

--- a/nixos/beszel-agent.nix
+++ b/nixos/beszel-agent.nix
@@ -28,6 +28,7 @@ in
         "/dev/nvme0n1 r"
         "/dev/nvme1n1 r"
         "/dev/sda r"
+        "/dev/sdb r"
         "/dev/sdc r"
       ];
       SupplementaryGroups    = [ "disk" ];

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -189,6 +189,8 @@ in
     iw             # modern wireless config (iw dev, iw scan …)
     wirelesstools  # iwconfig, iwlist, iwscan
     dhcpcd         # dhcp client for manual wifi sessions
+
+    smartmontools  # smartctl for ad-hoc disk inspection
   ];
 
   programs.kdeconnect.enable = true; # Enables KWallet D-Bus service

--- a/rpi5/monitoring.nix
+++ b/rpi5/monitoring.nix
@@ -191,14 +191,19 @@ $FAILURES"
   #   SMART fetch is observed in the hub _logs. Issue:
   #   https://github.com/henrygd/beszel/issues/1800
   #
-  # Beszel 0.18.6's background SMART fetcher in update() doesn't reliably fire
+  # Beszel 0.18.x's background SMART fetcher in update() doesn't reliably fire
   # on SMART_INTERVAL — data.Details.SmartInterval isn't transmitted over SSH
   # correctly, the hub falls back to a 1h default + cooldown that effectively
   # blocks subsequent fetches. The manual refresh endpoint bypasses the
-  # cooldown and always works.
+  # cooldown and reliably populates `smart_devices`.
   #
-  # The homepage superuser (created for the Beszel homepage widget) is reused
-  # here for the API login; password is plain in homepage.nix:81.
+  # IMPORTANT: `POST /api/beszel/smart/refresh` requires a regular `users`
+  # token, not a `_superusers` token — the handler calls `system.HasUser(auth.Id)`
+  # against the system's `users` field, which contains user IDs from the `users`
+  # collection. A superuser ID is not in that field, so the handler returns 404
+  # ("The requested resource wasn't found"). Workaround: auth as superuser, then
+  # use PocketBase's impersonate endpoint to mint a token for the first regular
+  # user that actually owns the systems.
   systemd.services.beszel-smart-refresh = {
     description = "Refresh Beszel SMART data for all systems (workaround for beszel#1800)";
     after = [ "beszel-hub.service" ];
@@ -210,7 +215,7 @@ $FAILURES"
         JQ="${pkgs.jq}/bin/jq"
         HUB=http://127.0.0.1:${toString beszelHubPort}
 
-        TOKEN=$($CURL -sf -X POST "$HUB/api/collections/_superusers/auth-with-password" \
+        SU_TOKEN=$($CURL -sf -X POST "$HUB/api/collections/_superusers/auth-with-password" \
           -H 'Content-Type: application/json' \
           -d '{"identity":"homepage@nic-os.local","password":"homepage-widget-pass"}' \
           | $JQ -r .token)
@@ -220,18 +225,32 @@ $FAILURES"
         # call that fails (no MTA configured) and logs a recordAuthResponse
         # error each run. Idempotent — safe to run every tick.
         $CURL -sf -X PATCH "$HUB/api/collections/_superusers" \
-          -H "Authorization: $TOKEN" -H 'Content-Type: application/json' \
+          -H "Authorization: $SU_TOKEN" -H 'Content-Type: application/json' \
           -d '{"authAlert":{"enabled":false}}' > /dev/null \
           && echo "authAlert disabled on _superusers" \
           || echo "WARN: failed to disable authAlert" >&2
 
+        # Pick the first regular user and impersonate them so the refresh
+        # handler's HasUser check passes (see comment block above).
+        USER_ID=$($CURL -sf -H "Authorization: $SU_TOKEN" \
+          "$HUB/api/collections/users/records?perPage=1&fields=id" \
+          | $JQ -r '.items[0].id // empty')
+        if [ -z "$USER_ID" ]; then
+          echo "ERROR: no regular user found in users collection — cannot refresh SMART" >&2
+          exit 1
+        fi
+        USER_TOKEN=$($CURL -sf -X POST -H "Authorization: $SU_TOKEN" \
+          -H 'Content-Type: application/json' -d '{"duration":3600}' \
+          "$HUB/api/collections/users/impersonate/$USER_ID" \
+          | $JQ -r .token)
+
         # Iterate over every registered system and kick its manual SMART refresh.
-        SYSTEMS=$($CURL -sf -H "Authorization: $TOKEN" \
+        SYSTEMS=$($CURL -sf -H "Authorization: $SU_TOKEN" \
           "$HUB/api/collections/systems/records?perPage=100&fields=id,name,status" \
           | $JQ -r '.items[] | select(.status=="up") | .id')
 
         for id in $SYSTEMS; do
-          $CURL -sf -X POST -H "Authorization: $TOKEN" \
+          $CURL -sf -X POST -H "Authorization: $USER_TOKEN" \
             "$HUB/api/beszel/smart/refresh?system=$id" > /dev/null \
             && echo "refreshed SMART for system=$id" \
             || echo "WARN: refresh failed for system=$id" >&2


### PR DESCRIPTION
## Summary
Add SMART disk monitoring to **beast** (BeAsT) by extending the beszel-agent with `smartmontools` on PATH, `CAP_SYS_RAWIO` + `CAP_SYS_ADMIN` ambient/bounding caps, the `disk` supplementary group, and `DeviceAllow` for all 5 physical disks (`nvme0n1`, `nvme1n1`, `sda`, `sdb`, `sdc`). Auto-discover devices via `smartctl --scan` (native SATA/NVMe — no USB-bridge type suffixes needed).

`smartmontools` also added to `nixos/configuration.nix` system packages for ad-hoc inspection.

## Bonus: fix for hub-side `beszel-smart-refresh` 404 (rpi5)
While verifying I noticed the workaround in `rpi5/monitoring.nix beszel-smart-refresh.service` was silently 404-ing every hour. `smart_devices` had been stale on rpi5 since 2026-04-25 and empty for beast.

Root cause: the hub's `POST /api/beszel/smart/refresh` handler calls `system.HasUser(auth.Id)`, which checks the system record's `users` field against the auth id. That field stores IDs from the `users` collection only — a `_superusers` token is never a member, so the handler returns `404 "The requested resource wasn't found"`, indistinguishable from a missing route. (Confirmation: same endpoint without `?system=...` returns `400 "Invalid system parameter"`, proving the route IS registered.)

Fix: auth as superuser to disable authAlert + list systems, then `POST /api/collections/users/impersonate/<user_id>` to mint a user-level token, then call refresh with the impersonation token. Verified live — refresh service now logs `refreshed SMART for system=...` for both rpi5 and beast.

Memory note updated: `known_issue_beszel_smart_refresh_broken.md`.

## Test plan
- [x] `sudo nixos-rebuild switch --flake "path:.#BeAsT"` on beast over SSH — succeeds, only `beszel-agent.service` restarted.
- [x] `systemctl show beszel-agent.service -p AmbientCapabilities -p SupplementaryGroups -p DeviceAllow` on beast: `cap_sys_rawio cap_sys_admin`, `disk`, 5 `DeviceAllow` entries.
- [x] Agent journal: `INFO SMART_INTERVAL duration=1h0m0s`, no EPERM after restart.
- [x] `sudo smartctl --scan` on beast lists all 5 disks (3× SATA, 2× NVMe).
- [x] `sudo nixos-rebuild switch --flake "path:.#rpi5"` on rpi5 with the impersonate fix — succeeds.
- [x] `sudo systemctl start beszel-smart-refresh.service` post-rebuild: `refreshed SMART for system=dq0qxe6e48csd0c` + `refreshed SMART for system=1elqjy76vieyv7w` (vs `WARN: refresh failed` previously).
- [x] `smart_devices` collection now has 5 fresh rows for beast (Toshiba MQ01, WDC WD3200, WDC WD10EZEX, Crucial T710, Samsung 990 PRO) and 2 fresh rows for rpi5 (Hitachi HDD via USB-SATA, HP EX900 SSD via USB-NVMe).
- [ ] Visible in Beszel UI — should populate now that `smart_devices` is current; left for human eyeball confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)