### PR TITLE
fix(claude): drop dead opus-4-8 pin, bump CC to 2.1.158 for 1M context

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -763,11 +763,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1779786838,
-        "narHash": "sha256-0geHoGiR5f8qiXg+gO4rSF6Up6Var+kKqiOv9AO/uUc=",
+        "lastModified": 1780365719,
+        "narHash": "sha256-QfWfccTN+70ZQ4m2qlU9PiKfz2Yppq94058iJyARNwc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f44f7788c891fbe5542177df78374f8cdab10e8f",
+        "rev": "ffa10e26ae11d676b2db836259889f1f571cb14f",
         "type": "github"
       },
       "original": {

--- a/home/dotfiles/claude-settings.json
+++ b/home/dotfiles/claude-settings.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
-  "model": "claude-opus-4-8",
   "env": {
     "ANTHROPIC_BASE_URL": "https://ai.gate-mintaka.ts.net"
   },


### PR DESCRIPTION
## Summary
- Drop `model = "claude-opus-4-8"` pin from `home/dotfiles/claude-settings.json`. CC 2.1.148 didn't ship `claude-opus-4-8` as a literal in its binary, so its 1M-context wrapper never applied to the pinned ID — we got 4-8 at the default 200K window. Long conversations hit the limit and auto-compacted constantly.
- Bump `nixpkgs-unstable` 2026-05-26 → 2026-06-02, which lifts `claude-code` 2.1.148 → 2.1.158. 2.1.158 ships both `claude-opus-4-8` and `claude-opus-4-7[1m]` as known literals, so the CLI's default resolution can apply the [1m] wrapper.

## Verification
After `nixos-rebuild switch` + `home-manager switch`:

```
$ claude --version
2.1.158 (Claude Code)

$ claude --print --output-format stream-json --verbose 'reply ping' | jq -c 'select(.type=="system") | {model}'
{"model":"claude-opus-4-8[1m]"}
```

Default model now resolves to Opus 4.8 with the 1M-context wrapper, no pin needed.

## Test plan
- [x] `claude --version` reports 2.1.158
- [x] stream-json init event reports `model: claude-opus-4-8[1m]`
- [ ] First long interactive conversation post-merge does not compact at ~200K tokens