### PR TITLE
fix(claude): resolve cluster.local MCP hostnames via /etc/hosts

### DIFF
--- a/home/mcp.nix
+++ b/home/mcp.nix
@@ -28,10 +28,9 @@ let
     "trusk-argocd"      = { type = "http"; url = "http://gateway-mcp.dev-tools.svc.cluster.local:3000/mcp"; };
     "trusk-grafana"     = { type = "http"; url = "http://gateway-mcp.dev-tools.svc.cluster.local:8000/mcp"; };
     "trusk-datadog"     = { type = "http"; url = "http://gateway-mcp.dev-tools.svc.cluster.local:9000/mcp"; };
-    "trusk-github"      = { type = "sse";  url = "http://supergateway-mcp.dev-tools.svc.cluster.local:7001/sse"; };
-    "trusk-context7"    = { type = "sse";  url = "http://supergateway-mcp.dev-tools.svc.cluster.local:7002/sse"; };
-    "trusk-steampipe"   = { type = "sse";  url = "http://steampipe-mcp-server.dev-tools.svc.cluster.local:9194/sse"; };
-    "trusk-searxncrawl" = { type = "sse";  url = "http://searxncrawl-mcp.dev-tools.svc.cluster.local:7010/sse"; };
+    "trusk-github"      = { type = "http"; url = "http://supergateway-mcp.dev-tools.svc.cluster.local:7001/mcp"; };
+    "trusk-context7"    = { type = "http"; url = "http://supergateway-mcp.dev-tools.svc.cluster.local:7002/mcp"; };
+    "trusk-steampipe"   = { type = "http"; url = "http://steampipe-mcp-server.dev-tools.svc.cluster.local:9194/mcp"; };
     firecrawl           = { type = "http"; url = "https://mcp.firecrawl.dev/fc-c6a062b4ff1849d3991eeb116c0632a4/v2/mcp"; };
 
     # Private — secrets loaded at runtime via wrapper scripts

--- a/macos/scripts/tun2proxy-work.sh
+++ b/macos/scripts/tun2proxy-work.sh
@@ -11,6 +11,18 @@ TUN2PROXY="/opt/homebrew/opt/tun2proxy/bin/tun2proxy-bin"
 GW="10.0.0.1"
 MARKER="# WORK-TAILSCALE-MANAGED"
 
+# Cluster-internal MCP hostnames that Claude Code can't resolve via
+# /etc/resolver/cluster.local (its HTTP client bypasses macOS's split-horizon
+# resolver). We dig each via the cluster CoreDNS reached over tun2proxy and
+# pin the answer into /etc/hosts under the same MARKER. See home/mcp.nix for
+# the URLs that reference these names.
+CLUSTER_DNS="192.168.64.10"
+CLUSTER_HOSTS=(
+  "gateway-mcp.dev-tools.svc.cluster.local"
+  "supergateway-mcp.dev-tools.svc.cluster.local"
+  "steampipe-mcp-server.dev-tools.svc.cluster.local"
+)
+
 # Wait for work tailscaled
 for _ in $(seq 1 30); do $TS --socket=$SOCK status >/dev/null 2>&1 && break; sleep 2; done
 
@@ -38,6 +50,14 @@ for p in (data.get('Peer') or {}).values():
     DNS)    echo "$value $extra $MARKER" ;;
   esac
 done > /tmp/hosts.work
+
+# Resolve cluster.local MCP hostnames via cluster CoreDNS and append.
+# Claude Code's MCP HTTP transport doesn't honor /etc/resolver/cluster.local,
+# so /etc/hosts is the only path that works for it.
+for h in "${CLUSTER_HOSTS[@]}"; do
+  ip=$(/usr/bin/dig +short +time=2 +tries=1 "@$CLUSTER_DNS" "$h" 2>/dev/null | /usr/bin/head -1)
+  [ -n "$ip" ] && echo "$ip $h $MARKER" >> /tmp/hosts.work
+done
 
 # Update /etc/hosts atomically
 grep -v "$MARKER" /etc/hosts > /tmp/hosts.clean 2>/dev/null || true


### PR DESCRIPTION
## Summary

- Claude Code's MCP HTTP transport bypasses macOS's `/etc/resolver/cluster.local`, so every `*.dev-tools.svc.cluster.local` MCP entry fails with a misleading `ConnectionRefused after 11ms (errno: none)` while `curl`/`dig`/Node's `dns.lookup` work fine from the same shell.
- `tun2proxy-work.sh` now resolves the three cluster MCP hostnames via cluster CoreDNS (`192.168.64.10`, reached over the tun2proxy bridge) and pins each into `/etc/hosts` under the existing `WORK-TAILSCALE-MANAGED` marker — the daily 06:00 launchd refresh keeps the IPs fresh.
- `home/mcp.nix`: flip `trusk-github / trusk-context7 / trusk-steampipe` from legacy SSE to streamable-HTTP at `/mcp` (servers no longer serve `/sse`), and drop `trusk-searxncrawl` — the in-cluster service is gone.

## Why

Diagnosed by running ``claude --print --debug`` with the HM-injected MCP config and tailing stderr:

\`\`\`
MCP server "trusk-datadog": Testing basic HTTP connectivity to http://gateway-mcp.dev-tools.svc.cluster.local:9000/mcp
MCP server "trusk-datadog": HTTP Connection failed after 11ms: Unable to connect. (code: ConnectionRefused, errno: none)
\`\`\`

Confirmed in plain Node: \`dns.lookup\` returns \`192.168.111.84\`, \`dns.resolve4\` returns \`ENOTFOUND\`. Default \`fetch\` uses \`dns.lookup\` and works; Claude's custom dispatcher takes a path that does not honor \`/etc/resolver/*\`. \`/etc/hosts\` is the only resolver hook Claude's HTTP path respects in this configuration.

After adding the hosts entries: \`trusk-datadog/k8s/argocd/grafana\` all report \`Successfully connected (transport: http) in ~65ms\`.

## Test plan

- [x] \`bash -n macos/scripts/tun2proxy-work.sh\` (syntax OK)
- [x] \`nix-instantiate --parse home/mcp.nix\` (syntax OK)
- [x] \`claude --print --debug --strict-mcp-config --mcp-config <hm-config>\` → \`trusk-datadog/k8s/argocd/grafana\` all connect; tools/list returns datadog tools
- [ ] After \`darwin-rebuild switch\`: \`sudo launchctl kickstart -k system/org.nixos.tun2proxy-work\` and confirm \`grep WORK-TAILSCALE-MANAGED.*cluster.local /etc/hosts\` has 3 entries
- [ ] After rebuild: \`trusk-github\` connects (already verified upstream at \`/mcp\` returns 200); \`trusk-context7 / trusk-steampipe\` are config-correct but their cluster pods currently return 404 — server-side issue, not bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)