### PR TITLE
revert(beast): remove alfie steam-gamescope autologin

### DIFF
--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -160,7 +160,7 @@ in
     ];
   };
 
-  # Couch user — auto-logs into Steam gamescope session at boot (see initial_session below).
+  # Couch user — logs in via greeter and launches Steam gamescope session.
   # Password set manually via: sudo passwd alfie
   users.users.alfie = {
     isNormalUser = true;
@@ -317,14 +317,6 @@ in
   # Use Hyprland instead of cage for greeter — enables hypridle DPMS (power saving after WOL)
   services.greetd.settings.default_session.command = lib.mkForce
     "${pkgs.dbus}/bin/dbus-run-session ${pkgs.hyprland}/bin/Hyprland --config ${greeterHyprlandConfig}";
-
-  # Auto-login alfie into Steam gamescope at boot. After logout, default_session (greeter) takes over.
-  # `programs.steam.gamescopeSession.enable = true` adds the steam-gamescope wrapper to
-  # environment.systemPackages (a separate derivation, NOT under ${pkgs.steam}/bin) — invoke by bare name.
-  services.greetd.settings.initial_session = {
-    command = "steam-gamescope";
-    user = "alfie";
-  };
 
   users.users.greeter = {
     isSystemUser = true;


### PR DESCRIPTION
## Summary
- Drops the `services.greetd.settings.initial_session` block on BeAsT so boot no longer auto-logs alfie into steam-gamescope.
- Hyprland greeter (`default_session`) is the only session greetd starts; alfie (or anyone) logs in normally and can still launch the gamescope session from there.
- Updates the alfie user comment to match.

## Test plan
- [x] `sudo nixos-rebuild switch --flake path:.#BeAsT` on beast — succeeded, greetd config now has no `[initial_session]` block (verified at `/nix/store/...-greetd.toml`).
- [x] `loginctl terminate-session 1` killed the running alfie/gamescope session; greeter took over tty1 cleanly, no alfie processes left.
- [ ] Reboot beast and confirm greeter prompts for login instead of dropping into Steam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)