### PR TITLE
fix(picoclaw): sure skill points at :13334 + raise tool-iteration limit

### DIFF
--- a/rpi5/picoclaw/picoclaw.nix
+++ b/rpi5/picoclaw/picoclaw.nix
@@ -69,7 +69,7 @@ let
       max_tokens = 8192;
       context_window = 131072;
       temperature = 0.7;
-      max_tool_iterations = 20;
+      max_tool_iterations = 100;
       summarize_message_threshold = 20;
       summarize_token_percent = 75;
     };

--- a/rpi5/picoclaw/skills/sure/SKILL.md
+++ b/rpi5/picoclaw/skills/sure/SKILL.md
@@ -11,28 +11,23 @@ Use this skill when the user asks about their **Sure** personal finance board: b
 
 ## Setup
 
-1. Open your Sure instance, for example: `https://localhost:3000`
-2. Go to **Settings → API key**
-3. Export your API key and base URL:
+On this host (rpi5) the Sure backend listens on **`http://127.0.0.1:13334`**
+(loopback) — NOT `:3000` (that's Beszel on the tailnet) and NOT `:8340`
+(that's the for-sure / Lunchflow connector, a different service with a
+different key). `SURE_API_KEY` is already injected into picoclaw's
+environment from `/run/agenix/picoclaw-env`, so you do **not** need to set it
+yourself — just use `$SURE_API_KEY`.
 
-```bash
-export SURE_API_KEY="YOUR_API_KEY"
-```
-
-Example:
-
-```bash
-# Optional remote example:
-# export SURE_BASE_URL="https://sure.example.com"
-export SURE_API_KEY="..."
-```
+If running the skill outside picoclaw, generate a key in your Sure instance
+under **Settings → API key** and `export SURE_API_KEY=...`. To target a remote
+instance, override the base URL: `export SURE_BASE_URL="https://sure.example.com"`.
 
 ## Auth header
 
-Base URL default:
+Base URL default (local Sure backend on rpi5):
 
 ```bash
-export SURE_BASE_URL="${SURE_BASE_URL:-http://127.0.0.1:3000}"
+export SURE_BASE_URL="${SURE_BASE_URL:-http://127.0.0.1:13334}"
 ```
 
 Reuse this in commands:


### PR DESCRIPTION
## What

Two picoclaw fixes:

1. **`sure` skill base URL** — defaulted `SURE_BASE_URL` to `http://127.0.0.1:3000`, but loopback `:3000` isn't listening (Beszel only binds the tailnet IP), so every Sure query failed to connect. Repointed to `http://127.0.0.1:13334/api/v1` — the same backend `homepage-stats.py` uses with the same `SURE_API_KEY` from `picoclaw-env`. Verified: returns 17 accounts. Also documented that `:8340` (for-sure/Lunchflow) is a *different* service, to stop the recurring confusion.
2. **`max_tool_iterations` 20 → 100** — 20 was too tight for multi-step skills.

## Verification

- `curl -H "X-Api-Key: $SURE_API_KEY" http://127.0.0.1:13334/api/v1/accounts` → 17 accounts ✅
- Live workspace skill copy already hot-patched so picoclaw can query Sure immediately.
- Limit bump takes effect on next `home-manager switch` (config.json regenerated at build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)