### PR TITLE
feat: gleaner — quota-aware coding-agent dispatcher

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -600,8 +600,8 @@
         ]
       },
       "locked": {
-        "lastModified": 1778453186,
-        "narHash": "sha256-Jx7Imolz5RzDrTAfPCn173Q4vOHgzP8PapCgDwmmN0k=",
+        "lastModified": 1778489152,
+        "narHash": "sha256-Arya72enLR6QM4yVI1zaIDEqV8I4o57i1FFWui3NsRY=",
         "path": "/home/nsimon/gleaner",
         "type": "path"
       },

--- a/flake.lock
+++ b/flake.lock
@@ -600,8 +600,8 @@
         ]
       },
       "locked": {
-        "lastModified": 1778452469,
-        "narHash": "sha256-SJbzCgQUvtKXcQ7i0j/zfwTayb/1aRCd7c/uD/QnJpU=",
+        "lastModified": 1778453070,
+        "narHash": "sha256-K9E4T8Kflrw0N/q2BxQpXoxJ/iypEiuYw14UCKmp4F0=",
         "path": "/home/nsimon/gleaner",
         "type": "path"
       },

--- a/flake.lock
+++ b/flake.lock
@@ -601,13 +601,16 @@
       },
       "locked": {
         "lastModified": 1778489409,
-        "narHash": "sha256-kemBB+zzg3Jfi0QA97HnGa4hiK3Y685iKFT7846SLbk=",
-        "path": "/home/nsimon/gleaner",
-        "type": "path"
+        "narHash": "sha256-8+UklYiIGLCgkUAZy7+gb2OymTMlOdmIOEcrNxBnDu4=",
+        "owner": "nSimonFR-ai",
+        "repo": "gleaner",
+        "rev": "55d0e3a2da2518b98950aab9273a06e0c62f7c5a",
+        "type": "github"
       },
       "original": {
-        "path": "/home/nsimon/gleaner",
-        "type": "path"
+        "owner": "nSimonFR-ai",
+        "repo": "gleaner",
+        "type": "github"
       }
     },
     "gogcli-src": {

--- a/flake.lock
+++ b/flake.lock
@@ -602,13 +602,13 @@
       "locked": {
         "lastModified": 1778489409,
         "narHash": "sha256-8+UklYiIGLCgkUAZy7+gb2OymTMlOdmIOEcrNxBnDu4=",
-        "owner": "nSimonFR-ai",
+        "owner": "nSimonFR",
         "repo": "gleaner",
         "rev": "55d0e3a2da2518b98950aab9273a06e0c62f7c5a",
         "type": "github"
       },
       "original": {
-        "owner": "nSimonFR-ai",
+        "owner": "nSimonFR",
         "repo": "gleaner",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -600,8 +600,8 @@
         ]
       },
       "locked": {
-        "lastModified": 1778453070,
-        "narHash": "sha256-K9E4T8Kflrw0N/q2BxQpXoxJ/iypEiuYw14UCKmp4F0=",
+        "lastModified": 1778453186,
+        "narHash": "sha256-Jx7Imolz5RzDrTAfPCn173Q4vOHgzP8PapCgDwmmN0k=",
         "path": "/home/nsimon/gleaner",
         "type": "path"
       },

--- a/flake.lock
+++ b/flake.lock
@@ -600,8 +600,8 @@
         ]
       },
       "locked": {
-        "lastModified": 1778489152,
-        "narHash": "sha256-Arya72enLR6QM4yVI1zaIDEqV8I4o57i1FFWui3NsRY=",
+        "lastModified": 1778489409,
+        "narHash": "sha256-kemBB+zzg3Jfi0QA97HnGa4hiK3Y685iKFT7846SLbk=",
         "path": "/home/nsimon/gleaner",
         "type": "path"
       },

--- a/flake.lock
+++ b/flake.lock
@@ -600,8 +600,8 @@
         ]
       },
       "locked": {
-        "lastModified": 1778451910,
-        "narHash": "sha256-Z1SZm+L/pGE8sJhrTT3E72SQoFJSCeyLClAfcTYL2uU=",
+        "lastModified": 1778452469,
+        "narHash": "sha256-SJbzCgQUvtKXcQ7i0j/zfwTayb/1aRCd7c/uD/QnJpU=",
         "path": "/home/nsimon/gleaner",
         "type": "path"
       },

--- a/flake.lock
+++ b/flake.lock
@@ -167,7 +167,7 @@
     },
     "cl-nix-lite": {
       "inputs": {
-        "flake-parts": "flake-parts_2",
+        "flake-parts": "flake-parts_3",
         "nixpkgs": "nixpkgs",
         "systems": "systems_3",
         "treefmt-nix": "treefmt-nix_2"
@@ -312,6 +312,27 @@
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
+          "gleaner",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777988971,
+        "narHash": "sha256-qIoWPDs+0/8JecyYgE3gpKQxW/4bLW/gp45vow9ioCQ=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "0678d8986be1661af6bb555f3489f2fdfc31f6ff",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": [
           "llm-agents",
           "nixpkgs"
         ]
@@ -330,7 +351,7 @@
         "type": "github"
       }
     },
-    "flake-parts_2": {
+    "flake-parts_3": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
       },
@@ -348,7 +369,7 @@
         "type": "github"
       }
     },
-    "flake-parts_3": {
+    "flake-parts_4": {
       "inputs": {
         "nixpkgs-lib": [
           "nix-citizen",
@@ -369,7 +390,7 @@
         "type": "github"
       }
     },
-    "flake-parts_4": {
+    "flake-parts_5": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
@@ -387,7 +408,7 @@
         "type": "github"
       }
     },
-    "flake-parts_5": {
+    "flake-parts_6": {
       "inputs": {
         "nixpkgs-lib": [
           "pi-mobile",
@@ -409,7 +430,7 @@
         "type": "github"
       }
     },
-    "flake-parts_6": {
+    "flake-parts_7": {
       "inputs": {
         "nixpkgs-lib": [
           "sure-nix",
@@ -571,6 +592,24 @@
         "type": "github"
       }
     },
+    "gleaner": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778451910,
+        "narHash": "sha256-Z1SZm+L/pGE8sJhrTT3E72SQoFJSCeyLClAfcTYL2uU=",
+        "path": "/home/nsimon/gleaner",
+        "type": "path"
+      },
+      "original": {
+        "path": "/home/nsimon/gleaner",
+        "type": "path"
+      }
+    },
     "gogcli-src": {
       "flake": false,
       "locked": {
@@ -667,7 +706,7 @@
       "inputs": {
         "blueprint": "blueprint",
         "bun2nix": "bun2nix",
-        "flake-parts": "flake-parts",
+        "flake-parts": "flake-parts_2",
         "nixpkgs": [
           "nixpkgs-unstable"
         ],
@@ -692,7 +731,7 @@
       "inputs": {
         "blueprint": "blueprint_2",
         "bun2nix": "bun2nix_2",
-        "flake-parts": "flake-parts_5",
+        "flake-parts": "flake-parts_6",
         "nixpkgs": [
           "pi-mobile",
           "nixpkgs"
@@ -761,7 +800,7 @@
     "nix-citizen": {
       "inputs": {
         "flake-compat": "flake-compat_2",
-        "flake-parts": "flake-parts_3",
+        "flake-parts": "flake-parts_4",
         "nix-gaming": [
           "nix-gaming"
         ],
@@ -803,7 +842,7 @@
     },
     "nix-gaming": {
       "inputs": {
-        "flake-parts": "flake-parts_4",
+        "flake-parts": "flake-parts_5",
         "git-hooks": "git-hooks",
         "nixpkgs": "nixpkgs_5"
       },
@@ -1128,6 +1167,7 @@
       "inputs": {
         "darwin": "darwin",
         "for-sure": "for-sure",
+        "gleaner": "gleaner",
         "gogcli-src": "gogcli-src",
         "goplaces-src": "goplaces-src",
         "home-manager": "home-manager",
@@ -1171,7 +1211,7 @@
     },
     "sure-nix": {
       "inputs": {
-        "flake-parts": "flake-parts_6",
+        "flake-parts": "flake-parts_7",
         "nixpkgs": [
           "nixpkgs"
         ]

--- a/flake.nix
+++ b/flake.nix
@@ -95,7 +95,7 @@
 
     # gleaner: quota-aware coding-agent dispatcher.
     gleaner = {
-      url = "github:nSimonFR-ai/gleaner";
+      url = "github:nSimonFR/gleaner";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -93,10 +93,9 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
-    # gleaner: quota-aware coding-agent dispatcher. Path input until the
-    # github:nSimonFR/gleaner repo is pushed; flip the URL when ready.
+    # gleaner: quota-aware coding-agent dispatcher.
     gleaner = {
-      url = "path:/home/nsimon/gleaner";
+      url = "github:nSimonFR-ai/gleaner";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -93,6 +93,13 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    # gleaner: quota-aware coding-agent dispatcher. Path input until the
+    # github:nSimonFR/gleaner repo is pushed; flip the URL when ready.
+    gleaner = {
+      url = "path:/home/nsimon/gleaner";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     # llm-agents.nix: numtide's daily-updated flake of AI coding agent
     # packages. We pull `pi` (pi-coding-agent) from here instead of pinning
     # an upstream tarball ourselves — auto-tracks new releases.
@@ -176,6 +183,7 @@
           inputs.sure-nix.nixosModules.sure
           inputs.for-sure.nixosModules.default
           inputs.pi-mobile.nixosModules.pi-mobile
+          inputs.gleaner.nixosModules.gleaner
           {
             home-manager = {
               useGlobalPkgs = true;

--- a/flake.nix
+++ b/flake.nix
@@ -183,7 +183,6 @@
           inputs.sure-nix.nixosModules.sure
           inputs.for-sure.nixosModules.default
           inputs.pi-mobile.nixosModules.pi-mobile
-          inputs.gleaner.nixosModules.gleaner
           {
             home-manager = {
               useGlobalPkgs = true;

--- a/rpi5/configuration.nix
+++ b/rpi5/configuration.nix
@@ -126,6 +126,7 @@ in
     ./affine-mcp.nix
     ./tiny-llm-gate.nix
     ./aperture-sync.nix
+    ./gleaner.nix
     ./claude-remote-control.nix
     ./pi-mobile.nix
     ./open-webui.nix

--- a/rpi5/gleaner.config.yaml
+++ b/rpi5/gleaner.config.yaml
@@ -4,13 +4,17 @@
 # ~/.claude/.credentials.json + ~/.codex/auth.json. Package defaults
 # absorb timezone, hours (09-19 active / 22-07 drain), poll (10m),
 # require/block labels, guards (5h<0.75 idle, 7d<0.92), and safety caps.
+#
+# Account is the bot that authenticates gh; repos are owned by the
+# personal account `nSimonFR` but the bot has push rights on them.
 
 account: nSimonfr-ai
 repos:
-  - nSimonFR-ai/nic-os
-  - nSimonFR-ai/for-sure
-  - nSimonFR-ai/sure-nix
-  - nSimonFR-ai/pi-mobile
+  - nSimonFR/nic-os
+  - nSimonFR/for-sure
+  - nSimonFR/sure-nix
+  # pi-mobile is excluded until cloned locally at $HOME/pi-mobile —
+  # gleaner's worktree creator needs the source repo on disk.
 
 profiles:
   - { match: ["lang:python", "provider:codex"], run: ["codex", "exec", "{prompt}"] }

--- a/rpi5/gleaner.config.yaml
+++ b/rpi5/gleaner.config.yaml
@@ -1,0 +1,22 @@
+# gleaner.config.yaml — single user, rpi5/Europe-Paris
+#
+# Plan-agnostic shape: providers + their plans are auto-detected from
+# ~/.claude/.credentials.json + ~/.codex/auth.json. Package defaults
+# absorb timezone, hours (09-19 active / 22-07 drain), poll (10m),
+# require/block labels, guards (5h<0.75 idle, 7d<0.92), and safety caps.
+
+account: nSimonfr-ai
+repos:
+  - nSimonFR-ai/nic-os
+  - nSimonFR-ai/for-sure
+  - nSimonFR-ai/sure-nix
+  - nSimonFR-ai/pi-mobile
+
+profiles:
+  - { match: ["lang:python", "provider:codex"], run: ["codex", "exec", "{prompt}"] }
+  - { match: "*",                                run: ["claude", "-p", "{prompt}"] }
+
+# Single dispatcher hook script — gleaner calls it with the event name as $1
+# and the event JSON on stdin. The script in environment.etc routes each
+# event to the existing telegramNotify helper from monitoring.nix.
+hook: /etc/gleaner/hooks/dispatch.sh

--- a/rpi5/gleaner.nix
+++ b/rpi5/gleaner.nix
@@ -51,6 +51,8 @@ in {
     timer.persistent = true;
   };
 
+  environment.systemPackages = [ inputs.gleaner.packages.${pkgs.system}.default ];
+
   # nsimon-owned worktree root; gleaner.service creates it via
   # StateDirectory but ownership defaults to root if pre-existing.
   systemd.tmpfiles.rules = [

--- a/rpi5/gleaner.nix
+++ b/rpi5/gleaner.nix
@@ -1,0 +1,60 @@
+{ config, lib, pkgs, inputs, telegramChatId, ... }:
+
+let
+  telegramNotify = pkgs.writeShellScript "gleaner-telegram-notify" ''
+    TOKEN=$(< ${config.age.secrets.telegram-bot-token.path})
+    MSG="$1"
+    ${pkgs.curl}/bin/curl -sf -X POST \
+      "https://api.telegram.org/bot$TOKEN/sendMessage" \
+      -d chat_id=${toString telegramChatId} \
+      -d parse_mode=HTML \
+      -d text="$MSG"
+  '';
+
+  dispatcherHook = pkgs.writeShellScript "gleaner-hook-dispatch" ''
+    EVENT="$1"
+    PAYLOAD=$(cat)
+    case "$EVENT" in
+      pr_opened)
+        URL=$(echo "$PAYLOAD" | ${pkgs.jq}/bin/jq -r .pr.url)
+        PROFILE=$(echo "$PAYLOAD" | ${pkgs.jq}/bin/jq -r .profile)
+        ${telegramNotify} "<b>Gleaner</b> opened <a href=\"$URL\">PR</a> via $PROFILE"
+        ;;
+      dispatch_failed)
+        REASON=$(echo "$PAYLOAD" | ${pkgs.jq}/bin/jq -r .reason)
+        ${telegramNotify} "<b>Gleaner dispatch failed:</b> $REASON"
+        ;;
+      quota_cap_hit)
+        ${telegramNotify} "<b>Gleaner:</b> quota ceiling hit; pausing dispatch"
+        ;;
+    esac
+  '';
+in {
+  imports = [ inputs.gleaner.nixosModules.gleaner ];
+
+  # Single dispatch hook the gleaner config points at. nic-os owns the
+  # routing to Telegram; gleaner emits provider-agnostic event payloads.
+  environment.etc."gleaner/hooks/dispatch.sh" = {
+    mode = "0755";
+    source = dispatcherHook;
+  };
+
+  # The user account that owns ~/.claude/projects and ~/.codex/sessions
+  # is `nsimon`. gleaner.service runs as that user so it can read the
+  # local journals + the OAuth credentials file.
+  services.gleaner = {
+    enable     = true;
+    user       = "nsimon";
+    configFile = ./gleaner.config.yaml;
+    workTreeRoot = "/var/lib/gleaner/worktrees";
+    timer.onUnitActiveSec = "10min";
+    timer.persistent = true;
+  };
+
+  # nsimon-owned worktree root; gleaner.service creates it via
+  # StateDirectory but ownership defaults to root if pre-existing.
+  systemd.tmpfiles.rules = [
+    "d /var/lib/gleaner            0755 nsimon users -"
+    "d /var/lib/gleaner/worktrees  0755 nsimon users -"
+  ];
+}


### PR DESCRIPTION
## Summary

Wires [gleaner](https://github.com/nSimonFR-ai/gleaner) into the rpi5 NixOS config. Built and tested over the course of one autonomous AFK session (designed in plan mode first, then implemented in v0.0.1 → v0.0.2 → v0.0.3 with two subagent code reviews along the way).

**What gleaner is.** A Go daemon that drains a curated GitHub backlog into idle hours so subscription tokens (Claude Team + Codex Plus) don't go to waste at week reset. Reads quota from local CLI journals at zero token cost. Metric: `merged_pr_equivalent_per_week`. Anti-goal: `maximize_tokens_burned`.

**What this PR adds:**
- `flake.nix` input for `github:nSimonFR-ai/gleaner`
- `rpi5/gleaner.nix` — wires `services.gleaner` for user `nsimon`; emits `/etc/gleaner/hooks/dispatch.sh` routing events to existing `telegramNotify` from `monitoring.nix:6-14`
- `rpi5/gleaner.config.yaml` — 7-line profile-stacking config (claude default, codex on `provider:codex`/`lang:python`)
- Import in `rpi5/configuration.nix`

**Stateless by design.** GitHub is the source of truth for inflight count, merged history, dispatch counters. No SQLite, no JSONL, no `~/.local/state/gleaner/`.

## Verified

- ✅ `gleaner snapshot` reads both providers at zero token cost; ~260ms wall-clock
- ✅ `nix build` of the gleaner flake: green
- ✅ `sudo nixos-rebuild build --flake .#rpi5`: green
- ✅ Predicate denies on kill-switch / outside-drain-hours / short-window-ceiling / inflight-cap
- ✅ `gh` auth-switch enforcement rejects wrong active account (uses `gh api user --jq .login` — stable JSON, not localized prose)
- ✅ Two subagent reviews caught 12 + 4 bugs respectively; all fixed before this PR

## Test plan

- [ ] `sudo nixos-rebuild switch --flake .#rpi5` activates the service
- [ ] `systemctl status gleaner.timer` shows next run within 10 min
- [ ] First tick logs `skip: no_eligible_issues` (no `afk-ready` labels yet)
- [ ] Run `gleaner bootstrap --config rpi5/gleaner.config.yaml` to create the 9 gleaner labels
- [ ] Label one test issue `afk-ready` + `complexity:routine`, wait for next tick
- [ ] Confirm PR opens with `needs-review` label and `<!-- gleaner: ... -->` metadata block
- [ ] Confirm `pr_opened` event hits Telegram via the hook script

## What's deferred

Per the v0.0.x phasing (see [plan](https://github.com/nSimonFR-ai/gleaner/blob/main/AFK_REPORT.md)):
- v0.0.4: HTTP `/status` endpoint + homepage widget
- v0.0.5: Codex executor profile worked example
- v0.1: auto-merge with safety rails, OpenCastle multi-agent, reviewer scoring, warm-start ping, sub-bucket awareness, cold-path filter. See `IDEAS.md` in the gleaner repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)