### PR TITLE
fix(beast): reduce Star Citizen page-fault stutter

### DIFF
--- a/home/dotfiles/star-citizen/user.cfg
+++ b/home/dotfiles/star-citizen/user.cfg
@@ -1,6 +1,5 @@
 r.graphicsRenderer = 1
 pl_pit.forceSoftwareCursor = 1
-r_TexturesStreamPoolSize = 8192
+r_TexturesStreamPoolSize = 4096
 r_width = 3840
 r_height = 1600
-r_enable_full_gpu_sync = 1

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -493,7 +493,7 @@ in
   zramSwap = {
     enable = true;
     memoryPercent = 100; # 32GB zram = ~64-96GB effective with compression
-    algorithm = "zstd"; # Best compression ratio for Star Citizen
+    algorithm = "lz4hc"; # ~3x faster decompression than zstd — less page-fault stutter in Star Citizen at cost of ~3GB effective RAM
   };
 
   services.udev = {


### PR DESCRIPTION
## Summary

Live diagnosis during a session showed the FPS bottleneck wasn't the GPU (45% util) — it was memory pressure. 30 GB physical RAM was oversubscribed and **Star Citizen alone had 21 GB of its own pages compressed into zram** using `zstd`. zstd decompresses at ~1–1.5 GB/s, so every page fault during gameplay became a frame hitch.

Three changes, smallest-impact-on-config-surface first:

- **\`zramSwap.algorithm\` \`zstd\` → \`lz4hc\`** — ~3–4× faster decompression (~5 GB/s vs ~1.5 GB/s) for ~2.6× compression ratio instead of ~3.1×. At peak observed load (28 GB orig data) the new ratio still fits comfortably in the 30 GB zram pool. We trade ~3 GB of "effective RAM" for dramatically lower page-fault latency, which is what was actually hurting frame pacing.
- **\`r_TexturesStreamPoolSize\` \`8192\` → \`4096\`** — VRAM was at 11.7 / 12 GB on the 3080 Ti with Hyprland + Zen + Discord competing for it. Halving the SC texture pool frees ~4 GB and reduces texture upload stalls.
- **Remove \`r_enable_full_gpu_sync = 1\`** — CryEngine debug flag that forces CPU↔GPU sync after every frame. Should never have been on for gameplay.

Live evidence captured at diagnosis time:

\`\`\`
GPU util:        45%        (not the bottleneck)
VRAM:            11.7/12 GB (saturated)
RAM:             26/30 GB   (saturated)
zram:            28.1 GB orig → 9.1 GB compressed (3.10× zstd)
SC VmSwap:       21.5 GB    (~1/3 of game's working set in zram)
kswapd0:         7.2% CPU   (kernel full-time juggling pages)
Load avg:        20.4
\`\`\`

## Activation

- **zram algo change requires a reboot** — \`nixos-rebuild switch\` writes the new \`/etc/systemd/zram-generator.conf\` but the existing \`zram0\` device was created at boot with the old algorithm and is not reformatted by \`switch\`.
- **\`user.cfg\` is read at game start** — already deployed via the home-manager symlink-back-to-repo; restart SC to apply.

## Test plan

- [ ] \`sudo nixos-rebuild switch --flake path:.#BeAsT\` builds clean
- [ ] After reboot: \`cat /sys/block/zram0/comp_algorithm\` shows \`[lz4hc]\` selected
- [ ] After reboot under similar SC load, \`/sys/block/zram0/mm_stat\` ratio is ~2.5–2.7× (down from 3.1×) and memory pressure (\`/proc/pressure/memory\`) stays comparable or lower
- [ ] In-game: MangoHud frame-time graph shows fewer hitches under planetary travel / quantum-out (heavy texture streaming scenarios)
- [ ] VRAM stays below 11 GB headroom during normal gameplay

🤖 Generated with [Claude Code](https://claude.com/claude-code)