### PR TITLE
feat(claude): pin default model to opus 4.8

### DIFF
--- a/home/dotfiles/claude-settings.json
+++ b/home/dotfiles/claude-settings.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "model": "claude-opus-4-8",
   "env": {
     "ANTHROPIC_BASE_URL": "https://ai.gate-mintaka.ts.net"
   },


### PR DESCRIPTION
## Summary
- `~/.claude/settings.json` had no `model` key → Claude Code v2.1.148 defaulted to Opus 4.7.
- The `opus` alias inside CC 2.1.148 also still resolves to 4.7, so pinning explicitly to `claude-opus-4-8` until the CLI's alias map catches up.
- Tailscale gateway at `ai.gate-mintaka.ts.net` already exposes 4.8 — gateway was never the blocker.

## Test plan
- [x] Edit settings (via `mkOutOfStoreSymlink` from `home/claude.nix:90` — no rebuild needed).
- [x] Spawn fresh subprocess: `claude --print "...model ID..."` → reports `claude-opus-4-8` (was `claude-opus-4-7`).
- [ ] Next interactive session opens on 4.8.

## Follow-up
- When a future Claude Code release updates the `opus` alias map to point at the latest, swap this back to `"model": "opus"` so future bumps roll automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)