### PR TITLE
feat(affine): expose publicly via Tailscale Funnel on :443

### DIFF
--- a/rpi5/affine.nix
+++ b/rpi5/affine.nix
@@ -208,7 +208,7 @@ in
       HOME = dataDir;
       AFFINE_SERVER_HOST = "127.0.0.1";
       AFFINE_SERVER_PORT = toString port;
-      AFFINE_SERVER_EXTERNAL_URL = "https://${tailnetFqdn}:3010";
+      AFFINE_SERVER_EXTERNAL_URL = "https://${tailnetFqdn}";
       DATABASE_URL = dbUrl;
       REDIS_SERVER_HOST = redisHost;
       REDIS_SERVER_PORT = toString redisPort;
@@ -239,7 +239,7 @@ in
       # endpoints via DI, so link-preview/image-proxy requests go to
       # the cloud worker instead of our local server.
       CLOUD="https://affine-worker.toeverything.workers.dev"
-      SELF="https://${tailnetFqdn}:3010"
+      SELF="https://${tailnetFqdn}"
       for f in ${appDir}/static/js/*.js; do
         if grep -q "$CLOUD" "$f" 2>/dev/null; then
           ${pkgs.gnused}/bin/sed -i "s|$CLOUD|$SELF|g" "$f"

--- a/rpi5/services-registry.nix
+++ b/rpi5/services-registry.nix
@@ -24,7 +24,7 @@
         password = "{{HOMEPAGE_VAR_NEXTCLOUD_PASSWORD}}";
         fields = [ "freespace" "activeusers" "numfiles" "numshares" ];
       }; }
-    { port = 3010;  backend = "http://127.0.0.1:13010"; name = "AFFiNE";         icon = "affine.svg";         category = "Apps"; description = "Collaborative docs";
+    { port = 443;   backend = "http://127.0.0.1:13010"; name = "AFFiNE";         icon = "affine.svg";         category = "Apps"; description = "Collaborative docs"; funnel = true;
       widget = {
         type = "customapi";
         url = "http://127.0.0.1:13010/graphql";
@@ -88,7 +88,9 @@
     { port = 3030;  backend = "http://127.0.0.1:3030";  name = "Wakapi";         icon = "wakatime.svg";       category = "Services"; description = "Coding stats (WakaTime-compatible)"; }
 
     # Backend — API services
-    { port = 443;   backend = "http://127.0.0.1:18789"; name = "PicoClaw";       icon = "mdi-robot";          category = "Backend"; description = "AI gateway"; }
+    # PicoClaw demoted from 443 to 8444 (tailnet-only) so AFFiNE can claim the
+    # bare https://rpi5.gate-mintaka.ts.net URL via Tailscale Funnel.
+    { port = 8444;  backend = "http://127.0.0.1:18789"; name = "PicoClaw";       icon = "mdi-robot";          category = "Backend"; description = "AI gateway"; }
     { port = 4001;  backend = "http://127.0.0.1:4001";  name = "tiny-llm-gate";  icon = "mdi-brain";          category = "Backend"; description = "LLM gateway (OpenAI + Gemini)"; }
     { port = 4040;  backend = "http://127.0.0.1:4040";  name = "Codex Proxy";    icon = "mdi-code-braces";    category = "Backend"; description = "ChatGPT OAuth proxy (token counts + tool_calls)"; }
     { port = 7020;  backend = "http://127.0.0.1:4001/mcp/affine"; name = "AFFiNE MCP"; icon = "mdi-api";       category = "Backend"; description = "AFFiNE MCP gateway (via tiny-llm-gate)"; }


### PR DESCRIPTION
## Summary
- AFFiNE moves from tailnet-only `:3010` → bare `https://rpi5.gate-mintaka.ts.net` with `funnel = true`
- PicoClaw demoted from `:443` (tailnet-only serve) → `:8444` (tailnet-only) to free the funnel slot
- `AFFINE_SERVER_EXTERNAL_URL` + the `SELF` cloud-worker JS patch drop the `:3010` suffix

## Side effects
- **Public signup is now reachable** — disable open registration in AFFiNE admin before announcing the URL.
- **Google Calendar OAuth** redirect URI in Google Cloud Console must be updated to drop `:3010`, otherwise calendar integration breaks.
- **Bookmarks/desktop client** pointed at `:3010` stop working.
- **PicoClaw bookmark** moves to `:8444`.

## Test plan
- [ ] `sudo nixos-rebuild switch --flake .#rpi5 --max-jobs 1 -j 1` succeeds
- [ ] `tailscale funnel status` lists 443/8443/10000 with AFFiNE on 443
- [ ] `curl -sI https://rpi5.gate-mintaka.ts.net` returns AFFiNE
- [ ] `curl -sI https://rpi5.gate-mintaka.ts.net:8444` returns PicoClaw
- [ ] Login still works (sessions may need re-issue due to external URL change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)