### PR TITLE
feat(beast): Audacity voice toy for alfie (replaces REAPER stack)

### DIFF
--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -48,7 +48,7 @@ in
     ./rgb/lg-sphere-ambient.nix # LG 38GN950 sphere lighting video-sync (wlr-screencopy → HID)
     ./piper-autoprofile.nix
     ./tobii-native.nix # Tobii Eye Tracker 5 native Linux (experimental)
-    ./music-production.nix # REAPER + audio plugins/bridges
+    ./music-production.nix # Audacity + Graillon voice plugins for alfie
     # Tailscale client configuration
     (import ../shared/tailscale.nix { role = "client"; enableSSH = true; })
     ./beszel-agent.nix

--- a/nixos/music-production.nix
+++ b/nixos/music-production.nix
@@ -1,55 +1,5 @@
 { pkgs, lib, ... }:
 let
-  talVocoder2 = pkgs.stdenvNoCC.mkDerivation rec {
-    pname = "tal-vocoder-2";
-    version = "2023-07-21";
-
-    src = pkgs.fetchzip {
-      url = "https://tal-software.com/downloads/plugins/TAL-Vocoder-2_64_linux.zip";
-      # Upstream silently re-zipped the file at this URL; old hash was QrYjoD9... — refreshed 2026-06-01.
-      hash = "sha256-S+ol+xj9Fofh9fOFpv3W8xJiJhCVCMtIgu58fLnGCR8=";
-      stripRoot = false;
-    };
-
-    nativeBuildInputs = [ pkgs.autoPatchelfHook ];
-    buildInputs = with pkgs; [
-      alsa-lib
-      freetype
-      gcc.cc.lib
-      stdenv.cc.cc.lib
-    ];
-
-    installPhase = ''
-      runHook preInstall
-
-      # Upstream 2026 re-zip moved files into a TAL-Vocoder-2/ subdir and
-      # dropped the bundled .vst3 directory — only CLAP + VST2 ship now.
-      install -Dm644 TAL-Vocoder-2/ReadmeLinux.txt \
-        $out/share/doc/${pname}/ReadmeLinux.txt
-
-      install -Dm755 TAL-Vocoder-2/TAL-Vocoder-2.clap \
-        $out/lib/clap/TAL-Vocoder-2.clap
-      install -Dm755 TAL-Vocoder-2/libTAL-Vocoder-2.so \
-        $out/lib/vst/libTAL-Vocoder-2.so
-
-      runHook postInstall
-    '';
-
-    meta = {
-      description = "TAL-Vocoder-2 free vocoder plugin (CLAP, VST2, VST3)";
-      homepage = "https://tal-software.com/products/tal-vocoder";
-      license = lib.licenses.unfreeRedistributable;
-      platforms = [ "x86_64-linux" ];
-    };
-  };
-
-  reaperNoStartupErrors = pkgs.writeShellApplication {
-    name = "reaper";
-    text = ''
-      exec ${pkgs.reaper}/bin/reaper -ignoreerrors "$@"
-    '';
-  };
-
   graillonFree = pkgs.stdenvNoCC.mkDerivation rec {
     pname = "graillon-free";
     version = "3.2";
@@ -98,34 +48,13 @@ let
   };
 in
 {
-  # Pro-audio basics for REAPER on PipeWire.
-  # Keep global PipeWire timing in nixos/audio.nix untouched; REAPER can opt into
-  # JACK/PipeWire with `pw-jack reaper` without changing the desktop audio graph.
-  security.rtkit.enable = true;
-  services.pipewire.jack.enable = true;
-
-  environment.systemPackages = with pkgs; [
-    (lib.hiPrio reaperNoStartupErrors)
-    reaper
-    reaper-sws-extension
-    reaper-reapack-extension
-
-    # Plugin formats / bridges / routing helpers
-    talVocoder2
+  environment.systemPackages = [
+    pkgs.audacity
     graillonFree
-    yabridge
-    yabridgectl
-    wineWowPackages.waylandFull
-    winetricks
-    qpwgraph
-    pipewire.jack # provides pw-jack for JACK clients on PipeWire
-
-    # Native Linux pitch-correction alternatives available in nixpkgs.
-    # MAutoPitch is not distributed as a native Linux plugin; use yabridge
-    # with its Windows VST build if you still want that specific plugin.
-    autotalent
-    x42-plugins
-    lsp-plugins
-    distrho-ports
   ];
+
+  environment.variables = {
+    VST3_PATH = "${graillonFree}/lib/vst3";
+    LV2_PATH = "${graillonFree}/lib/lv2";
+  };
 }


### PR DESCRIPTION
## What

Replaces the REAPER pro-audio contents of `nixos/music-production.nix` with a small voice toy for the couch user (alfie):

- **Audacity** 3.7.5
- **Auburn Sounds Graillon FREE** — live pitch/formant voice changer (CLAP/LV2/VST3), exposed via `VST3_PATH`/`LV2_PATH` so Audacity scans it. Stands in for "Pitchmunk", which has no Linux build.

The module keeps its filename; `configuration.nix` only updates the import's inline comment.

## Why this never shipped before

The migration was sitting uncommitted, and it couldn't rebuild: a GSnap derivation used `requireFile` with a placeholder hash and the zip was never added to the nix store, which aborts the whole system build. As a result Audacity/Graillon never got installed (system was still on the old generation, `audacity` absent). GSnap is left out of this PR — GVST gates its download behind a JS flow, so it can't be auto-fetched; it can come back in its own change once the zip is in the store.

## Testing

- `nixos-rebuild dry-build --flake .#BeAsT` — clean eval.
- Evaluated `system.build.toplevel` matches the running generation (`yz6hc54…`), i.e. the live system already reflects this config. Verified on the box:
  - `audacity` present in `/run/current-system/sw/bin`
  - Graillon VST3 + LV2 present and on `VST3_PATH`/`LV2_PATH`
  - side effect: `rtkit` user/group removed (it belonged to the old REAPER realtime stack)

Post-merge, alfie enables the plugin once via Audacity *Effect → Plugin Manager* → "Auburn Sounds Graillon 3".

🤖 Generated with [Claude Code](https://claude.com/claude-code)