### PR TITLE
fix(affine-mcp + picoclaw): heal env-file crash-loop and connect picoclaw MCP

### DIFF
--- a/rpi5/affine-mcp.nix
+++ b/rpi5/affine-mcp.nix
@@ -92,6 +92,15 @@ in
     serviceConfig = {
       DynamicUser = true;
       RuntimeDirectory = "affine-mcp";
+      # The env file is written into /run/affine-mcp by the separate
+      # affine-mcp-env oneshot (RemainAfterExit). Default RuntimeDirectoryPreserve=no
+      # makes systemd delete /run/affine-mcp on every stop of THIS service, so any
+      # crash- or rebuild-restart wipes the env file — and the oneshot, still
+      # "active", never regenerates it, leaving this unit in a permanent
+      # "Failed to load environment files" crash-loop. Preserve the dir so the
+      # injected env file survives restarts (only cleared at reboot, where the
+      # oneshot reruns before us via the before= ordering).
+      RuntimeDirectoryPreserve = "yes";
       EnvironmentFile = "/run/affine-mcp/env";
       ExecStart = "${pkgs.nodejs_22}/bin/node ${affineMcpServer}/lib/node_modules/affine-mcp-server/dist/index.js";
       Restart = "on-failure";

--- a/rpi5/picoclaw/picoclaw.nix
+++ b/rpi5/picoclaw/picoclaw.nix
@@ -180,9 +180,21 @@ let
           max_search_results = 20;
         };
         servers = {
+          # picoclaw's MCP client (pkg/mcp/manager.go) speaks ONLY Streamable
+          # HTTP (go-sdk StreamableClientTransport) for BOTH type "sse" and
+          # "http": it POSTs `initialize` straight to the URL and never performs
+          # the legacy-SSE GET handshake. The shared home/mcp.nix bridge URL
+          # ends in /sse (legacy SSE, GET-only) → picoclaw hit 405 "Method Not
+          # Allowed" and loaded zero MCP tools. tiny-llm-gate only bridges
+          # SSE-to-client (no Streamable-HTTP client endpoint), so point picoclaw
+          # straight at the local affine-mcp backend's Streamable HTTP endpoint
+          # (loopback, no gate/tailnet hop). The bearer header is injected into
+          # the runtime config.json by setupScript so the token (a 0444 agenix
+          # secret) never enters the Nix store.
           affine = {
             enabled = true;
-            inherit (config.programs.claude-code.mcpServers.affine) type url;
+            type = "http";
+            url = "http://127.0.0.1:7021/mcp";
           };
         };
       };
@@ -205,7 +217,19 @@ let
   setupScript = pkgs.writeShellScript "picoclaw-setup" ''
     set -eu
     ${pkgs.coreutils}/bin/mkdir -p ${configDir} ${workspaceDir} ${workspaceDir}/skills
-    ${pkgs.coreutils}/bin/install -m 0644 ${configFile} ${configDir}/config.json
+    ${pkgs.coreutils}/bin/install -m 0600 ${configFile} ${configDir}/config.json
+
+    # Inject the AFFiNE MCP bearer into the runtime config.json. The token is a
+    # secret (0444 agenix file) so it must NOT be baked into ${configFile}
+    # (which lands world-readable in the Nix store). picoclaw does no env
+    # expansion on the MCP `headers` map, so patch the literal value in here at
+    # start time. Mode 0600 above (picoclaw also rewrites it 0600 on migration).
+    affine_tok="$(${pkgs.coreutils}/bin/cat /run/agenix/affine-mcp-http-token)"
+    ${pkgs.jq}/bin/jq \
+      --arg auth "Bearer $affine_tok" \
+      '.tools.mcp.servers.affine.headers.Authorization = $auth' \
+      ${configDir}/config.json > ${configDir}/config.json.tmp
+    ${pkgs.coreutils}/bin/mv ${configDir}/config.json.tmp ${configDir}/config.json
 
     # Skills: copy (not symlink) so realpath stays inside the workspace.
     ${pkgs.rsync}/bin/rsync -aL --delete --chmod=Du+rwx,Dgo+rx,Fu+rw,Fgo+r \


### PR DESCRIPTION
## Summary

picoclaw was logging a persistent error and loading **zero** MCP tools. Two independent root causes, both fixed here.

### 1. `affine-mcp.service` crash-loop (`RuntimeDirectory` wiped the env file)
`affine-mcp.service` owns `/run/affine-mcp` as its `RuntimeDirectory`, but the env file (`AFFINE_API_TOKEN`, bearer token) is written there by the *separate* `affine-mcp-env` oneshot. With the default `RuntimeDirectoryPreserve=no`, systemd deletes `/run/affine-mcp` on every **stop** of `affine-mcp` — so any crash- or rebuild-restart wiped the env file. The oneshot (`RemainAfterExit`) stays `active` and never regenerates it → permanent `Failed to load environment files` crash-loop (observed **84 restarts**, backend down ~3.5h).

**Fix:** `RuntimeDirectoryPreserve = "yes"` so the injected env file survives restarts (cleared only at reboot, where the oneshot reruns first via the existing `before=` ordering).

### 2. picoclaw pointed at the legacy-SSE endpoint (`405 Method Not Allowed`)
picoclaw's MCP client (`pkg/mcp/manager.go`) uses the go-sdk `StreamableClientTransport` for **both** `type: "sse"` and `"http"` — it POSTs `initialize` straight to the URL and never does the legacy-SSE `GET` handshake. The shared `home/mcp.nix` bridge URL ends in `/sse` (GET-only legacy endpoint) → every connect failed with `405 Method Not Allowed`.

`tiny-llm-gate` only bridges *SSE-to-client* (no Streamable-HTTP client endpoint), so this points picoclaw straight at the local `affine-mcp` backend's Streamable-HTTP endpoint (`http://127.0.0.1:7021/mcp`, loopback — no gate/tailnet hop). The bearer token is injected into the runtime `config.json` by the `ExecStartPre` setup script (`jq`), keeping the secret out of the Nix store (the `0444` agenix file is readable by the `nsimon` user service).

## Verification (live on rpi5)
- `affine-mcp.service`: `active`, listening on `:7021`, `healthz → 200`.
- `home-manager switch` applied; picoclaw restarted.
- picoclaw journal:
  - `Connected to MCP server protocol=2025-06-18 server=affine serverName=affine-mcp serverVersion=1.13.0`
  - `Listed tools from MCP server server=affine toolCount=87`
  - `MCP tools registered successfully ... unique_tools=87`
- No more `Method Not Allowed`; token confirmed injected (`config.json` `headers.Authorization`, mode `0600`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)