### PR TITLE
fix(wakapi): disable built-in wakatime.com importer

### DIFF
--- a/rpi5/wakapi.nix
+++ b/rpi5/wakapi.nix
@@ -28,6 +28,14 @@ in {
         allow_signup = false;
         insecure_cookies = false;
       };
+      # Disable wakapi's built-in scheduled wakatime.com importer.
+      # Why: wakatime.com warned us twice (2026-05-18, 2026-05-19) about the daily
+      # POST to /api/v1/users/current/data_dumps that the binary fires at 04:15
+      # whenever a user has a wakatime_api_key saved. The user-account key was
+      # also cleared, but this disables the scheduler at the source.
+      app = {
+        import_enabled = false;
+      };
       mail = {
         enabled = true;
         provider = "smtp";


### PR DESCRIPTION
## Summary
- PR #252 removed the external systemd `wakapi-autoimport` timer, but the **wakapi binary itself** kept POSTing to `https://api.wakatime.com/api/v1/users/current/data_dumps` at 04:15 every day because the nSimon user profile had a `wakatime_api_key` saved.
- Wakatime sent a **second** warning email on 2026-05-19. Logs confirm the daily fire on May 16/17/18/19.
- Sets `app.import_enabled = false` in wakapi config to disable the scheduler at the binary level.
- Also cleared the `wakatime_api_key` column on the live DB (41 → 0 bytes) so tomorrow's 04:15 doesn't fire before this lands.

## Test plan
- [ ] `sudo nixos-rebuild switch --flake .#rpi5 --max-jobs 1 -j 1`
- [ ] `journalctl -u wakapi -f` around 04:15 tomorrow → no "running wakatime dump import" line
- [ ] wakapi UI still loads at https://rpi5.gate-mintaka.ts.net:3030

🤖 Generated with [Claude Code](https://claude.com/claude-code)