### PR TITLE
fix(macos): pin mas to nixpkgs-unstable for brew bundle compat

### DIFF
--- a/home/dotfiles/editor/cursor-settings.json
+++ b/home/dotfiles/editor/cursor-settings.json
@@ -37,7 +37,9 @@
   "editor.multiCursorModifier": "ctrlCmd",
   "editor.overviewRulerBorder": false,
   "editor.renderWhitespace": "all",
-  "editor.rulers": [100],
+  "editor.rulers": [
+    100
+  ],
   "editor.tabSize": 2,
   "editor.unicodeHighlight.invisibleCharacters": false,
   "editor.accessibilitySupport": "off",
@@ -117,7 +119,10 @@
   "files.insertFinalNewline": true,
   "diffEditor.ignoreTrimWhitespace": false,
   "vsicons.dontShowNewVersionMessage": true,
-  "cursor.cpp.disabledLanguages": ["plaintext", "scminput"],
+  "cursor.cpp.disabledLanguages": [
+    "plaintext",
+    "scminput"
+  ],
   "cursor.terminal.usePreviewBox": true,
   "editor.minimap.size": "fit",
   "editor.minimap.showSlider": "always",

--- a/macos/configuration.nix
+++ b/macos/configuration.nix
@@ -11,6 +11,18 @@
 {
   nixpkgs.config.allowUnfree = true;
 
+  # Homebrew 5.x's `brew bundle` invokes `mas get <id>` to install Mac App Store
+  # apps, but nixpkgs release-25.11 still ships mas 2.2.2 (pre-`get`). Pull mas
+  # from nixpkgs-unstable (6.0.1+) so masApps entries can actually install.
+  nixpkgs.overlays = [
+    (final: prev: {
+      mas = (import inputs.nixpkgs-unstable {
+        inherit (prev.stdenv.hostPlatform) system;
+        config.allowUnfree = true;
+      }).mas;
+    })
+  ];
+
   #nix.configureBuildUsers = true;
 
   nix.extraOptions = ''


### PR DESCRIPTION
## Summary
- Homebrew 5.x's `brew bundle` now calls `mas get <id>` to install Mac App Store apps, but nixpkgs `release-25.11` still ships `mas` 2.2.2 — the `get` subcommand only landed in 2.3.0+. New `masApps` entries (Spark, Timepage) fail during `darwin-rebuild switch` with `Error: 2 unexpected arguments: 'get', '<id>'`.
- Adds a `nixpkgs.overlays` entry in `macos/configuration.nix` that pulls `mas` from `nixpkgs-unstable` (6.0.1), where `get` exists. Already-installed MAS apps are unaffected.
- Also includes Cursor's auto-reformat of `cursor-settings.json` (two arrays expanded to multi-line), which was sitting as an unresolved merge and was blocking the commit.

## Test plan
- [x] `sudo darwin-rebuild switch --flake path:.#nBookPro` exits 0
- [x] `Installing Spark` / `Installing Timepage` succeed; `/Applications/Spark Desktop.app` and `/Applications/Timepage.app` present
- [x] `/run/current-system/activate` now references `mas-6.0.1` instead of `mas-2.2.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)