### PR TITLE
feat(gleaner): wire v0.3.0 quota-gated cron dispatcher

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -167,7 +167,7 @@
     },
     "cl-nix-lite": {
       "inputs": {
-        "flake-parts": "flake-parts_2",
+        "flake-parts": "flake-parts_3",
         "nixpkgs": "nixpkgs",
         "systems": "systems_3",
         "treefmt-nix": "treefmt-nix_2"
@@ -312,6 +312,27 @@
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
+          "gleaner",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777988971,
+        "narHash": "sha256-qIoWPDs+0/8JecyYgE3gpKQxW/4bLW/gp45vow9ioCQ=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "0678d8986be1661af6bb555f3489f2fdfc31f6ff",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": [
           "llm-agents",
           "nixpkgs"
         ]
@@ -330,7 +351,7 @@
         "type": "github"
       }
     },
-    "flake-parts_2": {
+    "flake-parts_3": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
       },
@@ -348,7 +369,7 @@
         "type": "github"
       }
     },
-    "flake-parts_3": {
+    "flake-parts_4": {
       "inputs": {
         "nixpkgs-lib": [
           "nix-citizen",
@@ -369,7 +390,7 @@
         "type": "github"
       }
     },
-    "flake-parts_4": {
+    "flake-parts_5": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
@@ -387,7 +408,7 @@
         "type": "github"
       }
     },
-    "flake-parts_5": {
+    "flake-parts_6": {
       "inputs": {
         "nixpkgs-lib": [
           "pi-mobile",
@@ -409,7 +430,7 @@
         "type": "github"
       }
     },
-    "flake-parts_6": {
+    "flake-parts_7": {
       "inputs": {
         "nixpkgs-lib": [
           "sure-nix",
@@ -571,6 +592,27 @@
         "type": "github"
       }
     },
+    "gleaner": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778779685,
+        "narHash": "sha256-J5WuKAqiA8qETOOV/iMEO0qePZrzMXQUaV5OEwECamk=",
+        "owner": "nSimonFR",
+        "repo": "gleaner",
+        "rev": "1b10f06f682978c62b3b6b8dd8fcb820422cebc2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nSimonFR",
+        "repo": "gleaner",
+        "type": "github"
+      }
+    },
     "gogcli-src": {
       "flake": false,
       "locked": {
@@ -667,7 +709,7 @@
       "inputs": {
         "blueprint": "blueprint",
         "bun2nix": "bun2nix",
-        "flake-parts": "flake-parts",
+        "flake-parts": "flake-parts_2",
         "nixpkgs": [
           "nixpkgs-unstable"
         ],
@@ -692,7 +734,7 @@
       "inputs": {
         "blueprint": "blueprint_2",
         "bun2nix": "bun2nix_2",
-        "flake-parts": "flake-parts_5",
+        "flake-parts": "flake-parts_6",
         "nixpkgs": [
           "pi-mobile",
           "nixpkgs"
@@ -761,7 +803,7 @@
     "nix-citizen": {
       "inputs": {
         "flake-compat": "flake-compat_2",
-        "flake-parts": "flake-parts_3",
+        "flake-parts": "flake-parts_4",
         "nix-gaming": [
           "nix-gaming"
         ],
@@ -803,7 +845,7 @@
     },
     "nix-gaming": {
       "inputs": {
-        "flake-parts": "flake-parts_4",
+        "flake-parts": "flake-parts_5",
         "git-hooks": "git-hooks",
         "nixpkgs": "nixpkgs_5"
       },
@@ -1128,6 +1170,7 @@
       "inputs": {
         "darwin": "darwin",
         "for-sure": "for-sure",
+        "gleaner": "gleaner",
         "gogcli-src": "gogcli-src",
         "goplaces-src": "goplaces-src",
         "home-manager": "home-manager",
@@ -1171,7 +1214,7 @@
     },
     "sure-nix": {
       "inputs": {
-        "flake-parts": "flake-parts_6",
+        "flake-parts": "flake-parts_7",
         "nixpkgs": [
           "nixpkgs"
         ]

--- a/flake.nix
+++ b/flake.nix
@@ -75,6 +75,11 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    gleaner = {
+      url = "github:nSimonFR/gleaner";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     # steipete CLI tools: bump with
     #   sudo nix flake lock --update-input gogcli-src --update-input goplaces-src
     gogcli-src = {
@@ -176,6 +181,7 @@
           inputs.sure-nix.nixosModules.sure
           inputs.for-sure.nixosModules.default
           inputs.pi-mobile.nixosModules.pi-mobile
+          inputs.gleaner.nixosModules.gleaner
           {
             home-manager = {
               useGlobalPkgs = true;

--- a/rpi5/configuration.nix
+++ b/rpi5/configuration.nix
@@ -125,6 +125,7 @@ in
     ./affine.nix
     ./affine-mcp.nix
     ./cyrus.nix
+    ./gleaner.nix
     ./tiny-llm-gate.nix
     ./aperture-sync.nix
     ./claude-remote-control.nix

--- a/rpi5/gleaner.config.yaml
+++ b/rpi5/gleaner.config.yaml
@@ -1,0 +1,43 @@
+# gleaner.config.yaml — quota-gated cron dispatcher (v0.3.0+)
+#
+# Each trigger has a `when` expression over the live claude+codex
+# quota snapshot and a `run` argv. The systemd timer fires `gleaner
+# tick` every services.gleaner.timer.onUnitActiveSec, evaluates each
+# trigger, and execs the matching ones.
+#
+# Identifiers available in `when`:
+#   claude.short_pct / claude.long_pct   (% of window used, 0..100)
+#   claude.extra_usage / claude.ok       (bool)
+#   codex.short_pct  / codex.long_pct    (same)
+#   codex.extra_usage  / codex.ok        (same)
+#
+# Operators: && || < <= > >= == !=. A provider that failed its
+# snapshot has *.ok = false and *_pct = +Inf, so `<` checks exclude.
+
+triggers:
+  # Wiring-health trigger: fires on every tick, just records the
+  # snapshot to the journal. Keep until the next real trigger lands
+  # — then either delete it or tighten its `when`.
+  - name: heartbeat
+    when: "claude.ok || codex.ok"
+    timeout: 5s
+    run:
+      - /run/current-system/sw/bin/logger
+      - -t
+      - gleaner
+      - heartbeat
+
+  # Example, commented out — uncomment + restart `gleaner.timer` once
+  # you're ready for gleaner to actually hand work to cyrus.
+  #
+  # - name: cyrus-handoff
+  #   when: "claude.long_pct < 50 && codex.short_pct < 80"
+  #   timeout: 10m
+  #   env:
+  #     LINEAR_KEY_FILE: /run/agenix/linear-key
+  #   run:
+  #     - bash
+  #     - -c
+  #     - |
+  #       export LINEAR_KEY=$(cat "$LINEAR_KEY_FILE")
+  #       exec claude -p "Pick the next NSI ticket labelled cyrus-ready (oldest first), assign it to the cyrus user, post a one-line ack comment. Use the linear skill. Quit immediately after."

--- a/rpi5/gleaner.nix
+++ b/rpi5/gleaner.nix
@@ -1,0 +1,20 @@
+{ config, lib, pkgs, inputs, ... }:
+
+{
+  # The user account that owns ~/.claude/.credentials.json and
+  # ~/.codex/sessions is `nsimon`. gleaner.service runs as that user so
+  # `gleaner snapshot` can read both at zero token cost.
+  services.gleaner = {
+    enable     = true;
+    user       = "nsimon";
+    configFile = ./gleaner.config.yaml;
+    timer.onUnitActiveSec = "10min";
+    timer.persistent = true;
+  };
+
+  # Expose `gleaner` on the system PATH so the user can run `gleaner
+  # snapshot` from any shell without remembering the nix store path.
+  environment.systemPackages = [
+    inputs.gleaner.packages.${pkgs.system}.default
+  ];
+}


### PR DESCRIPTION
## Summary

Wires the rescoped gleaner (https://github.com/nSimonFR/gleaner/pull/13)
into rpi5. Replaces the abandoned #230, which carried the pre-v0.3
hook script / repo list / profile match — none of which map to v0.3.

Gleaner is now two subcommands:

- \`gleaner snapshot\` — claude + codex utilization at zero token cost.
- \`gleaner tick --config\` — evaluates each trigger's \`when\` expression
  against the live snapshot and execs the matching \`run\` commands.

The systemd timer is the only driver; there's no orchestrator, no
worktrees, no tracker abstraction. Whatever a trigger needs to do
(assign a Linear ticket, kick off a Codex run, post a Slack message)
lives in its \`run\` command — typically a \`claude -p \"…\"\` invocation
that loads the appropriate skill.

## Initial config

The first config ships a single **heartbeat** trigger (\`logger -t
gleaner heartbeat\`) so we can confirm the timer fires + the snapshot
adapters work end-to-end on the rpi5 host without touching tokens. A
**cyrus-handoff** trigger is staged in the YAML as a commented-out
block — uncomment + restart \`gleaner.timer\` once the heartbeat is
healthy and you're ready for gleaner to actually hand work to cyrus.

## Files

- \`flake.nix\` — add gleaner input + module to the rpi5 host.
- \`flake.lock\` — pinned at gleaner@1b10f06 (v0.3.0).
- \`rpi5/configuration.nix\` — import \`./gleaner.nix\`.
- \`rpi5/gleaner.nix\` — 20-line wrapper enabling \`services.gleaner\`.
- \`rpi5/gleaner.config.yaml\` — the heartbeat + commented cyrus-handoff.

## Test plan

- [x] \`nix build .#nixosConfigurations.rpi5.config.system.build.toplevel\` green
- [ ] \`sudo nixos-rebuild switch --flake .#rpi5 --max-jobs 1 -j 1\`
- [ ] \`systemctl status gleaner.timer\` shows active
- [ ] \`systemctl start gleaner.service\` (manual first fire)
- [ ] \`journalctl -u gleaner.service -n 40\` shows:
      \`event=snapshot_ok provider=claude …\`
      \`event=snapshot_ok provider=codex …\`
      \`event=trigger_ok name=heartbeat …\`
      + a matching \`gleaner: heartbeat\` line in \`journalctl -t gleaner\`
- [ ] Wait for one timer-driven fire — confirm \`OnUnitActiveSec=10min\` ticks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)