### PR TITLE
feat(picoclaw): protonmail skill via himalaya + hydroxide

### DIFF
--- a/rpi5/home.nix
+++ b/rpi5/home.nix
@@ -14,6 +14,7 @@
     pnpm
     vdirsyncer
     khal
+    himalaya
     (callPackage ./gogcli.nix { gogcli-src = inputs.gogcli-src; })
     (callPackage ./goplaces.nix { goplaces-src = inputs.goplaces-src; })
   ];

--- a/rpi5/home.nix
+++ b/rpi5/home.nix
@@ -7,6 +7,7 @@
 {
   imports = [
     ./picoclaw/picoclaw.nix
+    ./mail.nix
   ];
 
   home.packages = with pkgs; [
@@ -14,7 +15,6 @@
     pnpm
     vdirsyncer
     khal
-    himalaya
     (callPackage ./gogcli.nix { gogcli-src = inputs.gogcli-src; })
     (callPackage ./goplaces.nix { goplaces-src = inputs.goplaces-src; })
   ];

--- a/rpi5/hydroxide.nix
+++ b/rpi5/hydroxide.nix
@@ -37,6 +37,11 @@ in
   };
   users.groups.hydroxide = {};
 
+  # Picoclaw runs as nsimon and shells out to himalaya, which reads the bridge
+  # password at invocation time. Group membership grants read on the 0440 agenix
+  # file without changing its owner. See rpi5/picoclaw/skills/protonmail/.
+  users.users.nsimon.extraGroups = [ "hydroxide" ];
+
   systemd.tmpfiles.rules = [
     "d /var/lib/hydroxide          0700 hydroxide hydroxide - -"
     "d /var/lib/hydroxide/.config  0700 hydroxide hydroxide - -"

--- a/rpi5/hydroxide.nix
+++ b/rpi5/hydroxide.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, unstablePkgs, ... }:
+{ config, lib, pkgs, unstablePkgs, username, ... }:
 # Hydroxide — third-party ProtonMail bridge exposing IMAP / SMTP / CardDAV.
 #
 # Pulled from nixpkgs-unstable for v0.2.31, which includes the
@@ -37,10 +37,10 @@ in
   };
   users.groups.hydroxide = {};
 
-  # Picoclaw runs as nsimon and shells out to himalaya, which reads the bridge
+  # Picoclaw runs as ${username} and shells out to himalaya, which reads the bridge
   # password at invocation time. Group membership grants read on the 0440 agenix
   # file without changing its owner. See rpi5/picoclaw/skills/protonmail/.
-  users.users.nsimon.extraGroups = [ "hydroxide" ];
+  users.users.${username}.extraGroups = [ "hydroxide" ];
 
   systemd.tmpfiles.rules = [
     "d /var/lib/hydroxide          0700 hydroxide hydroxide - -"

--- a/rpi5/mail.nix
+++ b/rpi5/mail.nix
@@ -1,0 +1,42 @@
+{ pkgs, username, ... }:
+# Mail tooling for rpi5: himalaya CLI talking to the local hydroxide ProtonMail
+# bridge. Co-located with the picoclaw `protonmail` skill that consumes it.
+#
+# Bridge endpoints + group access are configured in rpi5/hydroxide.nix:
+#   - IMAP 127.0.0.1:1143, SMTP 127.0.0.1:1025 (also exposed on tailscale0)
+#   - ${username} is a member of the `hydroxide` group → 0440 read on
+#     /run/agenix/protonmail-bridge-password.
+let
+  protonAddress = "${username}@protonmail.com";
+in
+{
+  home.packages = [ pkgs.himalaya ];
+
+  home.file.".config/himalaya/config.toml".text = ''
+    [accounts.proton]
+    default = true
+    email = "${protonAddress}"
+    display-name = "Nicolas Simon"
+
+    backend.type = "imap"
+    backend.host = "127.0.0.1"
+    backend.port = 1143
+    backend.encryption.type = "none"
+    backend.login = "${protonAddress}"
+    backend.auth.type = "password"
+    backend.auth.cmd = "cat /run/agenix/protonmail-bridge-password"
+
+    message.send.backend.type = "smtp"
+    message.send.backend.host = "127.0.0.1"
+    message.send.backend.port = 1025
+    message.send.backend.encryption.type = "none"
+    message.send.backend.login = "${protonAddress}"
+    message.send.backend.auth.type = "password"
+    message.send.backend.auth.cmd = "cat /run/agenix/protonmail-bridge-password"
+
+    folder.aliases.inbox = "INBOX"
+    folder.aliases.sent = "Sent"
+    folder.aliases.trash = "Trash"
+    folder.aliases.drafts = "Drafts"
+  '';
+}

--- a/rpi5/picoclaw/picoclaw.nix
+++ b/rpi5/picoclaw/picoclaw.nix
@@ -275,16 +275,16 @@ in
     backend.port = 1143
     backend.encryption.type = "none"
     backend.login = "nicolas.simon@protonmail.com"
-    backend.auth.type = "raw"
-    backend.auth.raw.cmd = "cat /run/agenix/protonmail-bridge-password"
+    backend.auth.type = "password"
+    backend.auth.cmd = "cat /run/agenix/protonmail-bridge-password"
 
     message.send.backend.type = "smtp"
     message.send.backend.host = "127.0.0.1"
     message.send.backend.port = 1025
     message.send.backend.encryption.type = "none"
     message.send.backend.login = "nicolas.simon@protonmail.com"
-    message.send.backend.auth.type = "raw"
-    message.send.backend.auth.raw.cmd = "cat /run/agenix/protonmail-bridge-password"
+    message.send.backend.auth.type = "password"
+    message.send.backend.auth.cmd = "cat /run/agenix/protonmail-bridge-password"
 
     folder.aliases.inbox = "INBOX"
     folder.aliases.sent = "Sent"

--- a/rpi5/picoclaw/picoclaw.nix
+++ b/rpi5/picoclaw/picoclaw.nix
@@ -259,39 +259,6 @@ in
     fileext = ".ics"
   '';
 
-  # himalaya config for the `protonmail` skill. Talks to the local hydroxide
-  # bridge over plaintext loopback (encryption.type = "none"). The bridge
-  # password is read at invocation time via the auth `raw.cmd` — nsimon needs
-  # group membership on `hydroxide` (granted in rpi5/hydroxide.nix) to read
-  # the 0440 agenix file.
-  home.file.".config/himalaya/config.toml".text = ''
-    [accounts.proton]
-    default = true
-    email = "nsimon@protonmail.com"
-    display-name = "Nicolas Simon"
-
-    backend.type = "imap"
-    backend.host = "127.0.0.1"
-    backend.port = 1143
-    backend.encryption.type = "none"
-    backend.login = "nsimon@protonmail.com"
-    backend.auth.type = "password"
-    backend.auth.cmd = "cat /run/agenix/protonmail-bridge-password"
-
-    message.send.backend.type = "smtp"
-    message.send.backend.host = "127.0.0.1"
-    message.send.backend.port = 1025
-    message.send.backend.encryption.type = "none"
-    message.send.backend.login = "nsimon@protonmail.com"
-    message.send.backend.auth.type = "password"
-    message.send.backend.auth.cmd = "cat /run/agenix/protonmail-bridge-password"
-
-    folder.aliases.inbox = "INBOX"
-    folder.aliases.sent = "Sent"
-    folder.aliases.trash = "Trash"
-    folder.aliases.drafts = "Drafts"
-  '';
-
   home.file.".config/khal/config".text = ''
     [calendars]
     [[nextcloud]]

--- a/rpi5/picoclaw/picoclaw.nix
+++ b/rpi5/picoclaw/picoclaw.nix
@@ -267,14 +267,14 @@ in
   home.file.".config/himalaya/config.toml".text = ''
     [accounts.proton]
     default = true
-    email = "nicolas.simon@protonmail.com"
+    email = "nsimon@protonmail.com"
     display-name = "Nicolas Simon"
 
     backend.type = "imap"
     backend.host = "127.0.0.1"
     backend.port = 1143
     backend.encryption.type = "none"
-    backend.login = "nicolas.simon@protonmail.com"
+    backend.login = "nsimon@protonmail.com"
     backend.auth.type = "password"
     backend.auth.cmd = "cat /run/agenix/protonmail-bridge-password"
 
@@ -282,7 +282,7 @@ in
     message.send.backend.host = "127.0.0.1"
     message.send.backend.port = 1025
     message.send.backend.encryption.type = "none"
-    message.send.backend.login = "nicolas.simon@protonmail.com"
+    message.send.backend.login = "nsimon@protonmail.com"
     message.send.backend.auth.type = "password"
     message.send.backend.auth.cmd = "cat /run/agenix/protonmail-bridge-password"
 

--- a/rpi5/picoclaw/picoclaw.nix
+++ b/rpi5/picoclaw/picoclaw.nix
@@ -259,6 +259,39 @@ in
     fileext = ".ics"
   '';
 
+  # himalaya config for the `protonmail` skill. Talks to the local hydroxide
+  # bridge over plaintext loopback (encryption.type = "none"). The bridge
+  # password is read at invocation time via the auth `raw.cmd` — nsimon needs
+  # group membership on `hydroxide` (granted in rpi5/hydroxide.nix) to read
+  # the 0440 agenix file.
+  home.file.".config/himalaya/config.toml".text = ''
+    [accounts.proton]
+    default = true
+    email = "nicolas.simon@protonmail.com"
+    display-name = "Nicolas Simon"
+
+    backend.type = "imap"
+    backend.host = "127.0.0.1"
+    backend.port = 1143
+    backend.encryption.type = "none"
+    backend.login = "nicolas.simon@protonmail.com"
+    backend.auth.type = "raw"
+    backend.auth.raw.cmd = "cat /run/agenix/protonmail-bridge-password"
+
+    message.send.backend.type = "smtp"
+    message.send.backend.host = "127.0.0.1"
+    message.send.backend.port = 1025
+    message.send.backend.encryption.type = "none"
+    message.send.backend.login = "nicolas.simon@protonmail.com"
+    message.send.backend.auth.type = "raw"
+    message.send.backend.auth.raw.cmd = "cat /run/agenix/protonmail-bridge-password"
+
+    folder.aliases.inbox = "INBOX"
+    folder.aliases.sent = "Sent"
+    folder.aliases.trash = "Trash"
+    folder.aliases.drafts = "Drafts"
+  '';
+
   home.file.".config/khal/config".text = ''
     [calendars]
     [[nextcloud]]

--- a/rpi5/picoclaw/skills/protonmail/SKILL.md
+++ b/rpi5/picoclaw/skills/protonmail/SKILL.md
@@ -36,16 +36,16 @@ backend.host = "127.0.0.1"
 backend.port = 1143
 backend.encryption.type = "none"
 backend.login = "nicolas.simon@protonmail.com"
-backend.auth.type = "raw"
-backend.auth.raw.cmd = "cat /run/agenix/protonmail-bridge-password"
+backend.auth.type = "password"
+backend.auth.cmd = "cat /run/agenix/protonmail-bridge-password"
 
 message.send.backend.type = "smtp"
 message.send.backend.host = "127.0.0.1"
 message.send.backend.port = 1025
 message.send.backend.encryption.type = "none"
 message.send.backend.login = "nicolas.simon@protonmail.com"
-message.send.backend.auth.type = "raw"
-message.send.backend.auth.raw.cmd = "cat /run/agenix/protonmail-bridge-password"
+message.send.backend.auth.type = "password"
+message.send.backend.auth.cmd = "cat /run/agenix/protonmail-bridge-password"
 ```
 
 Plaintext on `127.0.0.1` is fine — the bridge terminates locally.

--- a/rpi5/picoclaw/skills/protonmail/SKILL.md
+++ b/rpi5/picoclaw/skills/protonmail/SKILL.md
@@ -1,0 +1,251 @@
+<!-- vendored via `npx skills add steipete/clawdis@himalaya` (commit 27e5d49); locally adapted for personal ProtonMail via the hydroxide bridge on rpi5 -->
+---
+name: protonmail
+description: Read, search, and send the user's personal ProtonMail using the himalaya CLI against the local hydroxide bridge (IMAP :1143 / SMTP :1025).
+homepage: https://github.com/pimalaya/himalaya
+metadata: {"openclaw":{"emoji":"📧","os":["linux"],"requires":{"bins":["himalaya"]}}}
+---
+
+# ProtonMail (himalaya + hydroxide)
+
+> **PERSONAL mail only.** This skill is wired to the user's personal ProtonMail
+> (`nicolas.simon@protonmail.com`) via the local hydroxide bridge. Work mail is out of scope.
+
+`himalaya` is a CLI email client. On the rpi5 it talks to **hydroxide**, a third-party
+ProtonMail bridge running as a system service that exposes IMAP on `127.0.0.1:1143` and SMTP
+on `127.0.0.1:1025`. Both authenticate with the bridge password at
+`/run/agenix/protonmail-bridge-password` (group-readable by `hydroxide`, which `nsimon` is a
+member of). The himalaya config at `~/.config/himalaya/config.toml` is Nix-managed in
+`rpi5/picoclaw/picoclaw.nix` — do **not** hand-edit. Edit the Nix module instead.
+
+## References
+
+- `references/configuration.md` (himalaya config file + IMAP/SMTP authentication; informational only)
+- `references/message-composition.md` (MML syntax for composing emails)
+
+## Configuration (informational — already Nix-managed)
+
+```toml
+[accounts.proton]
+default = true
+email = "nicolas.simon@protonmail.com"
+display-name = "Nicolas Simon"
+
+backend.type = "imap"
+backend.host = "127.0.0.1"
+backend.port = 1143
+backend.encryption.type = "none"
+backend.login = "nicolas.simon@protonmail.com"
+backend.auth.type = "raw"
+backend.auth.raw.cmd = "cat /run/agenix/protonmail-bridge-password"
+
+message.send.backend.type = "smtp"
+message.send.backend.host = "127.0.0.1"
+message.send.backend.port = 1025
+message.send.backend.encryption.type = "none"
+message.send.backend.login = "nicolas.simon@protonmail.com"
+message.send.backend.auth.type = "raw"
+message.send.backend.auth.raw.cmd = "cat /run/agenix/protonmail-bridge-password"
+```
+
+Plaintext on `127.0.0.1` is fine — the bridge terminates locally.
+
+## Common Operations
+
+### List Folders
+
+```bash
+himalaya folder list
+```
+
+### List Emails
+
+List emails in INBOX (default):
+
+```bash
+himalaya envelope list
+```
+
+List emails in a specific folder:
+
+```bash
+himalaya envelope list --folder "Sent"
+```
+
+List with pagination:
+
+```bash
+himalaya envelope list --page 1 --page-size 20
+```
+
+### Search Emails
+
+```bash
+himalaya envelope list from john@example.com subject meeting
+```
+
+### Read an Email
+
+Read email by ID (shows plain text):
+
+```bash
+himalaya message read 42
+```
+
+Export raw MIME:
+
+```bash
+himalaya message export 42 --full
+```
+
+### Reply to an Email
+
+Interactive reply (opens $EDITOR):
+
+```bash
+himalaya message reply 42
+```
+
+Reply-all:
+
+```bash
+himalaya message reply 42 --all
+```
+
+### Forward an Email
+
+```bash
+himalaya message forward 42
+```
+
+### Write a New Email
+
+Interactive compose (opens $EDITOR):
+
+```bash
+himalaya message write
+```
+
+Send directly using template:
+
+```bash
+cat << 'EOF' | himalaya template send
+From: you@example.com
+To: recipient@example.com
+Subject: Test Message
+
+Hello from Himalaya!
+EOF
+```
+
+Or with headers flag:
+
+```bash
+himalaya message write -H "To:recipient@example.com" -H "Subject:Test" "Message body here"
+```
+
+### Move/Copy Emails
+
+Move to folder:
+
+```bash
+himalaya message move 42 "Archive"
+```
+
+Copy to folder:
+
+```bash
+himalaya message copy 42 "Important"
+```
+
+### Delete an Email
+
+```bash
+himalaya message delete 42
+```
+
+### Manage Flags
+
+Add flag:
+
+```bash
+himalaya flag add 42 --flag seen
+```
+
+Remove flag:
+
+```bash
+himalaya flag remove 42 --flag seen
+```
+
+## Multiple Accounts
+
+List accounts:
+
+```bash
+himalaya account list
+```
+
+Use a specific account:
+
+```bash
+himalaya --account work envelope list
+```
+
+## Attachments
+
+Save attachments from a message:
+
+```bash
+himalaya attachment download 42
+```
+
+Save to specific directory:
+
+```bash
+himalaya attachment download 42 --dir ~/Downloads
+```
+
+## Output Formats
+
+Most commands support `--output` for structured output:
+
+```bash
+himalaya envelope list --output json
+himalaya envelope list --output plain
+```
+
+## Debugging
+
+Enable debug logging:
+
+```bash
+RUST_LOG=debug himalaya envelope list
+```
+
+Full trace with backtrace:
+
+```bash
+RUST_LOG=trace RUST_BACKTRACE=1 himalaya envelope list
+```
+
+## Tips
+
+- Use `himalaya --help` or `himalaya <command> --help` for detailed usage.
+- Message IDs are relative to the current folder; re-list after folder changes.
+- For composing rich emails with attachments, use MML syntax (see `references/message-composition.md`).
+- Default account is `proton`; no need to pass `--account`.
+
+## Troubleshooting
+
+- **Auth fails** → bridge password lives at `/run/agenix/protonmail-bridge-password`
+  (mode `0440 hydroxide:hydroxide`). `nsimon` must be in the `hydroxide` group;
+  `id nsimon` should list it. The agenix file changes path on rebuild — restart
+  picoclaw (`systemctl --user restart picoclaw`) if it has stale env.
+- **Bridge offline** → `systemctl status hydroxide` and `journalctl -u hydroxide -e`.
+  Hydroxide can crashloop after a rotation of `~/.config/hydroxide/auth.json`; re-auth
+  via the FIRST-TIME SETUP block at the top of `rpi5/hydroxide.nix`.
+- **Connection refused** on `127.0.0.1:1143` / `:1025` → check `ss -tlnp | grep -E '1143|1025'`;
+  hydroxide binds `0.0.0.0` on those ports.
+- **TLS errors** → encryption is intentionally `none` on the loopback hop; if himalaya
+  insists on TLS, double-check the config block above against `~/.config/himalaya/config.toml`.

--- a/rpi5/picoclaw/skills/protonmail/SKILL.md
+++ b/rpi5/picoclaw/skills/protonmail/SKILL.md
@@ -9,7 +9,7 @@ metadata: {"openclaw":{"emoji":"📧","os":["linux"],"requires":{"bins":["himala
 # ProtonMail (himalaya + hydroxide)
 
 > **PERSONAL mail only.** This skill is wired to the user's personal ProtonMail
-> (`nicolas.simon@protonmail.com`) via the local hydroxide bridge. Work mail is out of scope.
+> (`nsimon@protonmail.com`) via the local hydroxide bridge. Work mail is out of scope.
 
 `himalaya` is a CLI email client. On the rpi5 it talks to **hydroxide**, a third-party
 ProtonMail bridge running as a system service that exposes IMAP on `127.0.0.1:1143` and SMTP
@@ -28,14 +28,14 @@ member of). The himalaya config at `~/.config/himalaya/config.toml` is Nix-manag
 ```toml
 [accounts.proton]
 default = true
-email = "nicolas.simon@protonmail.com"
+email = "nsimon@protonmail.com"
 display-name = "Nicolas Simon"
 
 backend.type = "imap"
 backend.host = "127.0.0.1"
 backend.port = 1143
 backend.encryption.type = "none"
-backend.login = "nicolas.simon@protonmail.com"
+backend.login = "nsimon@protonmail.com"
 backend.auth.type = "password"
 backend.auth.cmd = "cat /run/agenix/protonmail-bridge-password"
 
@@ -43,7 +43,7 @@ message.send.backend.type = "smtp"
 message.send.backend.host = "127.0.0.1"
 message.send.backend.port = 1025
 message.send.backend.encryption.type = "none"
-message.send.backend.login = "nicolas.simon@protonmail.com"
+message.send.backend.login = "nsimon@protonmail.com"
 message.send.backend.auth.type = "password"
 message.send.backend.auth.cmd = "cat /run/agenix/protonmail-bridge-password"
 ```

--- a/rpi5/picoclaw/skills/protonmail/references/configuration.md
+++ b/rpi5/picoclaw/skills/protonmail/references/configuration.md
@@ -1,0 +1,184 @@
+# Himalaya Configuration Reference
+
+Configuration file location: `~/.config/himalaya/config.toml`
+
+## Minimal IMAP + SMTP Setup
+
+```toml
+[accounts.default]
+email = "user@example.com"
+display-name = "Your Name"
+default = true
+
+# IMAP backend for reading emails
+backend.type = "imap"
+backend.host = "imap.example.com"
+backend.port = 993
+backend.encryption.type = "tls"
+backend.login = "user@example.com"
+backend.auth.type = "password"
+backend.auth.raw = "your-password"
+
+# SMTP backend for sending emails
+message.send.backend.type = "smtp"
+message.send.backend.host = "smtp.example.com"
+message.send.backend.port = 587
+message.send.backend.encryption.type = "start-tls"
+message.send.backend.login = "user@example.com"
+message.send.backend.auth.type = "password"
+message.send.backend.auth.raw = "your-password"
+```
+
+## Password Options
+
+### Raw password (testing only, not recommended)
+
+```toml
+backend.auth.raw = "your-password"
+```
+
+### Password from command (recommended)
+
+```toml
+backend.auth.cmd = "pass show email/imap"
+# backend.auth.cmd = "security find-generic-password -a user@example.com -s imap -w"
+```
+
+### System keyring (requires keyring feature)
+
+```toml
+backend.auth.keyring = "imap-example"
+```
+
+Then run `himalaya account configure <account>` to store the password.
+
+## Gmail Configuration
+
+```toml
+[accounts.gmail]
+email = "you@gmail.com"
+display-name = "Your Name"
+default = true
+
+backend.type = "imap"
+backend.host = "imap.gmail.com"
+backend.port = 993
+backend.encryption.type = "tls"
+backend.login = "you@gmail.com"
+backend.auth.type = "password"
+backend.auth.cmd = "pass show google/app-password"
+
+message.send.backend.type = "smtp"
+message.send.backend.host = "smtp.gmail.com"
+message.send.backend.port = 587
+message.send.backend.encryption.type = "start-tls"
+message.send.backend.login = "you@gmail.com"
+message.send.backend.auth.type = "password"
+message.send.backend.auth.cmd = "pass show google/app-password"
+```
+
+**Note:** Gmail requires an App Password if 2FA is enabled.
+
+## iCloud Configuration
+
+```toml
+[accounts.icloud]
+email = "you@icloud.com"
+display-name = "Your Name"
+
+backend.type = "imap"
+backend.host = "imap.mail.me.com"
+backend.port = 993
+backend.encryption.type = "tls"
+backend.login = "you@icloud.com"
+backend.auth.type = "password"
+backend.auth.cmd = "pass show icloud/app-password"
+
+message.send.backend.type = "smtp"
+message.send.backend.host = "smtp.mail.me.com"
+message.send.backend.port = 587
+message.send.backend.encryption.type = "start-tls"
+message.send.backend.login = "you@icloud.com"
+message.send.backend.auth.type = "password"
+message.send.backend.auth.cmd = "pass show icloud/app-password"
+```
+
+**Note:** Generate an app-specific password at appleid.apple.com
+
+## Folder Aliases
+
+Map custom folder names:
+
+```toml
+[accounts.default.folder.alias]
+inbox = "INBOX"
+sent = "Sent"
+drafts = "Drafts"
+trash = "Trash"
+```
+
+## Multiple Accounts
+
+```toml
+[accounts.personal]
+email = "personal@example.com"
+default = true
+# ... backend config ...
+
+[accounts.work]
+email = "work@company.com"
+# ... backend config ...
+```
+
+Switch accounts with `--account`:
+
+```bash
+himalaya --account work envelope list
+```
+
+## Notmuch Backend (local mail)
+
+```toml
+[accounts.local]
+email = "user@example.com"
+
+backend.type = "notmuch"
+backend.db-path = "~/.mail/.notmuch"
+```
+
+## OAuth2 Authentication (for providers that support it)
+
+```toml
+backend.auth.type = "oauth2"
+backend.auth.client-id = "your-client-id"
+backend.auth.client-secret.cmd = "pass show oauth/client-secret"
+backend.auth.access-token.cmd = "pass show oauth/access-token"
+backend.auth.refresh-token.cmd = "pass show oauth/refresh-token"
+backend.auth.auth-url = "https://provider.com/oauth/authorize"
+backend.auth.token-url = "https://provider.com/oauth/token"
+```
+
+## Additional Options
+
+### Signature
+
+```toml
+[accounts.default]
+signature = "Best regards,\nYour Name"
+signature-delim = "-- \n"
+```
+
+### Downloads directory
+
+```toml
+[accounts.default]
+downloads-dir = "~/Downloads/himalaya"
+```
+
+### Editor for composing
+
+Set via environment variable:
+
+```bash
+export EDITOR="vim"
+```

--- a/rpi5/picoclaw/skills/protonmail/references/message-composition.md
+++ b/rpi5/picoclaw/skills/protonmail/references/message-composition.md
@@ -1,0 +1,199 @@
+# Message Composition with MML (MIME Meta Language)
+
+Himalaya uses MML for composing emails. MML is a simple XML-based syntax that compiles to MIME messages.
+
+## Basic Message Structure
+
+An email message is a list of **headers** followed by a **body**, separated by a blank line:
+
+```
+From: sender@example.com
+To: recipient@example.com
+Subject: Hello World
+
+This is the message body.
+```
+
+## Headers
+
+Common headers:
+
+- `From`: Sender address
+- `To`: Primary recipient(s)
+- `Cc`: Carbon copy recipients
+- `Bcc`: Blind carbon copy recipients
+- `Subject`: Message subject
+- `Reply-To`: Address for replies (if different from From)
+- `In-Reply-To`: Message ID being replied to
+
+### Address Formats
+
+```
+To: user@example.com
+To: John Doe <john@example.com>
+To: "John Doe" <john@example.com>
+To: user1@example.com, user2@example.com, "Jane" <jane@example.com>
+```
+
+## Plain Text Body
+
+Simple plain text email:
+
+```
+From: alice@localhost
+To: bob@localhost
+Subject: Plain Text Example
+
+Hello, this is a plain text email.
+No special formatting needed.
+
+Best,
+Alice
+```
+
+## MML for Rich Emails
+
+### Multipart Messages
+
+Alternative text/html parts:
+
+```
+From: alice@localhost
+To: bob@localhost
+Subject: Multipart Example
+
+<#multipart type=alternative>
+This is the plain text version.
+<#part type=text/html>
+<html><body><h1>This is the HTML version</h1></body></html>
+<#/multipart>
+```
+
+### Attachments
+
+Attach a file:
+
+```
+From: alice@localhost
+To: bob@localhost
+Subject: With Attachment
+
+Here is the document you requested.
+
+<#part filename=/path/to/document.pdf><#/part>
+```
+
+Attachment with custom name:
+
+```
+<#part filename=/path/to/file.pdf name=report.pdf><#/part>
+```
+
+Multiple attachments:
+
+```
+<#part filename=/path/to/doc1.pdf><#/part>
+<#part filename=/path/to/doc2.pdf><#/part>
+```
+
+### Inline Images
+
+Embed an image inline:
+
+```
+From: alice@localhost
+To: bob@localhost
+Subject: Inline Image
+
+<#multipart type=related>
+<#part type=text/html>
+<html><body>
+<p>Check out this image:</p>
+<img src="cid:image1">
+</body></html>
+<#part disposition=inline id=image1 filename=/path/to/image.png><#/part>
+<#/multipart>
+```
+
+### Mixed Content (Text + Attachments)
+
+```
+From: alice@localhost
+To: bob@localhost
+Subject: Mixed Content
+
+<#multipart type=mixed>
+<#part type=text/plain>
+Please find the attached files.
+
+Best,
+Alice
+<#part filename=/path/to/file1.pdf><#/part>
+<#part filename=/path/to/file2.zip><#/part>
+<#/multipart>
+```
+
+## MML Tag Reference
+
+### `<#multipart>`
+
+Groups multiple parts together.
+
+- `type=alternative`: Different representations of same content
+- `type=mixed`: Independent parts (text + attachments)
+- `type=related`: Parts that reference each other (HTML + images)
+
+### `<#part>`
+
+Defines a message part.
+
+- `type=<mime-type>`: Content type (e.g., `text/html`, `application/pdf`)
+- `filename=<path>`: File to attach
+- `name=<name>`: Display name for attachment
+- `disposition=inline`: Display inline instead of as attachment
+- `id=<cid>`: Content ID for referencing in HTML
+
+## Composing from CLI
+
+### Interactive compose
+
+Opens your `$EDITOR`:
+
+```bash
+himalaya message write
+```
+
+### Reply (opens editor with quoted message)
+
+```bash
+himalaya message reply 42
+himalaya message reply 42 --all  # reply-all
+```
+
+### Forward
+
+```bash
+himalaya message forward 42
+```
+
+### Send from stdin
+
+```bash
+cat message.txt | himalaya template send
+```
+
+### Prefill headers from CLI
+
+```bash
+himalaya message write \
+  -H "To:recipient@example.com" \
+  -H "Subject:Quick Message" \
+  "Message body here"
+```
+
+## Tips
+
+- The editor opens with a template; fill in headers and body.
+- Save and exit the editor to send; exit without saving to cancel.
+- MML parts are compiled to proper MIME when sending.
+- Use `himalaya message export --full` to inspect the raw MIME structure of received emails.


### PR DESCRIPTION
## Summary

- Adds personal ProtonMail to picoclaw's toolbelt. Vendors `steipete/clawdis@himalaya` as `rpi5/picoclaw/skills/protonmail/` and configures the CLI to talk to the existing hydroxide bridge (IMAP :1143 / SMTP :1025) on loopback.
- `nsimon` joins the `hydroxide` group so himalaya can read `/run/agenix/protonmail-bridge-password` (0440) at invocation time via `backend.auth.cmd = "cat …"`; secret owner is unchanged.
- himalaya config rendered in `rpi5/picoclaw/picoclaw.nix` alongside the existing vdirsyncer/khal blocks — same "picoclaw is the consumer" pattern used for caldav-calendar.

Two follow-up commits fix issues found at verification time: `auth.type = "raw"` was a schema guess that himalaya 1.1.0 rejects (only `password`/`oauth2`); and the real Proton address is `nsimon@protonmail.com`, not `nicolas.simon@`.

## Test plan

- [x] `id nsimon` lists `hydroxide`
- [x] `sudo -u nsimon -i cat /run/agenix/protonmail-bridge-password >/dev/null` → exit 0
- [x] `sudo -u nsimon -i himalaya account list` → shows `proton` (IMAP, SMTP, default)
- [x] `sudo -u nsimon -i himalaya envelope list -o json` → INBOX envelopes returned
- [x] `sudo -u nsimon -i himalaya envelope list --folder Sent -o json` → Sent returned
- [x] `ls /home/nsimon/.picoclaw/workspace/skills/protonmail/` → SKILL.md + references/
- [ ] End-to-end via Telegram: ask picoclaw to summarise the last 3 emails (manual, user-driven)

🤖 Generated with [Claude Code](https://claude.com/claude-code)