### PR TITLE
feat(beast): share nsimon's hyprland config with alfie + seat group

### DIFF
--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -169,8 +169,14 @@ in
       "video"
       "audio"
       "input"
+      "seat"
     ];
   };
+
+  # Share nsimon's Hyprland config with alfie when she logs into Hyprland (after exiting gamescope).
+  systemd.tmpfiles.rules = [
+    "L+ /home/alfie/.config/hypr/hyprland.conf - - - - ${./dotfiles/hypr/hyprland.conf}"
+  ];
 
   environment.systemPackages = with pkgs; [
     cage


### PR DESCRIPTION
## Summary
- Stack on top of #258 (`fix/sc-fps-mem-pressure`).
- Symlink alfie's `~/.config/hypr/hyprland.conf` to nsimon's curated config via `systemd-tmpfiles` — fixes broken Xwayland/Steam/cursor on NVIDIA Wayland and the missing vertical-monitor transform.
- Add `seat` to alfie's groups (required for Wayland seat management; nsimon already has it).

## Test plan
- [ ] `sudo nixos-rebuild switch --flake .#BeAsT` on beast from this branch
- [ ] `id alfie` shows `seat` (gid 991)
- [ ] `sudo readlink /home/alfie/.config/hypr/hyprland.conf` resolves into `/nix/store/.../hyprland.conf`
- [ ] alfie can log into Hyprland after exiting gamescope and the LG ultrawide displays normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)