### PR TITLE
feat(claude-rc): 6h timer to keep Claude OAuth token warm

### DIFF
--- a/rpi5/claude-remote-control.nix
+++ b/rpi5/claude-remote-control.nix
@@ -47,6 +47,16 @@ let
   # by maxSessions=8 in startScript, so ~560MB ceiling — fine on the rpi5.
   maxInactivitySec = "86400"; # 24h
 
+  # Periodic no-op `claude -p` invocation whose sole purpose is to keep the
+  # OAuth access token fresh. When the bridge sits idle for long stretches the
+  # long-running process stops refreshing credentials.json; a headless print
+  # query forces a token refresh, which the path unit below picks up and
+  # re-extracts to /run/claude-oauth/token (consumed by tiny-llm-gate).
+  tokenRefreshScript = pkgs.writeShellScript "claude-token-refresh" ''
+    set -eu
+    exec claude -p "say hello world" --dangerously-skip-permissions
+  '';
+
   stopScript = pkgs.writeShellScript "claude-remote-control-stop" ''
     # Send SIGTERM to the claude process inside tmux, giving it time
     # to deregister from Anthropic's API before we kill the session.
@@ -223,6 +233,33 @@ in
     timerConfig = {
       OnBootSec = "10min";
       OnUnitActiveSec = "30min";
+    };
+  };
+
+  # Keep the Claude OAuth token warm during idle periods. Runs a throwaway
+  # headless query every 6h; the resulting credentials.json refresh is detected
+  # by the path unit and re-extracted to /run/claude-oauth/token.
+  systemd.services.claude-token-refresh = {
+    description = "Refresh Claude Code OAuth token via headless query";
+    serviceConfig = {
+      Type = "oneshot";
+      User = username;
+      Group = "users";
+      ExecStart = tokenRefreshScript;
+      Environment = [
+        "HOME=/home/${username}"
+        "PATH=/etc/profiles/per-user/${username}/bin:/run/current-system/sw/bin:/usr/bin:/bin"
+      ];
+    };
+  };
+
+  systemd.timers.claude-token-refresh = {
+    description = "Periodic Claude Code OAuth token refresh timer";
+    wantedBy = [ "timers.target" ];
+    timerConfig = {
+      OnBootSec = "15min";
+      OnUnitActiveSec = "6h";
+      Persistent = true;
     };
   };
 


### PR DESCRIPTION
## What

Adds a `claude-token-refresh` systemd service + timer (every 6h, `Persistent`, 15min after boot) that runs a throwaway `claude -p "say hello world"` query.

## Why

When the remote-control bridge sits idle for long stretches it stops refreshing `~/.claude/.credentials.json`, so the OAuth access token can go stale. A periodic headless query forces a token refresh; the existing `claude-oauth-extract` path unit detects the `credentials.json` change and re-extracts the fresh token to `/run/claude-oauth/token` (consumed by tiny-llm-gate).

Lives in `claude-remote-control.nix` alongside the rest of the OAuth plumbing, modeled on the existing `claude-rc-session-cleanup` service/timer pair.

## Apply

After merge, on rpi5:

```
sudo nixos-rebuild switch --flake /home/nsimon/nic-os#rpi5 --max-jobs 1 -j 1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)