### PR TITLE
chore(monitoring): drop http-health-alert timer

### DIFF
--- a/rpi5/monitoring.nix
+++ b/rpi5/monitoring.nix
@@ -91,35 +91,6 @@ $FAILED"
     };
   };
 
-  # ── Alert: HTTP health checks ────────────────────────────────────────────────
-  systemd.services.http-health-alert = {
-    description = "Alert on unhealthy HTTP services";
-    serviceConfig = {
-      Type = "oneshot";
-      ExecStart = pkgs.writeShellScript "http-health-alert" ''
-        CURL="${pkgs.curl}/bin/curl"
-        FAILURES=""
-        $CURL -sf --max-time 10 http://127.0.0.1:18789/health > /dev/null 2>&1 || FAILURES="$FAILURES
-- picoclaw (18789/health)"
-        $CURL -sf --max-time 10 http://127.0.0.1:${toString beszelHubPort}/api/health > /dev/null 2>&1 || FAILURES="$FAILURES
-- beszel (${toString beszelHubPort}/api/health)"
-        $CURL -sf --max-time 10 http://127.0.0.1:13900/api/v1/health > /dev/null 2>&1 || FAILURES="$FAILURES
-- dawarich (13900/api/v1/health)"
-        if [ -n "$FAILURES" ]; then
-          ${telegramNotify} "<b>HTTP health check failed on rpi5</b>
-$FAILURES"
-        fi
-      '';
-    };
-  };
-  systemd.timers.http-health-alert = {
-    wantedBy = [ "timers.target" ];
-    timerConfig = {
-      OnBootSec = "2m";
-      OnUnitActiveSec = "2m";
-    };
-  };
-
   # ── Alert: earlyoom kills ────────────────────────────────────────────────────
   systemd.services.earlyoom-alert = {
     description = "Alert on earlyoom OOM kills";


### PR DESCRIPTION
## Summary
- Remove the `http-health-alert` systemd service + timer from `rpi5/monitoring.nix`.
- `systemd-failed-alert` already catches the same failure modes via systemd unit state — picoclaw, beszel-hub, and dawarich all have `Restart=on-failure`, so a fatal crash surfaces as a failed unit and pages Telegram through that path.
- Also clears a future footgun: had the probe list ever been extended to one of the eight socket-activated idle-sleep services, the 2-min curl cadence would have re-armed their idle timers (≥600s) indefinitely, defeating the RAM savings from the recent socket-activate migration.

## Test plan
- [ ] `sudo nixos-rebuild switch --flake /home/nsimon/nic-os#rpi5 --max-jobs 1 -j 1` succeeds
- [ ] `systemctl list-timers | rg http-health-alert` returns nothing
- [ ] `systemctl status systemd-failed-alert.timer` still active
- [ ] Kill picoclaw manually → confirm Telegram fires via systemd-failed-alert within ~2 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)