### PR TITLE
chore: sync editor + claude settings, ignore .vscode/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ result
 
 __pycache__/
 .claude/
+.vscode/

--- a/home/dotfiles/claude-settings.json
+++ b/home/dotfiles/claude-settings.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "env": {
+    "ANTHROPIC_BASE_URL": "https://ai.gate-mintaka.ts.net"
+  },
   "permissions": {
     "allow": [
       "Bash(*)",
@@ -61,11 +64,9 @@
       }
     ]
   },
-  "env": {
-    "ANTHROPIC_BASE_URL": "https://ai.gate-mintaka.ts.net"
-  },
-  "effortLevel": "medium",
-  "voiceEnabled": true,
+  "effortLevel": "xhigh",
   "skipDangerousModePermissionPrompt": true,
+  "agentPushNotifEnabled": true,
+  "voiceEnabled": true,
   "trustAll": true
 }

--- a/home/dotfiles/editor/cursor-settings.json
+++ b/home/dotfiles/editor/cursor-settings.json
@@ -148,6 +148,7 @@
   "gitlens.graph.layout": "editor",
   "datadog.telemetry.setup.enableTelemetry": "disabled",
   "datadog.telemetry.setup.enableAgentObservability": false,
-  "datadog.staticAnalysis.notification.suppressOnboarding": true,
   "datadog.connection.notification.suppressSignInNotification": true,
+  "window.autoDetectColorScheme": false,
+  "datadog.codeSecurity.notification.suppressOnboarding": true,
 }


### PR DESCRIPTION
## Summary
- `claude-settings.json`: writeback after upstream Claude Code app changes — `effortLevel` bumped to `xhigh`, `agentPushNotifEnabled` added, keys reordered to match the app's serialization order.
- `cursor-settings.json`: writeback from Cursor — adds `window.autoDetectColorScheme: false` and renames the Datadog suppress-onboarding key (`staticAnalysis.notification.suppressOnboarding` → `codeSecurity.notification.suppressOnboarding`) to match the new extension schema.
- `.gitignore`: add `.vscode/` so Cursor/VSCode-generated workspace stubs stop showing up in `git status`.

## Test plan
- [x] `git status` clean after the commit
- [ ] `home-manager switch --flake "path:.#nsimon@nBookPro"` activates cleanly with new claude/cursor settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)