### PR TITLE
feat(home): add jujutsu (jj) alongside git

### DIFF
--- a/home/default.nix
+++ b/home/default.nix
@@ -32,6 +32,7 @@
   xdg.configFile."git/config".source = ./dotfiles/git/gitconfig;
   xdg.configFile."git/config-shared".source = ./dotfiles/git/gitconfig-shared;
   xdg.configFile."git/ignore".source = ./dotfiles/git/gitignore;
+  xdg.configFile."jj/config.toml".source = ./dotfiles/jj/config.toml;
   xdg.configFile."tmux/tmux.conf".source = ./dotfiles/tmux.conf;
   xdg.configFile."atuin/config.toml".source = ./dotfiles/atuin.toml;
   xdg.configFile."mpv/mpv.conf".source = ./dotfiles/mpv.conf;

--- a/home/dotfiles/jj/config.toml
+++ b/home/dotfiles/jj/config.toml
@@ -1,0 +1,22 @@
+[user]
+name = "Nicolas Simon"
+email = "nsimon@pm.me"
+
+[ui]
+default-command = "status"
+pager = "less -FRX"
+
+[signing]
+behavior = "own"
+backend = "gpg"
+key = "DA790614A5E94643A86333BBFDA7E6C61C9EA664"
+
+[git]
+auto-local-bookmark = true
+
+[aliases]
+l = ["log"]
+s = ["status"]
+d = ["diff"]
+n = ["new"]
+e = ["edit"]

--- a/home/dotfiles/zsh/aliases.zsh
+++ b/home/dotfiles/zsh/aliases.zsh
@@ -8,6 +8,7 @@ alias pipupdate="su -c \"pip freeze --local | grep -v '^\-e' | cut -d = -f 1	| x
 alias gc="git checkout"
 alias gcam="git commit --amend --no-edit"
 alias grb="git rebase -i --autosquash"
+alias j="jj"
 alias repo="gh repo view --web"
 alias prs="gh pr list --web"
 alias cpr="createpr"

--- a/home/packages.nix
+++ b/home/packages.nix
@@ -37,6 +37,7 @@
       gnused
       gnugrep
       gzip
+      unstablePkgs.jujutsu
       jq
       k9s
       kompose


### PR DESCRIPTION
## Summary
- Add `unstablePkgs.jujutsu` to the shared Home Manager package set.
- Add `home/dotfiles/jj/config.toml` with identity, GPG signing (same key as gitconfig), `default-command = status`, and short aliases (`l`, `s`, `d`, `n`, `e`).
- Wire the config via `xdg.configFile."jj/config.toml"`.
- Add `alias j="jj"` to `home/dotfiles/zsh/aliases.zsh`.

## Scope
jj-as-frontend, colocated on the existing git repo — git/gh, the personal-identity terminal wrapper, and the `createpr` / `pr` / `issue` / `gmaster` flows are untouched and keep working.

Closes NSI-18

## Test plan
- [ ] `darwin-rebuild build --flake .#nBookPro` succeeds
- [ ] `nixos-rebuild build --flake .#rpi5` succeeds
- [ ] After switch: `jj --version` works and `jj` (no args) runs `status`
- [ ] `git commit` still signs with the existing GPG key
- [ ] `createpr`, `gmaster`, `gmain` still work on a colocated repo

<!-- generated-by-cyrus -->