### PR TITLE
feat(cyrus): add pnpm to service PATH

### DIFF
--- a/rpi5/cyrus.nix
+++ b/rpi5/cyrus.nix
@@ -342,6 +342,9 @@ in
         pkgs.gh
         pkgs.openssh
         pkgs.nodejs_22
+        # Many cyrus-managed repos use pnpm workspaces; agent shells need it
+        # on PATH (corepack can't write into the read-only nix-store node).
+        pkgs.pnpm_10
         # @anthropic-ai/claude-agent-sdk spawns the `claude` CLI as a child.
         # Without it the SDK exits 127 ("command not found") on every session.
         unstablePkgs.claude-code


### PR DESCRIPTION
## Summary
- Cyrus's running service PATH was missing `pnpm`, so any agent session on a pnpm-workspace repo (e.g. terradex NSI-42) hit `pnpm: command not found`.
- Fallback via `corepack enable` failed too: nodejs lives in `/nix/store` → `EROFS` writing the symlink.
- `cyrus-build.service` already includes `pnpm_10`; this just mirrors it to the long-running service.

## Test plan
- [ ] `sudo nixos-rebuild switch --flake .#rpi5 --max-jobs 1 -j 1`
- [ ] `systemctl restart cyrus`
- [ ] Verify: `sudo cat /proc/\$(systemctl show -p MainPID --value cyrus)/environ | tr '\0' '\n' | grep ^PATH` contains a `pnpm` store path
- [ ] Re-trigger an NSI issue on a pnpm repo and confirm `pnpm -r typecheck` runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)