### PR TITLE
fix(cursor): symlink settings to repo so Cursor can write back

### DIFF
--- a/home/editors.nix
+++ b/home/editors.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }:
+{ pkgs, lib, config, ... }:
 let
   wakatimeExt = pkgs.vscode-extensions.wakatime.vscode-wakatime;
   cursorPrefix =
@@ -22,10 +22,13 @@ in
   xdg.configFile."zed/settings.json".source = ./dotfiles/editor/zed-settings.json;
 
   # ── Cursor ──────────────────────────────────────────────────────────
+  # Cursor writes back to settings.json (UI prompts, telemetry opt-outs, etc.),
+  # so symlink to the repo via mkOutOfStoreSymlink instead of a read-only store
+  # path. Just `git commit` after Cursor updates them.
   home.file."${cursorPrefix}/Cursor/User/settings.json".source =
-    ./dotfiles/editor/cursor-settings.json;
+    config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/nic-os/home/dotfiles/editor/cursor-settings.json";
   home.file."${cursorPrefix}/Cursor/User/keybindings.json".source =
-    ./dotfiles/editor/cursor-keybindings.json;
+    config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/nic-os/home/dotfiles/editor/cursor-keybindings.json";
 
   # Install the WakaTime extension on each HM switch. Cursor reuses the
   # VS Code extension API + Open VSX; the CLI is idempotent.


### PR DESCRIPTION
## Summary
- Cursor prompted for settings on every launch because `settings.json` / `keybindings.json` were store-path symlinks (read-only).
- Switched both to `mkOutOfStoreSymlink` pointing at `home/dotfiles/editor/`, matching the existing Star Citizen pattern. Cursor's writes now persist; commit them after.

## Test plan
- [x] `home-manager switch` applies cleanly
- [x] `readlink -f ~/Library/Application\ Support/Cursor/User/settings.json` resolves to `home/dotfiles/editor/cursor-settings.json`
- [x] Target is writable
- [ ] Open Cursor, confirm no settings prompt on next launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)