### PR TITLE
fix(macos): add --force-cleanup for Homebrew 5.x bundle compat

### DIFF
--- a/macos/components/homebrew.nix
+++ b/macos/components/homebrew.nix
@@ -9,6 +9,9 @@
     # autoUpdate = true;
     # upgrade = true;
     cleanup = "zap";
+    # Homebrew 5.x requires --force / --force-cleanup / $HOMEBREW_ASK
+    # for `brew bundle install --cleanup`.
+    extraFlags = [ "--force-cleanup" ];
   };
 
   taps = [


### PR DESCRIPTION
## Summary
- Homebrew 5.x rejects `brew bundle install --cleanup` without `--force` / `--force-cleanup` / `$HOMEBREW_ASK`.
- nix-darwin emits the bare `--cleanup` flag whenever `homebrew.onActivation.cleanup` is set (`"zap"` here), so `darwin-rebuild switch` fails at the "Homebrew bundle..." activation step.
- Pass `--force-cleanup` via `homebrew.onActivation.extraFlags` to unblock activation.

## Test plan
- [x] `sudo darwin-rebuild switch --flake path:.#nBookPro` completes (exit 0)
- [x] `home-manager switch --flake path:.#nsimon@nBookPro` completes (exit 0)
- [x] `brew bundle` reports 70 deps installed and cleanup runs without the invalid-usage error

🤖 Generated with [Claude Code](https://claude.com/claude-code)