### PR TITLE
feat(aperture): route oMLX (Mac MLX) through Aperture

### DIFF
--- a/home/dotfiles/zsh/aliases.zsh
+++ b/home/dotfiles/zsh/aliases.zsh
@@ -38,3 +38,10 @@ alias claude-beast='ANTHROPIC_BASE_URL=http://localhost:4001 ANTHROPIC_API_KEY=l
 #   pi gemma4:e4b       → beast Ollama
 #   pi auto             → beast-first with codex fallback
 pi() { command pi --provider aperture --model "${1:-gpt-5.5}" "${@:2}"; }
+
+# oMLX (Mac local MLX inference) is reached through Aperture like every other
+# provider — registered in rpi5/tiny-llm-gate.nix as provider=omlx. Invoke with
+#   pi Qwen3.6-27B-4bit
+# Requires `tailscale serve --bg --https=8443 http://127.0.0.1:8000` to be set
+# up once on this Mac so the RPi5 can reach oMLX. The serve config persists
+# across reboots; check with `tailscale serve status`.

--- a/home/dotfiles/zsh/aliases.zsh
+++ b/home/dotfiles/zsh/aliases.zsh
@@ -33,15 +33,20 @@ alias claude-beast='ANTHROPIC_BASE_URL=http://localhost:4001 ANTHROPIC_API_KEY=l
 
 # pi: pi-coding-agent via Aperture → tiny-llm-gate → codex-proxy / beast Ollama.
 # All routes go through https://ai.gate-mintaka.ts.net for observability.
-# Defaults to gpt-5.5 (Codex subscription); pass any tlg model id as $1, e.g.
-#   pi                  → gpt-5.5
+# Pass any tlg model id as $1 to override the default, e.g.
+#   pi                  → default (Qwen3.6-27B-4bit on Mac, gpt-5.5 elsewhere)
 #   pi gemma4:e4b       → beast Ollama
+#   pi gpt-5.5          → Codex subscription
 #   pi auto             → beast-first with codex fallback
-pi() { command pi --provider aperture --model "${1:-gpt-5.5}" "${@:2}"; }
-
-# oMLX (Mac local MLX inference) is reached through Aperture like every other
-# provider — registered in rpi5/tiny-llm-gate.nix as provider=omlx. Invoke with
-#   pi Qwen3.6-27B-4bit
-# Requires `tailscale serve --bg --https=8443 http://127.0.0.1:8000` to be set
-# up once on this Mac so the RPi5 can reach oMLX. The serve config persists
-# across reboots; check with `tailscale serve status`.
+#
+# On Mac the default is Qwen3.6-27B-4bit — local MLX inference on this host,
+# reached through Aperture (registered in rpi5/tiny-llm-gate.nix as
+# provider=omlx). Requires `tailscale serve --bg --https=8443
+# http://127.0.0.1:8000` to be set up once on this Mac so the RPi5 can reach
+# oMLX. The serve config persists across reboots; check with
+# `tailscale serve status`.
+if [[ "$OSTYPE" == darwin* ]]; then
+  pi() { command pi --provider aperture --model "${1:-Qwen3.6-27B-4bit}" "${@:2}"; }
+else
+  pi() { command pi --provider aperture --model "${1:-gpt-5.5}" "${@:2}"; }
+fi

--- a/home/pi-coding-agent/default.nix
+++ b/home/pi-coding-agent/default.nix
@@ -33,7 +33,9 @@ in
 
   # Anthropic baseUrl override is Aperture-routed; the
   # `anthropic-beta: oauth-2025-04-20` header tells Anthropic to honour the
-  # OAuth Bearer that tiny-llm-gate injects.
+  # OAuth Bearer that tiny-llm-gate injects. oMLX is reached through Aperture
+  # too (registered in rpi5/tiny-llm-gate.nix as provider=omlx), so no
+  # per-host provider entry is needed here.
   home.file.".pi/agent/models.json".text = builtins.toJSON {
     providers.anthropic = {
       baseUrl = "https://ai.gate-mintaka.ts.net";

--- a/rpi5/tiny-llm-gate.nix
+++ b/rpi5/tiny-llm-gate.nix
@@ -38,6 +38,16 @@ in
           base_url = "http://127.0.0.1:4040/v1";
           api_key = "unused";
         };
+
+        # oMLX on the Mac (M3 Pro, MLX backend). Reached via the Mac's
+        # `tailscale serve` HTTPS endpoint so the cert is auto-issued by
+        # Tailscale. Mac may be offline (laptop); requests fail in that case,
+        # same posture as codex when its OAuth token is stale.
+        omlx = {
+          type = "openai";
+          base_url = "https://macbook-pro-appleosx-15.gate-mintaka.ts.net:8443/v1";
+          api_key = "unused";
+        };
       };
 
       models = {
@@ -68,6 +78,12 @@ in
         "gpt-5.2"            = { provider = "codex"; upstream_model = "gpt-5.2"; };
         "gpt-5.3-codex"      = { provider = "codex"; upstream_model = "gpt-5.3-codex"; };
         "codex-auto-review"  = { provider = "codex"; upstream_model = "codex-auto-review"; };
+
+        # -- oMLX models (Mac local inference via tailscale serve) --
+        # No fallback: Mac-asleep should surface as an error rather than
+        # silently consume the codex budget.
+        "Qwen3.6-27B-4bit"         = { provider = "omlx"; upstream_model = "Qwen3.6-27B-4bit"; };
+        "Qwen3.6-35B-A3B-4bit-DWQ" = { provider = "omlx"; upstream_model = "Qwen3.6-35B-A3B-4bit-DWQ"; };
 
         # "auto" — local-first model: try gemma4:e4b on beast, fall back to
         # codex gpt-5.5 if beast is unreachable (TCP refused / timeout) or


### PR DESCRIPTION
## Summary
- Add `omlx` upstream provider to `tiny-llm-gate.nix` pointing at the Mac's `tailscale serve` HTTPS endpoint
- Register `Qwen3.6-27B-4bit` and `Qwen3.6-35B-A3B-4bit-DWQ` in the gate's `models` block — `aperture-sync` auto-propagates them to Aperture
- Drop the macOS-only `pi-local` alias and the per-host `omlx` provider in `pi-coding-agent`, since oMLX now goes through Aperture like every other provider

## Why
`pi-local` bypassed Aperture and required a parallel provider config in `home/pi-coding-agent/default.nix`. Routing oMLX through Aperture gives:
- Session/usage logging in Aperture (cost stays $0, but request logs are useful)
- A single source of truth for model registration (`tiny-llm-gate.nix` → `aperture-sync.nix`)
- Uniform invocation: `pi --model Qwen3.6-27B-4bit` instead of `pi-local`

## Architecture
```
pi (Mac, --provider aperture)
  → Aperture (ai.gate-mintaka.ts.net)
  → tiny-llm-gate (:4001 on rpi5, provider=omlx)
  → tailscale serve (macbook-pro-appleosx-15.gate-mintaka.ts.net:8443)
  → oMLX (127.0.0.1:8000 on Mac)
```
Tradeoff: Mac→Pi→Mac round-trip adds Tailscale latency (~2-5s observed for short prompts). No fallback chain — Mac-asleep surfaces as an error rather than silently spending the codex budget.

## Manual prerequisite
On the Mac, run once:
```
tailscale serve --bg --https=8443 http://127.0.0.1:8000
```
Tailscale persists the serve config across reboots. Cert is auto-issued.

## Test plan
- [x] `nixos-rebuild switch --flake .#rpi5` succeeds
- [x] `curl https://ai.gate-mintaka.ts.net/v1/models | jq` lists `Qwen3.6-27B-4bit` and `Qwen3.6-35B-A3B-4bit-DWQ`
- [x] `curl https://ai.gate-mintaka.ts.net/api/config` shows 33 models on `rpi5-gate` (up from 31)
- [x] End-to-end completion via Aperture returns tokens (~4.7s for a 15-token reply)
- [x] `pi --provider aperture --model Qwen3.6-27B-4bit "..."` returns a real answer
- [ ] Mac-offline negative test: request errors cleanly (no codex fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)