### PR TITLE
feat(beast): give alfie zen browser + nsimon's rofi launcher

### DIFF
--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -174,9 +174,12 @@ in
     ];
   };
 
-  # Share nsimon's Hyprland config with alfie when she logs into Hyprland (after exiting gamescope).
+  # Share nsimon's Hyprland config and rofi launcher config with alfie when she logs into
+  # Hyprland (after exiting gamescope). She has no home-manager, so these are root-owned
+  # symlinks recreated on each rebuild.
   systemd.tmpfiles.rules = [
     "L+ /home/alfie/.config/hypr/hyprland.conf - - - - ${./dotfiles/hypr/hyprland.conf}"
+    "L+ /home/alfie/.config/rofi - - - - ${./dotfiles/rofi}"
   ];
 
   environment.systemPackages = with pkgs; [
@@ -184,6 +187,8 @@ in
     ddcutil
     ethtool # verify WoL: ethtool eno1 | grep Wake
     dmenu
+    rofi # app launcher (SUPER+Space) for alfie — same one nsimon gets via home-manager
+    inputs.zen-browser.packages.${pkgs.stdenv.hostPlatform.system}.twilight # zen browser for alfie (nsimon's comes from home-manager)
     feh
     gamescope
     regreet


### PR DESCRIPTION
## What

Gives the couch user `alfie` on **beast**:
- **zen browser** — `inputs.zen-browser.packages.<system>.twilight` added to `environment.systemPackages` (nsimon gets his via home-manager; alfie has none).
- **the same rofi launcher** ("dmenu") as nsimon — `rofi` added to system packages, and nsimon's `nixos/dotfiles/rofi` config tree symlinked into `/home/alfie/.config/rofi` via `systemd.tmpfiles`, mirroring the existing `hyprland.conf` share.

## Why

alfie inherits nsimon's `hyprland.conf` (`exec-once = zen-twilight`, `SUPER+Space → rofi -show drun ...`) but those binaries lived only in nsimon's home-manager profile and she had no `~/.config/rofi`, so both silently failed for her.

## Test

`nix eval` of `nixosConfigurations.BeAsT` resolves `rofi-2.0.0` + `zen-twilight-1.21t` and the new tmpfiles rule. Deployed to beast via `nixos-rebuild switch`; zen opens on alfie's session and `~/.config/rofi` resolves to the shared tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)