### PR TITLE
fix(cyrus): enable nix-ld so prebuilt-ELF npm tools run

### DIFF
--- a/rpi5/cyrus.nix
+++ b/rpi5/cyrus.nix
@@ -84,6 +84,25 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    # Cyrus's agent clones user repos and runs whatever lint/test/build the
+    # repo declares. Many npm packages ship per-platform prebuilt ELFs (biome,
+    # esbuild, swc, prisma, sharp, ...) dynamically linked against
+    # /lib/ld-linux-aarch64.so.1 + stock glibc. On NixOS those paths don't
+    # exist and execve fails before the program starts. nix-ld provides the
+    # loader shim at /lib/ld-linux-* and stages a library set under
+    # LD_LIBRARY_PATH so generic-Linux binaries Just Work.
+    programs.nix-ld = {
+      enable = true;
+      libraries = with pkgs; [
+        stdenv.cc.cc.lib  # libstdc++, libgcc_s
+        zlib
+        openssl
+        curl
+        glib
+        libgcc
+      ];
+    };
+
     users.users.${cfg.user} = {
       isSystemUser = true;
       group = cfg.user;


### PR DESCRIPTION
## Summary
- Cyrus's agent clones user repos and runs whatever lint/test/build the repo declares. Many npm packages ship per-platform prebuilt ELFs (biome, esbuild, swc, prisma, sharp, ...) dynamically linked against `/lib/ld-linux-aarch64.so.1` + stock glibc. On NixOS those paths don't exist and `execve` fails before the program starts — the agent reports e.g. "biome could not run locally."
- `programs.nix-ld` provides the loader shim at `/lib/ld-linux-*` and stages a library set under `LD_LIBRARY_PATH`. This is the canonical NixOS escape hatch for generic-Linux binaries.
- Scoped inside `rpi5/cyrus.nix` to keep the concern local to the service that needs it.

## Test plan
- [x] `nixos-rebuild switch --flake .#rpi5` succeeds on the rpi5
- [x] `/lib/ld-linux-aarch64.so.1` resolves to `nix-ld-2.0.6/libexec/nix-ld`
- [x] `cyrus.service` active after activation
- [ ] Next Linear assignment exercises biome inside a user repo without erroring