### PR TITLE
feat(macos): install Raycast

### DIFF
--- a/macos/components/homebrew.nix
+++ b/macos/components/homebrew.nix
@@ -67,6 +67,7 @@
     "plex"
     "postman"
     "qbittorrent"
+    "raycast"
     "rewind"
     "rocket"
     "sikarugir"


### PR DESCRIPTION
## Summary
- Add `raycast` to the Homebrew casks list

## Test plan
- [x] `darwin-rebuild switch` installs raycast cleanly (brew bundle: 69 → 70 dependencies)
- [x] `/Applications/Raycast.app` exists after activation

🤖 Generated with [Claude Code](https://claude.com/claude-code)