### PR TITLE
fix(music-production): refresh tal-vocoder-2 source hash + layout

### DIFF
--- a/nixos/music-production.nix
+++ b/nixos/music-production.nix
@@ -6,7 +6,8 @@ let
 
     src = pkgs.fetchzip {
       url = "https://tal-software.com/downloads/plugins/TAL-Vocoder-2_64_linux.zip";
-      hash = "sha256-QrYjoD9fs/JotlM86ZN/3N2Svcwds7xvXYudKuKt9gI=";
+      # Upstream silently re-zipped the file at this URL; old hash was QrYjoD9... — refreshed 2026-06-01.
+      hash = "sha256-S+ol+xj9Fofh9fOFpv3W8xJiJhCVCMtIgu58fLnGCR8=";
       stripRoot = false;
     };
 
@@ -21,15 +22,15 @@ let
     installPhase = ''
       runHook preInstall
 
-      install -Dm644 ReadmeLinux.txt \
+      # Upstream 2026 re-zip moved files into a TAL-Vocoder-2/ subdir and
+      # dropped the bundled .vst3 directory — only CLAP + VST2 ship now.
+      install -Dm644 TAL-Vocoder-2/ReadmeLinux.txt \
         $out/share/doc/${pname}/ReadmeLinux.txt
 
-      install -Dm755 TAL-Vocoder-2.clap \
+      install -Dm755 TAL-Vocoder-2/TAL-Vocoder-2.clap \
         $out/lib/clap/TAL-Vocoder-2.clap
-      install -Dm755 libTAL-Vocoder-2.so \
+      install -Dm755 TAL-Vocoder-2/libTAL-Vocoder-2.so \
         $out/lib/vst/libTAL-Vocoder-2.so
-      mkdir -p $out/lib/vst3
-      cp -r TAL-Vocoder-2.vst3 $out/lib/vst3/
 
       runHook postInstall
     '';


### PR DESCRIPTION
## Summary

Upstream tal-software.com silently re-zipped the file at the pinned download URL. Two breakages to repair so `nixos-rebuild` works again on Beast:

1. **Hash drift** — the recorded sha256 stopped matching the bytes served at the URL. Refreshed.
2. **Layout drift** — the new zip nests everything under `TAL-Vocoder-2/`, and the bundled `.vst3` directory was dropped. `installPhase` paths bumped; the vst3 install block removed (only CLAP and VST2 `.so` ship now).

## Symptom before this fix

```
error: hash mismatch in fixed-output derivation '/nix/store/.../source.drv':
         specified: sha256-QrYjoD9fs/JotlM86ZN/3N2Svcwds7xvXYudKuKt9gI=
            got:    sha256-S+ol+xj9Fofh9fOFpv3W8xJiJhCVCMtIgu58fLnGCR8=
error: Cannot build '/nix/store/.../tal-vocoder-2-2023-07-21.drv'.
```

After hash bump (round 1):
```
install: cannot stat 'ReadmeLinux.txt': No such file or directory
```

## Test plan

- [x] `sudo nixos-rebuild switch --flake 'path:.#BeAsT'` completes
- [x] `/run/current-system/sw/lib/clap/TAL-Vocoder-2.clap` exists
- [x] `/run/current-system/sw/lib/vst/libTAL-Vocoder-2.so` exists
- [ ] REAPER picks up the plugin in its CLAP / VST2 scan paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)