### PR TITLE
feat(beast): alfie couch user + SC perf tuning + Plex media stack

### DIFF
--- a/home/dotfiles/star-citizen/launcher.cfg
+++ b/home/dotfiles/star-citizen/launcher.cfg
@@ -16,14 +16,14 @@ PROTONPATH="$HOME/.var/app/io.github.mactan_sc.RSILauncher/.local/share/Steam/co
 # and is not confused with RSI Launcher's own per-session GL cache.
 # home.nix grants the Flatpak --filesystem access to this path.
 __GL_SHADER_DISK_CACHE=1
-__GL_SHADER_DISK_CACHE_SIZE=10737418240
+__GL_SHADER_DISK_CACHE_SIZE=21474836480 # 20 GB — SC 4.x Vulkan path compiles a lot; bigger cache = fewer evictions = less first-frame stutter on revisits
 __GL_SHADER_DISK_CACHE_PATH="$HOME/.cache/nvidia-shader-cache/star-citizen"
 __GL_SHADER_DISK_CACHE_SKIP_CLEANUP=1
 __GL_THREADED_OPTIMIZATIONS=1
 
-# Mesa (AMD/Intel) shader cache options
+# Mesa (AMD/Intel) shader cache options — unused on NVIDIA but kept for parity
 MESA_SHADER_CACHE_DIR="$WINEPREFIX"
-MESA_SHADER_CACHE_MAX_SIZE="10G"
+MESA_SHADER_CACHE_MAX_SIZE="20G"
 
 # Logs to $HOME/.local/share/umu/steamrt3/var/
 # STEAM_LINUX_RUNTIME_LOG=1
@@ -45,10 +45,15 @@ MANGOHUD=1
 SDL_JOYSTICK_HIDAPI=0
 PROTON_DISABLE_HIDRAW=0x231D/0x0200,0x231D/0x0205
 
-# DLSS investigation notes (all disabled — caused crashes):
-# - PROTON_FORCE_NVAPI=1: sets DXVK_NVAPI_DRIVER_VERSION=99999 for ALL Wine procs, breaks RSILauncher
-# - NVIDIA_WINE_DLL_DIR: enables NGX init but nvngx_dlssg.dll causes ACCESS_VIOLATION (0xC0000005)
-# - DXVK_NVAPI_DRS_NGX_DLSS_*_OVERRIDE: requires NVIDIA_WINE_DLL_DIR to actually show DLSS in-game
+# DLSS: works out of the box on GE-Proton 10-30 — NVIDIA_WINE_DLL_DIR is injected by
+# proton automatically and SC picks up DLSS in the in-game Render Quality settings.
+# No env vars needed here.
+#
+# Historical (kept in case it regresses on a future GE-Proton bump):
+# - PROTON_FORCE_NVAPI=1 once broke RSILauncher by setting DXVK_NVAPI_DRIVER_VERSION=99999
+#   globally → don't enable it; rely on proton's per-app injection instead.
+# - Earlier GE-Proton versions crashed with ACCESS_VIOLATION (0xC0000005) in nvngx_dlssg.dll
+#   (DLSS Frame Generation). Status on 10-30: untested by us — re-test before assuming it works.
 
 # Use Wine's Wayland backend instead of X11/Xwayland.
 # Fixes: BadWindow (X_UnmapWindow, XID 0x5x00001, serial ~320) fatal crash in RSI

--- a/home/dotfiles/star-citizen/user.cfg
+++ b/home/dotfiles/star-citizen/user.cfg
@@ -1,5 +1,18 @@
 r.graphicsRenderer = 1
 pl_pit.forceSoftwareCursor = 1
-r_TexturesStreamPoolSize = 4096
+r_TexturesStreamPoolSize = 3072
 r_width = 3840
 r_height = 1600
+
+# Streaming / I/O — reduce mid-flight hitches when assets stream in
+sys_streaming_CPU = 1
+sys_PakStreamCache = 1
+
+# Cheap visual cuts — no perceptible loss in motion, real GPU savings
+r_FogShadows = 0
+e_ParticlesShadows = 0
+r_SSReflHalfRes = 1
+r_ssdoHalfRes = 1
+
+# Don't burn CPU/GPU at full tilt when alt-tabbed
+sys_maxIdleFps = 60

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -169,8 +169,14 @@ in
       "video"
       "audio"
       "input"
+      "seat"
     ];
   };
+
+  # Share nsimon's Hyprland config with alfie when she logs into Hyprland (after exiting gamescope).
+  systemd.tmpfiles.rules = [
+    "L+ /home/alfie/.config/hypr/hyprland.conf - - - - ${./dotfiles/hypr/hyprland.conf}"
+  ];
 
   environment.systemPackages = with pkgs; [
     cage

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -211,7 +211,7 @@ in
   services.openssh.enable = true;
 
   services.flatpak.enable = true;
-  
+
   programs.hyprland.enable = true;
 
   xdg.portal = {

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -319,8 +319,10 @@ in
     "${pkgs.dbus}/bin/dbus-run-session ${pkgs.hyprland}/bin/Hyprland --config ${greeterHyprlandConfig}";
 
   # Auto-login alfie into Steam gamescope at boot. After logout, default_session (greeter) takes over.
+  # `programs.steam.gamescopeSession.enable = true` adds the steam-gamescope wrapper to
+  # environment.systemPackages (a separate derivation, NOT under ${pkgs.steam}/bin) — invoke by bare name.
   services.greetd.settings.initial_session = {
-    command = "${pkgs.steam}/bin/steam-gamescope";
+    command = "steam-gamescope";
     user = "alfie";
   };
 

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -75,7 +75,7 @@ in
       "nvidia-drm.fbdev=1" # Enable framebuffer device support
       "acpi_enforce_resources=lax" # Fix OpenRGB I2C/SMBus detection bug (GitLab issue #5059)
       "zswap.enabled=0" # Disable zswap when using zram (Star Citizen optimization)
-      "transparent_hugepages=madvise" # Allow large memory apps (Star Citizen) to use 2MB pages, reducing TLB pressure
+      "transparent_hugepage=always" # Auto-promote 4KB→2MB pages for all processes (Star Citizen + Wine don't request madvise themselves); cuts TLB miss overhead on the 21 GB working set. Singular spelling — `transparent_hugepages` (plural) is silently ignored by the kernel.
     ];
 
     kernel.sysctl = {
@@ -87,6 +87,7 @@ in
       "vm.dirty_expire_centisecs" = 1500; # Flush dirty pages after 15s (was 30s)
       "vm.dirty_writeback_centisecs" = 300; # Check for dirty pages every 3s (was 5s)
       "vm.min_free_kbytes" = 262144; # Keep 256MB free to prevent emergency reclaim I/O storms
+      "vm.vfs_cache_pressure" = 50; # Default 100. Keeps dentry/inode cache around longer — helps SC's tens of thousands of small asset files re-open faster on subsequent loads
     };
 
     kernelModules = [
@@ -448,6 +449,11 @@ in
       }
     ];
   };
+
+  # Override hardware-configuration.nix to disable atime writes on /. SC reads tens of
+  # thousands of asset files; relatime still issues writes on first read each day per file.
+  # noatime drops them entirely.
+  fileSystems."/".options = [ "noatime" ];
 
   fileSystems."/mnt/games" = {
     device = "/dev/disk/by-label/Games\\x20SSD";

--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -160,6 +160,18 @@ in
     ];
   };
 
+  # Couch user — auto-logs into Steam gamescope session at boot (see initial_session below).
+  # Password set manually via: sudo passwd alfie
+  users.users.alfie = {
+    isNormalUser = true;
+    home = "/home/alfie";
+    extraGroups = [
+      "video"
+      "audio"
+      "input"
+    ];
+  };
+
   environment.systemPackages = with pkgs; [
     cage
     ddcutil
@@ -299,6 +311,12 @@ in
   # Use Hyprland instead of cage for greeter — enables hypridle DPMS (power saving after WOL)
   services.greetd.settings.default_session.command = lib.mkForce
     "${pkgs.dbus}/bin/dbus-run-session ${pkgs.hyprland}/bin/Hyprland --config ${greeterHyprlandConfig}";
+
+  # Auto-login alfie into Steam gamescope at boot. After logout, default_session (greeter) takes over.
+  services.greetd.settings.initial_session = {
+    command = "${pkgs.steam}/bin/steam-gamescope";
+    user = "alfie";
+  };
 
   users.users.greeter = {
     isSystemUser = true;

--- a/nixos/home.nix
+++ b/nixos/home.nix
@@ -32,6 +32,18 @@
 
   '';
 
+  # Plex HTPC inherits QT_STYLE_OVERRIDE=Adwaita-Dark and QT_QPA_PLATFORMTHEME=qt5ct
+  # from the host session. Neither the Adwaita-Dark Qt style nor qt5ct's plugin is
+  # available inside the freedesktop 23.08 runtime, so the QML engine fails to load
+  # WebWindow.qml ("module \"Adwaita-Dark\" is not installed") and the app segfaults
+  # during the shutdown that follows. Unsetting both lets Qt fall back to its
+  # built-in default style, which is what the app expects.
+  home.activation.plexHtpcFlatpakOverrides = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+    ${pkgs.flatpak}/bin/flatpak override --user tv.plex.PlexHTPC \
+      --unset-env=QT_STYLE_OVERRIDE \
+      --unset-env=QT_QPA_PLATFORMTHEME
+  '';
+
   services.flatpak.remotes = [
     {
       name = "RSILauncher";
@@ -42,6 +54,7 @@
   services.flatpak.packages = [
     { appId = "io.github.mactan_sc.RSILauncher"; origin = "RSILauncher"; }
     { appId = "org.freedesktop.Platform.VulkanLayer.MangoHud"; origin = "flathub"; }
+    { appId = "tv.plex.PlexHTPC"; origin = "flathub"; }
   ];
 
   programs.zsh.zplug.plugins = [


### PR DESCRIPTION
## Summary

- **Alfie couch user**: new local user `alfie` with auto-login into Steam gamescope via greetd `initial_session`; `/mnt/games/SteamLibrary` pre-configured as shared library (group-writable)
- **Star Citizen perf**: `transparent_hugepage=always`, `vfs_cache_pressure=50`, `noatime` on `/`; shader cache bumped to 20 GB; streaming/fog/shadow micro-opts in `user.cfg`; DLSS notes updated for GE-Proton 10-30
- **Plex media stack**: local empty PMS for cast discovery, PlexHTPC flatpak, `plex-mpv-shim` for 4K HDR HEVC via mpv; PlexHTPC Qt env unset to fix segfault on close