### PR TITLE
fix(zsh): bind Option+Left/Right in Cursor/VSCode terminals

### DIFF
--- a/home/dotfiles/zsh/bindkeys.zsh
+++ b/home/dotfiles/zsh/bindkeys.zsh
@@ -17,4 +17,8 @@ bindkey -e   # Default to standard emacs bindings, regardless of editor string
 bindkey "[D" backward-word
 bindkey "[C" forward-word
 
+# xterm / VSCode / Cursor: modified arrow keys (Option+Left/Right)
+bindkey "^[[1;3D" backward-word
+bindkey "^[[1;3C" forward-word
+
 autoload -U select-word-style && select-word-style bash


### PR DESCRIPTION
## Summary
- Cursor's xterm.js terminal sends `ESC [ 1 ; 3 D` / `ESC [ 1 ; 3 C` for Option+Left/Right (xterm modified-arrow-key format), which the existing iTerm-style `[D` / `[C` bindings don't cover.
- Without a matching bindkey, zsh consumes `ESC [ 1` as an unknown CSI prefix and the trailing `;3D` lands in the buffer — visible to the user as garbage characters instead of word-jumping.
- Adds two `bindkey` lines mapping the xterm sequences to `backward-word` / `forward-word`. iTerm/Terminal.app keep working via the existing bindings.

## Test plan
- [x] `home-manager switch --flake "path:.#nsimon@nBookPro"` activates cleanly
- [x] In a fresh Cursor terminal: Option+Left jumps word backward, Option+Right jumps word forward (no `;3D` text)
- [ ] iTerm2 Option+Arrow still works (existing `[D`/`[C` bindings untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)