### PR TITLE
fix(picoclaw): group_trigger.mention_only + allow Alfie in Telegram

### DIFF
--- a/rpi5/picoclaw/picoclaw.nix
+++ b/rpi5/picoclaw/picoclaw.nix
@@ -114,7 +114,11 @@ let
       # migrator on every boot).
       # `allow_from` accepts stringified IDs; numeric-only ID avoids the
       # username/ID mismatch bug reported in sipeed/picoclaw#62/#310.
-      allow_from = [ (toString telegramChatId) ];
+      # Senders (not chats): adding a user id also grants them DM access.
+      allow_from = [
+        (toString telegramChatId) # nSimon
+        "8627259779" # Alfie
+      ];
       use_markdown_v2 = false;
       streaming.enabled = true;
       # In group chats, only respond when the bot is @mentioned (otherwise it
@@ -189,7 +193,7 @@ let
       # Reuse OpenClaw's port so Tailscale Serve (:443 → :18789) keeps working
       # without downstream changes.
       port = 18789;
-      log_level = "debug"; # TEMP: revert to "info" once group_trigger.mention_only is verified
+      log_level = "info";
     };
   };
 

--- a/rpi5/picoclaw/picoclaw.nix
+++ b/rpi5/picoclaw/picoclaw.nix
@@ -189,7 +189,7 @@ let
       # Reuse OpenClaw's port so Tailscale Serve (:443 → :18789) keeps working
       # without downstream changes.
       port = 18789;
-      log_level = "info";
+      log_level = "debug"; # TEMP: revert to "info" once group_trigger.mention_only is verified
     };
   };
 

--- a/rpi5/picoclaw/picoclaw.nix
+++ b/rpi5/picoclaw/picoclaw.nix
@@ -117,8 +117,10 @@ let
       allow_from = [ (toString telegramChatId) ];
       use_markdown_v2 = false;
       streaming.enabled = true;
-      # Require @mention in groups (OpenClaw parity)
-      require_mention_in_groups = true;
+      # In group chats, only respond when the bot is @mentioned (otherwise it
+      # answers every message). `require_mention_in_groups` is silently
+      # ignored by picoclaw's schema — the real key is `group_trigger.mention_only`.
+      group_trigger.mention_only = true;
     };
 
     tools = {


### PR DESCRIPTION
## Summary
Two related changes for picoclaw's Telegram integration, verified end-to-end on rpi5.

### 1. Group mention filter (the original bug)
`require_mention_in_groups` at `rpi5/picoclaw/picoclaw.nix:121` is **not** a key in picoclaw's config schema — Go's default `json.Unmarshal` silently ignored it. The real schema key is `channels.telegram.group_trigger.mention_only` (see [`GroupTriggerConfig`](https://github.com/sipeed/picoclaw/blob/main/pkg/config/config.go#L319-L323)). Without the fix, picoclaw would reply to *every* message from an allowed sender in any group it's in.

### 2. Allow Alfie
Add Alfie's Telegram user_id (`8627259779`) to `allow_from`. Verified via debug logging that he was being rejected by the allowlist when @mentioning the bot in the family group `-1003356011841` ("nSimon, ServaTilis and Alfie").

**Caveat**: `allow_from` is sender-based, not chat-based — adding Alfie's id also lets him DM the bot directly. Acceptable for now.

## Commits
1. `fix(picoclaw): use group_trigger.mention_only for group chats` — the dead-config fix
2. `chore(picoclaw): bump log_level to debug (temporary)` — used for verification
3. `feat(picoclaw): allow Alfie in Telegram + revert debug log_level` — finalizes both changes

(Commits 2+3 can be squashed into commit 1 if you prefer a clean history before merging.)

## Live verification (rpi5, gen 19, applied from worktree)
- ✅ `~/.picoclaw/config.json` → `allow_from: ["82389391","8627259779"]`, `group_trigger.mention_only: true`, `log_level: "info"`
- ✅ nSimon `@ServaTilisBot ping` → bot replied `pong` in 2 s (full agent loop: receive → strip mention → process → llm_request → outbound)
- ✅ Alfie (id `8627259779`) was rejected pre-fix, will now pass after this merge propagates from main (current rpi5 state already applied from the worktree)
- ✅ Anonymous-admin posts (Telegram pseudo-user `1087968824` / `@GroupAnonymousBot`) confirmed still blocked — by design, we won't allowlist that

## Notes for the reviewer
- The system is already running this configuration (rebuilt from the worktree path). Merging just lands it on `main` so future rebuilds don't revert it.
- The "Remain Anonymous" admin toggle on Telegram groups replaces a member's real user_id with `1087968824` — so anonymous admins can never be granted access. Alfie disabled it on his admin role during testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)