### PR TITLE
chore(flake): bump nixpkgs-unstable for claude-code 2.1.123 → 2.1.137

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -938,11 +938,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1777918403,
-        "narHash": "sha256-7QiZv0LcW1yIOLo2LNuCQjWon1Z1r99FwK24hbtBOF4=",
+        "lastModified": 1778458615,
+        "narHash": "sha256-cY07EsdhBJ8tFXPzDYevgqxRev9ZLxFonuq9wmq5kwg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "afc5551119aae6eab73a95c1960891cfe63204f6",
+        "rev": "c6e5ca3c836a5f4dd9af9f2c1fc1c38f0fac988a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

- Bump `nixpkgs-unstable` (`afc5551…` → `c6e5ca3…`, 2026-05-04 → 2026-05-11) to pull `claude-code 2.1.137` (was 2.1.123, 14 patch versions behind; npm shipped 2.1.139 the same day).
- `claude-remote-control.service` on the rpi5 stopped landing dispatched sessions while on 2.1.123 — bridge polled cleanly but no `<<<` work arrived from claude.ai/code. Updating to 2.1.137 fixed it (post-rebuild + explicit unit restart).
- Lock-only change; no flake.nix edits.

## Test plan

- [x] `nixos-rebuild switch` to generation 655 succeeded after one OOM retry (HA python dep churn).
- [x] `sudo systemctl restart claude-remote-control.service` — bridge banner now reads `Remote Control v2.1.137`, fresh `env_…` registered.
- [x] Dispatching a session from claude.ai/code with the URL printed in the new banner lands at the bridge (`bridge:api <<< type=work`) and spawns a `bridge-cse_*` worktree.
- [ ] Standalone `home-manager switch --flake .#"nsimon@rpi5"` still pending — the user-shell `claude` command remains on 2.1.123 until that's run; bridge is independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)