### PR TITLE
feat(home/claude): push Bash tool commands into atuin (sync across devices)

### DIFF
--- a/home/atuin.nix
+++ b/home/atuin.nix
@@ -1,0 +1,24 @@
+{ unstablePkgs, ... }:
+{
+  # Keep atuin's sync daemon alive headlessly so background hooks (e.g. the
+  # Claude Code Bash PostToolUse hook) and history written outside an
+  # interactive shell session still sync to api.atuin.sh. The shell init
+  # `atuin init zsh` only spawns a daemon when zsh starts, so on a
+  # mostly-headless box the socket dies and sync silently lapses.
+  systemd.user.services.atuin-daemon = {
+    Unit = {
+      Description = "Atuin sync daemon";
+      After = [ "network-online.target" ];
+      Wants = [ "network-online.target" ];
+    };
+    Install = {
+      WantedBy = [ "default.target" ];
+    };
+    Service = {
+      Type = "simple";
+      ExecStart = "${unstablePkgs.atuin}/bin/atuin daemon start";
+      Restart = "on-failure";
+      RestartSec = "5s";
+    };
+  };
+}

--- a/home/claude.nix
+++ b/home/claude.nix
@@ -85,8 +85,10 @@ in
     executable = true;
   };
 
-  # PostToolUse hook on Bash: append each command to ~/.claude/bash_history.log
-  # (zsh EXTENDED_HISTORY format) so it stays out of ~/.zsh_history and atuin.
+  # PostToolUse hook on Bash: register each command with atuin under a
+  # sentinel cwd (~/.claude/bash) so it syncs across devices and can be
+  # filtered (or excluded) with `atuin search --cwd ~/.claude/bash`.
+  # Requires the atuin daemon to be running — see ./atuin.nix.
   home.file.".claude/hooks/bash-history" = {
     source = ./scripts/claude-bash-history.sh;
     executable = true;

--- a/home/default.nix
+++ b/home/default.nix
@@ -9,6 +9,7 @@
     ../shared/agenix.nix
     ./packages.nix
     ./zsh.nix
+    ./atuin.nix
     ./claude.nix
     ./mcp.nix
     ./llm-aliases.nix

--- a/home/scripts/claude-bash-history.sh
+++ b/home/scripts/claude-bash-history.sh
@@ -1,13 +1,25 @@
 #!/usr/bin/env bash
-# PostToolUse hook for the Bash tool. Appends each command to a private log
-# (~/.claude/bash_history.log) in zsh EXTENDED_HISTORY format. Lives outside
-# ~/.zsh_history so atuin's zsh-history importer never sees these entries.
+# PostToolUse hook for the Bash tool. Pushes each command into atuin under
+# sentinel cwd ~/.claude/bash so it syncs across devices and can be filtered
+# with: atuin search --filter-mode global --cwd ~/.claude/bash
+# (or excluded from normal recall by the same path).
 # Always exits 0 — must not block Claude Code.
-LOG="${HOME}/.claude/bash_history.log"
-mkdir -p "$(dirname "$LOG")" 2>/dev/null
+SENTINEL="${HOME}/.claude/bash"
+SESSION_FILE="${HOME}/.claude/.atuin-session"
+mkdir -p "$SENTINEL" 2>/dev/null
+
+# Per-Claude-session UUID so all calls in one session group together.
+if [ ! -s "$SESSION_FILE" ]; then
+  atuin uuid > "$SESSION_FILE" 2>/dev/null || exit 0
+fi
+ATUIN_SESSION=$(cat "$SESSION_FILE" 2>/dev/null) || exit 0
+[ -z "$ATUIN_SESSION" ] && exit 0
+export ATUIN_SESSION
+
 cmd=$(jq -r '.tool_input.command // empty' 2>/dev/null) || exit 0
 [ -z "$cmd" ] && exit 0
-ts=$(date +%s)
-escaped=${cmd//$'\n'/$'\\\n'}
-printf ': %s:0;%s\n' "$ts" "$escaped" >> "$LOG" 2>/dev/null
+
+HID=$(cd "$SENTINEL" && atuin history start -- "$cmd" 2>/dev/null) || exit 0
+[ -z "$HID" ] && exit 0
+atuin history end --exit 0 "$HID" >/dev/null 2>&1
 exit 0


### PR DESCRIPTION
## Summary
- Replaces the local-only `~/.claude/bash_history.log` path from PR #223 with `atuin history start/end`, so Claude's Bash tool calls land in atuin and sync across devices via api.atuin.sh.
- Calls run under sentinel `cwd = ~/.claude/bash`, so you can find them with `atuin search --filter-mode global --cwd ~/.claude/bash` and exclude them from normal recall by the same path.
- Adds `home/atuin.nix` — a systemd user service that keeps the atuin daemon alive headlessly. The shell-init `atuin init zsh` only spawns a daemon when an interactive zsh starts, so on the mostly-headless rpi5 the socket dies and sync silently lapses (last sync was 11 days stale before this PR).

## Files
- `home/scripts/claude-bash-history.sh` — rewritten to push to atuin instead of writing to a private log.
- `home/atuin.nix` — new file, systemd user unit `atuin-daemon.service`.
- `home/default.nix` — imports `./atuin.nix`.
- `home/claude.nix` — comment updated to point at the new behavior.

## Test plan
- [ ] `home-manager switch --flake .#"nsimon@rpi5"` on rpi5.
- [ ] `systemctl --user status atuin-daemon` — service active.
- [ ] Restart Claude Code so the hook is wired in (settings.json read at session start).
- [ ] Run a recognizable Bash tool call from Claude (e.g. `echo MARKER-$(date +%s)`).
- [ ] On rpi5: `sqlite3 ~/.local/share/atuin/history.db "SELECT command FROM history WHERE cwd='/home/nsimon/.claude/bash' ORDER BY timestamp DESC LIMIT 5;"` — marker present.
- [ ] On Mac: `atuin sync && atuin search --filter-mode global --cwd /home/nsimon/.claude/bash` — marker visible.
- [ ] Confirm the marker is **not** in `~/.zsh_history` or in atuin's default per-host search (`atuin search MARKER` without `--filter-mode global`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)