### PR TITLE
chore(home): drop stale vim comment in packages.nix

### DIFF
--- a/home/packages.nix
+++ b/home/packages.nix
@@ -70,7 +70,6 @@
       tmux
       tree
       unzip
-      # vim installed by programs.vim (./wakatime.nix), bundles vim-wakatime
       watchman
       wget
       yarn


### PR DESCRIPTION
Tiny follow-up to #234. The placeholder comment for vim is no longer useful now that vim is installed declaratively via `programs.vim` in `home/editors.nix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)