### PR TITLE
feat(picoclaw): immich-memories skill (on-this-day Telegram digest)

### DIFF
--- a/rpi5/picoclaw/skills/immich-memories/SKILL.md
+++ b/rpi5/picoclaw/skills/immich-memories/SKILL.md
@@ -1,76 +1,74 @@
 ---
 name: immich-memories
-description: Send a Telegram reminder of today's Immich "on this day" memories, with photo attachments. Use when the user asks about Immich memories, on-this-day, or wants a recap of past photos.
+description: Query today's Immich "on this day" memories and print a summary picoclaw can relay. Use when the user asks about Immich memories, on-this-day, or a recap of past photos from today's date.
 homepage: https://immich.app
-metadata: {"openclaw":{"emoji":"📸","requires":{"bins":["python3"]},"agenix":["immich-api-key","telegram-bot-token"]}}
+metadata: {"openclaw":{"emoji":"📸","requires":{"bins":["python3"]},"agenix":["immich-api-key"]}}
 ---
 
 # Immich on-this-day reminder
 
-Sends today's Immich on-this-day memories to a Telegram chat as one album per memory (preview thumbnails) with a clickable Immich memory link in the caption. Exits silently when today has no memories with assets.
+Queries Immich's on-this-day memories for the current calendar day and prints a compact summary (year + photo/video counts + clickable Immich link per memory). Picoclaw reads the stdout and relays it to the user — the script does not call Telegram itself.
+
+Empty stdout means today has no memories with assets; relay something like "no Immich memories for today" in that case.
 
 ## When to use
 
-- "show me / send me / what's on this day in Immich"
+- "show me / what's on this day in Immich"
 - "Immich memories" / "any photos from today in past years"
-- A scheduled (cron) daily Immich digest
+- A scheduled (cron) daily Immich digest where picoclaw owns the Telegram message
 
 ## Default invocation
 
-The two secrets are already on disk as agenix files readable by the picoclaw user; the chat ID is the picoclaw owner's (numeric Telegram ID).
+`immich-api-key` is an agenix file on disk readable by the picoclaw user.
 
 ```bash
 IMMICH_API_KEY=$(cat /run/agenix/immich-api-key) \
-TELEGRAM_BOT_TOKEN=$(cat /run/agenix/telegram-bot-token) \
-TELEGRAM_CHAT_ID=82389391 \
   python3 {baseDir}/scripts/immich-on-this-day.py
 ```
 
-Behavior:
-- Posts up to 3 memory albums (most photos first), each with up to 4 preview JPEGs and a caption `YEAR — N photos[, M videos]` + Immich link.
-- If `total > 3`, a follow-up "+ N more memories" message is posted.
-- If today has zero in-window memories, the script exits 0 with no output and no Telegram message.
+Sample stdout (today has memories):
 
-## Useful flags
+```
+📸 Immich on this day
+
+3 memories today
+
+• 2021 — 12 photos
+  https://rpi5.gate-mintaka.ts.net:10000/memory/<id>
+  · IMG_5656.PNG — 2021-05-26
+  · IMG_5657.PNG — 2021-05-26
+
+• 2023 — 4 photos, 1 video
+  https://rpi5.gate-mintaka.ts.net:10000/memory/<id>
+  · VID_1234.MOV — 2023-05-26
+  · IMG_5658.PNG — 2023-05-26
+
+• 2025 — 1 photo
+  https://rpi5.gate-mintaka.ts.net:10000/memory/<id>
+  · IMG_5659.PNG — 2025-05-26
+```
+
+## Flags
 
 | Flag | Default | Effect |
 | --- | --- | --- |
-| `--dry-run` | off | Print captions + would-be attachments to stdout, do not fetch or POST. |
-| `--top N` | 3 | Cap to top N memories by asset count. Set to `0` to send nothing. |
-| `--attach-per-memory N` | 4 | Photos per album. Telegram caps at 10. |
-| `--no-attach` | off | Send a single text-only summary (one `sendMessage`) instead of albums. |
-| `--asset-preview N` | 2 | `--no-attach` mode only: filenames listed per memory in the text summary. |
+| `--top N` | 3 | Cap to top N memories by asset count. |
+| `--asset-preview N` | 2 | Text mode: filenames listed per memory. |
+| `--json` | off | Structured JSON output with full asset list and `asset_url` for each photo/video. |
 
-## Examples
+## JSON mode
 
-Dry-run (preview captions, no Telegram traffic):
+Use when you need to programmatically pick specific assets to act on (e.g. quote a particular photo back to the user):
 
 ```bash
 IMMICH_API_KEY=$(cat /run/agenix/immich-api-key) \
-  python3 {baseDir}/scripts/immich-on-this-day.py --dry-run
+  python3 {baseDir}/scripts/immich-on-this-day.py --json --top 5
 ```
 
-Text-only digest (no photo attachments, links and filename previews):
-
-```bash
-IMMICH_API_KEY=$(cat /run/agenix/immich-api-key) \
-TELEGRAM_BOT_TOKEN=$(cat /run/agenix/telegram-bot-token) \
-TELEGRAM_CHAT_ID=82389391 \
-  python3 {baseDir}/scripts/immich-on-this-day.py --no-attach
-```
-
-Send every memory with up to 8 photos each:
-
-```bash
-IMMICH_API_KEY=$(cat /run/agenix/immich-api-key) \
-TELEGRAM_BOT_TOKEN=$(cat /run/agenix/telegram-bot-token) \
-TELEGRAM_CHAT_ID=82389391 \
-  python3 {baseDir}/scripts/immich-on-this-day.py --top 10 --attach-per-memory 8
-```
+Shape: `{ "total": N, "shown": M, "memories": [{id, year, photos, videos, memory_url, assets: [{id, filename, type, fileCreatedAt, asset_url}]}] }`. JSON mode always prints (`{"total": 0, ...}` on empty days) so callers don't have to handle empty stdout specially.
 
 ## Notes
 
-- The script hits `http://127.0.0.1:2283/api/memories?type=on_this_day` (Immich's socket-activated proxy). The first request wakes the backend; subsequent calls are fast.
-- Memory links in captions use `https://rpi5.gate-mintaka.ts.net:10000` (Tailscale Funnel) so they open on phones. Photos in the album are uploaded as bytes to Telegram, not URLs — Telegram-side previews are independent of Immich auth.
-- Override the Immich endpoints with `IMMICH_INTERNAL_URL=` / `IMMICH_PUBLIC_URL=` if running against a different instance.
-- Videos count toward the per-memory `count` phrase but are not attached as album items (Telegram would need the full video binary; the user can tap the memory link to view them in Immich).
+- Internal API call hits `http://127.0.0.1:2283/api/memories?type=on_this_day` (Immich's socket-activated proxy). The first request wakes the backend; subsequent calls are fast.
+- `memory_url` / `asset_url` use `https://rpi5.gate-mintaka.ts.net:10000` (Tailscale Funnel) so the links open from phones. Override via `IMMICH_INTERNAL_URL=` / `IMMICH_PUBLIC_URL=` for a different instance.
+- Immich generates today's memories overnight via NightlyJobs. If the script runs before that job has fired (e.g. the backend was asleep through the boundary), the output may be empty even when photos for today exist; in that case re-run after a few minutes.

--- a/rpi5/picoclaw/skills/immich-memories/SKILL.md
+++ b/rpi5/picoclaw/skills/immich-memories/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: immich-memories
+description: Send a Telegram reminder of today's Immich "on this day" memories, with photo attachments. Use when the user asks about Immich memories, on-this-day, or wants a recap of past photos.
+homepage: https://immich.app
+metadata: {"openclaw":{"emoji":"📸","requires":{"bins":["python3"]},"agenix":["immich-api-key","telegram-bot-token"]}}
+---
+
+# Immich on-this-day reminder
+
+Sends today's Immich on-this-day memories to a Telegram chat as one album per memory (preview thumbnails) with a clickable Immich memory link in the caption. Exits silently when today has no memories with assets.
+
+## When to use
+
+- "show me / send me / what's on this day in Immich"
+- "Immich memories" / "any photos from today in past years"
+- A scheduled (cron) daily Immich digest
+
+## Default invocation
+
+The two secrets are already on disk as agenix files readable by the picoclaw user; the chat ID is the picoclaw owner's (numeric Telegram ID).
+
+```bash
+IMMICH_API_KEY=$(cat /run/agenix/immich-api-key) \
+TELEGRAM_BOT_TOKEN=$(cat /run/agenix/telegram-bot-token) \
+TELEGRAM_CHAT_ID=82389391 \
+  python3 {baseDir}/scripts/immich-on-this-day.py
+```
+
+Behavior:
+- Posts up to 3 memory albums (most photos first), each with up to 4 preview JPEGs and a caption `YEAR — N photos[, M videos]` + Immich link.
+- If `total > 3`, a follow-up "+ N more memories" message is posted.
+- If today has zero in-window memories, the script exits 0 with no output and no Telegram message.
+
+## Useful flags
+
+| Flag | Default | Effect |
+| --- | --- | --- |
+| `--dry-run` | off | Print captions + would-be attachments to stdout, do not fetch or POST. |
+| `--top N` | 3 | Cap to top N memories by asset count. Set to `0` to send nothing. |
+| `--attach-per-memory N` | 4 | Photos per album. Telegram caps at 10. |
+| `--no-attach` | off | Send a single text-only summary (one `sendMessage`) instead of albums. |
+| `--asset-preview N` | 2 | `--no-attach` mode only: filenames listed per memory in the text summary. |
+
+## Examples
+
+Dry-run (preview captions, no Telegram traffic):
+
+```bash
+IMMICH_API_KEY=$(cat /run/agenix/immich-api-key) \
+  python3 {baseDir}/scripts/immich-on-this-day.py --dry-run
+```
+
+Text-only digest (no photo attachments, links and filename previews):
+
+```bash
+IMMICH_API_KEY=$(cat /run/agenix/immich-api-key) \
+TELEGRAM_BOT_TOKEN=$(cat /run/agenix/telegram-bot-token) \
+TELEGRAM_CHAT_ID=82389391 \
+  python3 {baseDir}/scripts/immich-on-this-day.py --no-attach
+```
+
+Send every memory with up to 8 photos each:
+
+```bash
+IMMICH_API_KEY=$(cat /run/agenix/immich-api-key) \
+TELEGRAM_BOT_TOKEN=$(cat /run/agenix/telegram-bot-token) \
+TELEGRAM_CHAT_ID=82389391 \
+  python3 {baseDir}/scripts/immich-on-this-day.py --top 10 --attach-per-memory 8
+```
+
+## Notes
+
+- The script hits `http://127.0.0.1:2283/api/memories?type=on_this_day` (Immich's socket-activated proxy). The first request wakes the backend; subsequent calls are fast.
+- Memory links in captions use `https://rpi5.gate-mintaka.ts.net:10000` (Tailscale Funnel) so they open on phones. Photos in the album are uploaded as bytes to Telegram, not URLs — Telegram-side previews are independent of Immich auth.
+- Override the Immich endpoints with `IMMICH_INTERNAL_URL=` / `IMMICH_PUBLIC_URL=` if running against a different instance.
+- Videos count toward the per-memory `count` phrase but are not attached as album items (Telegram would need the full video binary; the user can tap the memory link to view them in Immich).

--- a/rpi5/picoclaw/skills/immich-memories/scripts/immich-on-this-day.py
+++ b/rpi5/picoclaw/skills/immich-memories/scripts/immich-on-this-day.py
@@ -1,34 +1,25 @@
 #!/usr/bin/env python3
-"""Send a Telegram reminder of today's Immich on-this-day memories.
+"""Print today's Immich on-this-day memories as a human-readable summary.
 
-Default mode posts one Telegram album per memory (thumbnails fetched from
-Immich, captioned with year + counts + clickable memory link). Pass
-``--no-attach`` to fall back to a single text message with links only.
-
-Picoclaw owns scheduling — this script is the one-shot worker. It exits
-silently with no message when today has nothing to show.
+Picoclaw owns transport (it relays the output to Telegram); this skill just
+queries Immich. Exits 0 with empty stdout when today has no memories.
 
 Config (env):
   IMMICH_API_KEY        required  (/run/agenix/immich-api-key)
-  TELEGRAM_BOT_TOKEN    required  (/run/agenix/telegram-bot-token)  unless --dry-run
-  TELEGRAM_CHAT_ID      required                                    unless --dry-run
   IMMICH_INTERNAL_URL   default http://127.0.0.1:2283
   IMMICH_PUBLIC_URL     default https://rpi5.gate-mintaka.ts.net:10000
 """
 import argparse
-import html
 import json
 import os
-import secrets
 import sys
-import urllib.parse
 import urllib.request
 import urllib.error
 from datetime import datetime, timezone
 
 
-def http(url, method="GET", headers=None, data=None):
-    req = urllib.request.Request(url, method=method, headers=headers or {}, data=data)
+def http(url, headers=None):
+    req = urllib.request.Request(url, headers=headers or {})
     try:
         with urllib.request.urlopen(req) as r:
             return r.status, dict(r.headers), r.read()
@@ -37,7 +28,6 @@ def http(url, method="GET", headers=None, data=None):
 
 
 def parse_iso_z(s):
-    # Immich emits "2026-05-24T00:00:00.000Z" and "2025-05-24T10:04:05+00:00".
     return datetime.fromisoformat(s.replace("Z", "+00:00"))
 
 
@@ -83,23 +73,22 @@ def count_phrase(assets):
     return ", ".join(parts)
 
 
-def format_message(memories, public_url, top, asset_preview):
-    """Text-only summary used by --no-attach mode."""
+def format_text(memories, public_url, top, asset_preview):
     total = len(memories)
     memories_sorted = sorted(memories, key=lambda m: len(m["assets"]), reverse=True)
     shown = memories_sorted[:top]
 
-    lines = ["📸 <b>Immich on this day</b>", ""]
-    lines.append(f"<i>{total} memor{'y' if total == 1 else 'ies'} today</i>")
+    lines = ["📸 Immich on this day", ""]
+    lines.append(f"{total} memor{'y' if total == 1 else 'ies'} today")
     lines.append("")
 
     for m in shown:
         year = parse_iso_z(m["memoryAt"]).year
         phrase = count_phrase(m["assets"])
-        lines.append(f"• <b>{year}</b> — {phrase}")
+        lines.append(f"• {year} — {phrase}")
         lines.append(f"  {public_url}/memory/{m['id']}")
         for a in m["assets"][:asset_preview]:
-            name = html.escape(a.get("originalFileName") or a["id"])
+            name = a.get("originalFileName") or a["id"]
             try:
                 date = parse_iso_z(a["fileCreatedAt"]).date().isoformat()
             except (KeyError, ValueError):
@@ -108,141 +97,50 @@ def format_message(memories, public_url, top, asset_preview):
         lines.append("")
 
     if total > top:
-        lines.append(f"<i>+ {total - top} more memor{'y' if total - top == 1 else 'ies'}</i>")
+        lines.append(f"+ {total - top} more memor{'y' if total - top == 1 else 'ies'}")
 
     return "\n".join(lines).rstrip() + "\n"
 
 
-def album_caption(mem, public_url, header):
-    """Album caption for one memory. `header` is prepended (first memory only)."""
-    year = parse_iso_z(mem["memoryAt"]).year
-    phrase = count_phrase(mem["assets"])
-    body = f"<b>{year}</b> — {phrase}\n{public_url}/memory/{mem['id']}"
-    return (header + body) if header else body
+def format_json(memories, public_url, top):
+    total = len(memories)
+    memories_sorted = sorted(memories, key=lambda m: len(m["assets"]), reverse=True)
+    shown = memories_sorted[:top]
 
-
-def fetch_preview(base, api_key, asset_id):
-    """Fetch a preview-sized JPEG for an asset. Returns (bytes, content_type) or None."""
-    status, headers, body = http(
-        f"{base}/api/assets/{asset_id}/thumbnail?size=preview",
-        headers={"x-api-key": api_key},
-    )
-    if status != 200:
-        print(f"thumbnail {asset_id}: HTTP {status}", file=sys.stderr)
-        return None
-    ctype = (headers.get("Content-Type") or "image/jpeg").split(";")[0].strip()
-    return body, ctype
-
-
-def build_multipart(fields, files):
-    """fields: dict[str, str]; files: list of (name, filename, content_type, bytes)."""
-    boundary = "----immich-on-this-day-" + secrets.token_hex(12)
-    parts = []
-    for k, v in fields.items():
-        parts.append(
-            f'--{boundary}\r\n'
-            f'Content-Disposition: form-data; name="{k}"\r\n\r\n'
-            f'{v}\r\n'.encode()
-        )
-    for name, filename, ctype, data in files:
-        parts.append(
-            f'--{boundary}\r\n'
-            f'Content-Disposition: form-data; name="{name}"; filename="{filename}"\r\n'
-            f'Content-Type: {ctype}\r\n\r\n'.encode()
-        )
-        parts.append(data)
-        parts.append(b"\r\n")
-    parts.append(f"--{boundary}--\r\n".encode())
-    return b"".join(parts), f"multipart/form-data; boundary={boundary}"
-
-
-def send_telegram(token, chat_id, text):
-    data = urllib.parse.urlencode({
-        "chat_id": chat_id,
-        "text": text,
-        "parse_mode": "HTML",
-        "disable_web_page_preview": "true",
-    }).encode()
-    status, _, body = http(
-        f"https://api.telegram.org/bot{token}/sendMessage",
-        method="POST",
-        headers={"Content-Type": "application/x-www-form-urlencoded"},
-        data=data,
-    )
-    if status != 200:
-        sys.exit(f"Telegram sendMessage -> HTTP {status}: {body[:300]!r}")
-
-
-def send_media_group(token, chat_id, caption, photos):
-    """photos: list of (asset_id, filename, content_type, bytes). Caption goes on item 0."""
-    media = []
-    files = []
-    for i, (asset_id, filename, ctype, data) in enumerate(photos):
-        attach_name = f"photo{i}"
-        item = {"type": "photo", "media": f"attach://{attach_name}"}
-        if i == 0 and caption:
-            item["caption"] = caption
-            item["parse_mode"] = "HTML"
-        media.append(item)
-        # Strip non-ASCII chars from the multipart filename — they're not
-        # encoded reliably and Telegram displays the caption anyway.
-        safe_name = filename.encode("ascii", "ignore").decode() or asset_id
-        files.append((attach_name, safe_name, ctype, data))
-
-    fields = {"chat_id": str(chat_id), "media": json.dumps(media)}
-    body, content_type = build_multipart(fields, files)
-    status, _, resp = http(
-        f"https://api.telegram.org/bot{token}/sendMediaGroup",
-        method="POST",
-        headers={"Content-Type": content_type, "Content-Length": str(len(body))},
-        data=body,
-    )
-    if status != 200:
-        sys.exit(f"Telegram sendMediaGroup -> HTTP {status}: {resp[:300]!r}")
-
-
-def send_memory_album(token, chat_id, mem, public_url, api_key, internal_url,
-                      attach_per_memory, header, dry_run):
-    """Send one memory as an album (or as caption-only text if no thumbnails)."""
-    caption = album_caption(mem, public_url, header)
-    images = [a for a in mem["assets"] if a.get("type") == "IMAGE"][:attach_per_memory]
-
-    if dry_run:
-        print(f"--- album for memory {mem['id']} ---")
-        print(caption)
-        for a in images:
-            print(f"  attach: {a.get('originalFileName') or a['id']}  (asset {a['id']})")
-        if not images:
-            print("  (no IMAGE assets — would send caption-only message)")
-        print()
-        return
-
-    photos = []
-    for a in images:
-        result = fetch_preview(internal_url, api_key, a["id"])
-        if result is None:
-            continue
-        data, ctype = result
-        photos.append((a["id"], a.get("originalFileName") or a["id"], ctype, data))
-
-    if photos:
-        send_media_group(token, chat_id, caption, photos)
-    else:
-        send_telegram(token, chat_id, caption)
+    return {
+        "total": total,
+        "shown": len(shown),
+        "memories": [
+            {
+                "id": m["id"],
+                "year": parse_iso_z(m["memoryAt"]).year,
+                "photos": sum(1 for a in m["assets"] if a.get("type") == "IMAGE"),
+                "videos": sum(1 for a in m["assets"] if a.get("type") == "VIDEO"),
+                "memory_url": f"{public_url}/memory/{m['id']}",
+                "assets": [
+                    {
+                        "id": a["id"],
+                        "filename": a.get("originalFileName"),
+                        "type": a.get("type"),
+                        "fileCreatedAt": a.get("fileCreatedAt"),
+                        "asset_url": f"{public_url}/photos/{a['id']}",
+                    }
+                    for a in m["assets"]
+                ],
+            }
+            for m in shown
+        ],
+    }
 
 
 def main():
     ap = argparse.ArgumentParser(description=__doc__)
-    ap.add_argument("--dry-run", action="store_true",
-                    help="print what would be sent, do not fetch thumbnails or POST")
     ap.add_argument("--top", type=int, default=3,
                     help="cap to top N memories by asset count (default 3)")
     ap.add_argument("--asset-preview", type=int, default=2,
-                    help="--no-attach mode: first N asset filenames per memory (default 2)")
-    ap.add_argument("--attach-per-memory", type=int, default=4,
-                    help="attach mode: up to N photos per album, capped at 10 by Telegram (default 4)")
-    ap.add_argument("--no-attach", action="store_true",
-                    help="send a single text-only summary instead of per-memory albums")
+                    help="text mode: first N asset filenames listed per memory (default 2)")
+    ap.add_argument("--json", action="store_true",
+                    help="emit structured JSON instead of human-readable text")
     args = ap.parse_args()
 
     api_key = os.environ.get("IMMICH_API_KEY")
@@ -254,42 +152,15 @@ def main():
 
     memories = fetch_memories(internal, api_key)
     today = select_today(memories, datetime.now(timezone.utc))
+
+    if args.json:
+        print(json.dumps(format_json(today, public, max(0, args.top)), indent=2))
+        return 0
+
     if not today or args.top <= 0:
         return 0
 
-    token = os.environ.get("TELEGRAM_BOT_TOKEN")
-    chat_id = os.environ.get("TELEGRAM_CHAT_ID")
-    if not args.dry_run and (not token or not chat_id):
-        sys.exit("TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID env vars are required (unless --dry-run)")
-
-    total = len(today)
-    memories_sorted = sorted(today, key=lambda m: len(m["assets"]), reverse=True)
-    shown = memories_sorted[:args.top]
-
-    if args.no_attach:
-        text = format_message(today, public, args.top, args.asset_preview)
-        if args.dry_run:
-            sys.stdout.write(text)
-            return 0
-        send_telegram(token, chat_id, text)
-        return 0
-
-    attach_cap = max(1, min(args.attach_per_memory, 10))
-    header = f"📸 <b>Immich on this day</b>\n<i>{total} memor{'y' if total == 1 else 'ies'} today</i>\n\n"
-
-    for i, mem in enumerate(shown):
-        send_memory_album(
-            token, chat_id, mem, public, api_key, internal,
-            attach_cap, header if i == 0 else "", args.dry_run,
-        )
-
-    if total > args.top:
-        tail = f"<i>+ {total - args.top} more memor{'y' if total - args.top == 1 else 'ies'}</i>"
-        if args.dry_run:
-            print(tail)
-        else:
-            send_telegram(token, chat_id, tail)
-
+    sys.stdout.write(format_text(today, public, args.top, args.asset_preview))
     return 0
 
 

--- a/rpi5/picoclaw/skills/immich-memories/scripts/immich-on-this-day.py
+++ b/rpi5/picoclaw/skills/immich-memories/scripts/immich-on-this-day.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""Send a Telegram reminder of today's Immich on-this-day memories.
+
+Default mode posts one Telegram album per memory (thumbnails fetched from
+Immich, captioned with year + counts + clickable memory link). Pass
+``--no-attach`` to fall back to a single text message with links only.
+
+Picoclaw owns scheduling — this script is the one-shot worker. It exits
+silently with no message when today has nothing to show.
+
+Config (env):
+  IMMICH_API_KEY        required  (/run/agenix/immich-api-key)
+  TELEGRAM_BOT_TOKEN    required  (/run/agenix/telegram-bot-token)  unless --dry-run
+  TELEGRAM_CHAT_ID      required                                    unless --dry-run
+  IMMICH_INTERNAL_URL   default http://127.0.0.1:2283
+  IMMICH_PUBLIC_URL     default https://rpi5.gate-mintaka.ts.net:10000
+"""
+import argparse
+import html
+import json
+import os
+import secrets
+import sys
+import urllib.parse
+import urllib.request
+import urllib.error
+from datetime import datetime, timezone
+
+
+def http(url, method="GET", headers=None, data=None):
+    req = urllib.request.Request(url, method=method, headers=headers or {}, data=data)
+    try:
+        with urllib.request.urlopen(req) as r:
+            return r.status, dict(r.headers), r.read()
+    except urllib.error.HTTPError as e:
+        return e.code, dict(e.headers or {}), e.read()
+
+
+def parse_iso_z(s):
+    # Immich emits "2026-05-24T00:00:00.000Z" and "2025-05-24T10:04:05+00:00".
+    return datetime.fromisoformat(s.replace("Z", "+00:00"))
+
+
+def fetch_memories(base, api_key):
+    status, _, body = http(
+        f"{base}/api/memories?type=on_this_day",
+        headers={"x-api-key": api_key, "Accept": "application/json"},
+    )
+    if status != 200:
+        sys.exit(f"Immich /api/memories -> HTTP {status}: {body[:200]!r}")
+    return json.loads(body)
+
+
+def select_today(memories, now):
+    out = []
+    for m in memories:
+        if m.get("type") != "on_this_day":
+            continue
+        try:
+            show = parse_iso_z(m["showAt"])
+            hide = parse_iso_z(m["hideAt"])
+        except (KeyError, ValueError):
+            continue
+        if not (show <= now <= hide):
+            continue
+        if not m.get("assets"):
+            continue
+        out.append(m)
+    return out
+
+
+def count_phrase(assets):
+    imgs = sum(1 for a in assets if a.get("type") == "IMAGE")
+    vids = sum(1 for a in assets if a.get("type") == "VIDEO")
+    parts = []
+    if imgs:
+        parts.append(f"{imgs} photo" + ("s" if imgs != 1 else ""))
+    if vids:
+        parts.append(f"{vids} video" + ("s" if vids != 1 else ""))
+    if not parts:
+        n = len(assets)
+        parts.append(f"{n} item" + ("s" if n != 1 else ""))
+    return ", ".join(parts)
+
+
+def format_message(memories, public_url, top, asset_preview):
+    """Text-only summary used by --no-attach mode."""
+    total = len(memories)
+    memories_sorted = sorted(memories, key=lambda m: len(m["assets"]), reverse=True)
+    shown = memories_sorted[:top]
+
+    lines = ["📸 <b>Immich on this day</b>", ""]
+    lines.append(f"<i>{total} memor{'y' if total == 1 else 'ies'} today</i>")
+    lines.append("")
+
+    for m in shown:
+        year = parse_iso_z(m["memoryAt"]).year
+        phrase = count_phrase(m["assets"])
+        lines.append(f"• <b>{year}</b> — {phrase}")
+        lines.append(f"  {public_url}/memory/{m['id']}")
+        for a in m["assets"][:asset_preview]:
+            name = html.escape(a.get("originalFileName") or a["id"])
+            try:
+                date = parse_iso_z(a["fileCreatedAt"]).date().isoformat()
+            except (KeyError, ValueError):
+                date = "?"
+            lines.append(f"  · {name} — {date}")
+        lines.append("")
+
+    if total > top:
+        lines.append(f"<i>+ {total - top} more memor{'y' if total - top == 1 else 'ies'}</i>")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def album_caption(mem, public_url, header):
+    """Album caption for one memory. `header` is prepended (first memory only)."""
+    year = parse_iso_z(mem["memoryAt"]).year
+    phrase = count_phrase(mem["assets"])
+    body = f"<b>{year}</b> — {phrase}\n{public_url}/memory/{mem['id']}"
+    return (header + body) if header else body
+
+
+def fetch_preview(base, api_key, asset_id):
+    """Fetch a preview-sized JPEG for an asset. Returns (bytes, content_type) or None."""
+    status, headers, body = http(
+        f"{base}/api/assets/{asset_id}/thumbnail?size=preview",
+        headers={"x-api-key": api_key},
+    )
+    if status != 200:
+        print(f"thumbnail {asset_id}: HTTP {status}", file=sys.stderr)
+        return None
+    ctype = (headers.get("Content-Type") or "image/jpeg").split(";")[0].strip()
+    return body, ctype
+
+
+def build_multipart(fields, files):
+    """fields: dict[str, str]; files: list of (name, filename, content_type, bytes)."""
+    boundary = "----immich-on-this-day-" + secrets.token_hex(12)
+    parts = []
+    for k, v in fields.items():
+        parts.append(
+            f'--{boundary}\r\n'
+            f'Content-Disposition: form-data; name="{k}"\r\n\r\n'
+            f'{v}\r\n'.encode()
+        )
+    for name, filename, ctype, data in files:
+        parts.append(
+            f'--{boundary}\r\n'
+            f'Content-Disposition: form-data; name="{name}"; filename="{filename}"\r\n'
+            f'Content-Type: {ctype}\r\n\r\n'.encode()
+        )
+        parts.append(data)
+        parts.append(b"\r\n")
+    parts.append(f"--{boundary}--\r\n".encode())
+    return b"".join(parts), f"multipart/form-data; boundary={boundary}"
+
+
+def send_telegram(token, chat_id, text):
+    data = urllib.parse.urlencode({
+        "chat_id": chat_id,
+        "text": text,
+        "parse_mode": "HTML",
+        "disable_web_page_preview": "true",
+    }).encode()
+    status, _, body = http(
+        f"https://api.telegram.org/bot{token}/sendMessage",
+        method="POST",
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        data=data,
+    )
+    if status != 200:
+        sys.exit(f"Telegram sendMessage -> HTTP {status}: {body[:300]!r}")
+
+
+def send_media_group(token, chat_id, caption, photos):
+    """photos: list of (asset_id, filename, content_type, bytes). Caption goes on item 0."""
+    media = []
+    files = []
+    for i, (asset_id, filename, ctype, data) in enumerate(photos):
+        attach_name = f"photo{i}"
+        item = {"type": "photo", "media": f"attach://{attach_name}"}
+        if i == 0 and caption:
+            item["caption"] = caption
+            item["parse_mode"] = "HTML"
+        media.append(item)
+        # Strip non-ASCII chars from the multipart filename — they're not
+        # encoded reliably and Telegram displays the caption anyway.
+        safe_name = filename.encode("ascii", "ignore").decode() or asset_id
+        files.append((attach_name, safe_name, ctype, data))
+
+    fields = {"chat_id": str(chat_id), "media": json.dumps(media)}
+    body, content_type = build_multipart(fields, files)
+    status, _, resp = http(
+        f"https://api.telegram.org/bot{token}/sendMediaGroup",
+        method="POST",
+        headers={"Content-Type": content_type, "Content-Length": str(len(body))},
+        data=body,
+    )
+    if status != 200:
+        sys.exit(f"Telegram sendMediaGroup -> HTTP {status}: {resp[:300]!r}")
+
+
+def send_memory_album(token, chat_id, mem, public_url, api_key, internal_url,
+                      attach_per_memory, header, dry_run):
+    """Send one memory as an album (or as caption-only text if no thumbnails)."""
+    caption = album_caption(mem, public_url, header)
+    images = [a for a in mem["assets"] if a.get("type") == "IMAGE"][:attach_per_memory]
+
+    if dry_run:
+        print(f"--- album for memory {mem['id']} ---")
+        print(caption)
+        for a in images:
+            print(f"  attach: {a.get('originalFileName') or a['id']}  (asset {a['id']})")
+        if not images:
+            print("  (no IMAGE assets — would send caption-only message)")
+        print()
+        return
+
+    photos = []
+    for a in images:
+        result = fetch_preview(internal_url, api_key, a["id"])
+        if result is None:
+            continue
+        data, ctype = result
+        photos.append((a["id"], a.get("originalFileName") or a["id"], ctype, data))
+
+    if photos:
+        send_media_group(token, chat_id, caption, photos)
+    else:
+        send_telegram(token, chat_id, caption)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--dry-run", action="store_true",
+                    help="print what would be sent, do not fetch thumbnails or POST")
+    ap.add_argument("--top", type=int, default=3,
+                    help="cap to top N memories by asset count (default 3)")
+    ap.add_argument("--asset-preview", type=int, default=2,
+                    help="--no-attach mode: first N asset filenames per memory (default 2)")
+    ap.add_argument("--attach-per-memory", type=int, default=4,
+                    help="attach mode: up to N photos per album, capped at 10 by Telegram (default 4)")
+    ap.add_argument("--no-attach", action="store_true",
+                    help="send a single text-only summary instead of per-memory albums")
+    args = ap.parse_args()
+
+    api_key = os.environ.get("IMMICH_API_KEY")
+    if not api_key:
+        sys.exit("IMMICH_API_KEY env var is required")
+
+    internal = os.environ.get("IMMICH_INTERNAL_URL", "http://127.0.0.1:2283").rstrip("/")
+    public = os.environ.get("IMMICH_PUBLIC_URL", "https://rpi5.gate-mintaka.ts.net:10000").rstrip("/")
+
+    memories = fetch_memories(internal, api_key)
+    today = select_today(memories, datetime.now(timezone.utc))
+    if not today or args.top <= 0:
+        return 0
+
+    token = os.environ.get("TELEGRAM_BOT_TOKEN")
+    chat_id = os.environ.get("TELEGRAM_CHAT_ID")
+    if not args.dry_run and (not token or not chat_id):
+        sys.exit("TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID env vars are required (unless --dry-run)")
+
+    total = len(today)
+    memories_sorted = sorted(today, key=lambda m: len(m["assets"]), reverse=True)
+    shown = memories_sorted[:args.top]
+
+    if args.no_attach:
+        text = format_message(today, public, args.top, args.asset_preview)
+        if args.dry_run:
+            sys.stdout.write(text)
+            return 0
+        send_telegram(token, chat_id, text)
+        return 0
+
+    attach_cap = max(1, min(args.attach_per_memory, 10))
+    header = f"📸 <b>Immich on this day</b>\n<i>{total} memor{'y' if total == 1 else 'ies'} today</i>\n\n"
+
+    for i, mem in enumerate(shown):
+        send_memory_album(
+            token, chat_id, mem, public, api_key, internal,
+            attach_cap, header if i == 0 else "", args.dry_run,
+        )
+
+    if total > args.top:
+        tail = f"<i>+ {total - args.top} more memor{'y' if total - args.top == 1 else 'ies'}</i>"
+        if args.dry_run:
+            print(tail)
+        else:
+            send_telegram(token, chat_id, tail)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- New picoclaw skill at `rpi5/picoclaw/skills/immich-memories/` that posts today's Immich on-this-day memories to Telegram as per-memory albums (preview thumbnails + clickable memory link).
- Default mode uploads up to 3 albums (most-photos-first), 4 photos per album. `--no-attach` falls back to a single text-only `sendMessage`. Empty days exit silently.
- Picoclaw owns scheduling — the skill is the one-shot worker (no new systemd unit, no new agenix secret; reuses existing `immich-api-key` + `telegram-bot-token`).

## Files
- `rpi5/picoclaw/skills/immich-memories/SKILL.md` — frontmatter with `openclaw` metadata (emoji 📸, requires `python3` + the two agenix secrets); invocation examples follow the tavily-search `{baseDir}/scripts/...` convention.
- `rpi5/picoclaw/skills/immich-memories/scripts/immich-on-this-day.py` — stdlib-only Python 3, multipart `sendMediaGroup` for albums + `sendMessage` fallback. Same style as `scripts/immich-nextcloud-sync.py`.

## Test plan
- [x] `python3 -m ast.parse` clean on the script
- [x] Bad API key → exit 1, stderr `HTTP 401: Invalid API key`
- [x] Missing `IMMICH_API_KEY` env → exit 1 with one-line stderr
- [x] Today (2026-05-26) has 0 in-window memories → silent exit 0 (verified against live `/api/memories?type=on_this_day`)
- [x] Formatter unit-tested on synthetic 4-memory payload: pluralization, sort, top-N cap, `+ N more memories` tail, HTML escape on filenames with `<`, `>`, `&`, `"`
- [x] End-to-end: posted 3 real Telegram albums (2020-05-08 + two others) to chat `82389391` using `send_memory_album` with real Immich asset IDs (3-4 photos per album, captions render with bold year + clickable memory link)
- [ ] After merge: confirm `nixos-rebuild switch` rsyncs the skill into `~/.picoclaw/workspace/skills/immich-memories/` and picoclaw picks it up (no Nix-side wiring needed; the skill is detected from `SKILL.md` frontmatter)
- [ ] Wire a picoclaw cron job for the daily run (out of scope for this PR — user owns scheduling per the design)

🤖 Generated with [Claude Code](https://claude.com/claude-code)