### PR TITLE
fix(beast): umask 002 for shared /mnt/games access

### DIFF
--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -182,6 +182,19 @@ in
     "L+ /home/alfie/.config/rofi - - - - ${./dotfiles/rofi}"
   ];
 
+  # umask 002 so nsimon + alfie can both read/write the shared /mnt/games tree.
+  # Why: NTFS via ntfs3 doesn't honor default ACLs, so group-write on new files
+  # depends entirely on the creating process's umask. NixOS default login.defs is
+  # UMASK 077, which made alfie's Steam create dirs as 0755 and lock nsimon out
+  # of staging dirs ("Disk write failure" on POE2 update). Both users' primary
+  # group is `users`, so g+w is enough to share access.
+  environment.shellInit = "umask 002";
+  environment.loginShellInit = "umask 002";
+  systemd.user.extraConfig = ''
+    DefaultUMask=0002
+  '';
+  security.loginDefs.settings.UMASK = "002";
+
   environment.systemPackages = with pkgs; [
     cage
     ddcutil


### PR DESCRIPTION
## Summary

- Set `umask 002` system-wide at the four entry points (login.defs, shellInit, loginShellInit, systemd user manager) so processes that nsimon and alfie launch into the shared `/mnt/games` tree create group-writable files.
- Fixes recurring "Disk write failure / Temp folder not writable" errors that have been stalling Steam updates on this drive (POE2 today, plus the broader 7944-dirs-without-g+w damage I just repaired manually with chgrp + chmod).

## Root cause

`/mnt/games` is NTFS via `ntfs3` (no default-ACL support). The mount is `gid=100,umask=0000,force` — that's permissive at the mount layer but it can only *cap* perms, not *add* them back. The actual perms on each new file come from the creating process's umask.

The documented contract (per memory) was "umask 002 system-wide" — but nothing in NixOS config enforced that. `/etc/login.defs` was `UMASK 077`, my interactive shell shows `022`. So alfie's Steam, launched from the GUI session, was creating `0755` dirs under `/mnt/games/SteamLibrary/steamapps/temp/` — nsimon's Steam then got EACCES when trying to stage POE2's update into them.

## What this PR changes

`nixos/configuration.nix` — four umask hooks next to the existing `users.users.alfie` block:

| hook | covers |
| --- | --- |
| `security.loginDefs.settings.UMASK = "002"` | overrides system default (was 077) — picked up by pam_umask |
| `environment.shellInit` | non-login interactive shells (bash/zsh subshells) |
| `environment.loginShellInit` | login shells |
| `systemd.user.extraConfig` → `DefaultUMask=0002` | systemd user manager — covers Steam/Hyprland menu launches (the actual offender here) |

The systemd-user one is the load-bearing piece for the GUI-launched-Steam case. Belt-and-braces shell hooks cover terminal-launched processes.

## Test plan

- [ ] `sudo nixos-rebuild switch` applies cleanly
- [ ] Log out + log back in (so systemd user manager picks up `DefaultUMask`)
- [ ] In a fresh shell: `umask` → `0002`
- [ ] `systemctl --user show-environment` shows `UMask=0002` (or check a unit's effective umask)
- [ ] Touch a file on /mnt/games as nsimon, verify it lands `0664`/`0775`
- [ ] Have alfie log in, launch Steam, install/update something, verify created dirs are `2775`

🤖 Generated with [Claude Code](https://claude.com/claude-code)