### PR TITLE
feat(claude): auto-allow MCP tool calls

### DIFF
--- a/home/dotfiles/claude-settings.json
+++ b/home/dotfiles/claude-settings.json
@@ -14,7 +14,8 @@
       "WebFetch(*)",
       "WebSearch(*)",
       "NotebookEdit(*)",
-      "Task(*)"
+      "Task(*)",
+      "mcp__*"
     ],
     "deny": []
   },


### PR DESCRIPTION
## Summary
- Adds the `mcp__*` wildcard to `permissions.allow` in `home/dotfiles/claude-settings.json` so Claude Code stops prompting for every MCP tool invocation (`mcp__claude_ai_*`, `mcp__trusk-*`, `mcp__Linear__*`, `mcp__firecrawl__*`, …).
- Matches the existing wildcard posture for first-party tools (`Bash(*)`, `Edit(*)`, `WebFetch(*)`, etc.) — every MCP server already in `home/mcp.nix` was hand-approved, so prompting on each tool call is pure friction.

## Test plan
- [ ] `nix flake check`
- [ ] `home-manager switch --flake .#$(hostname)` (or whichever target) rebuilds without diff conflicts on `~/.claude/settings.json`
- [ ] In a fresh Claude Code session, invoking an MCP tool (e.g. `mcp__trusk-grafana__list_datasources`) runs without a permission prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)