### PR TITLE
feat(claude): add telegram skill for posting messages/photos

### DIFF
--- a/home/claude-skills/telegram/SKILL.md
+++ b/home/claude-skills/telegram/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: telegram
+description: Send a Telegram message or photo from this machine via the bot — to Nico's DM, Alfie's DM, or the shared group. Use when asked to notify/ping/message someone on Telegram, or to post an update/result there.
+metadata:
+  short-description: Post to Telegram (sendMessage / sendPhoto) via the bot token
+---
+
+# Telegram
+
+Post messages and photos to Telegram from the rpi using the bot's HTTP API.
+**Outbound only** — picoclaw owns incoming messages.
+
+## Auth
+
+The bot token is an agenix secret on disk, readable by `nsimon`:
+
+```bash
+TOKEN=$(cat /run/agenix/telegram-bot-token)
+```
+
+(If that path is missing — e.g. a home-manager activation context — fall back to
+`/run/user/$(id -u)/agenix/telegram-bot-token`.)
+
+## Targets (chat_id)
+
+| Alias | chat_id | Who |
+| --- | --- | --- |
+| me / Nico | `82389391` | Nico's DM with the bot — **default** |
+| alfie | `8627259779` | Alfie's DM with the bot |
+| group | `-1003356011841` | Group "nSimon, ServaTilis and Alfie" (Nico + Alfie + bot) |
+
+Default to **Nico's DM** unless told otherwise. The **group is shared with Alfie** —
+only post there when both should see it. (The group is set to trigger picoclaw only
+when the bot is @mentioned, so a plain post won't start an agent turn.)
+
+## Send a text message
+
+```bash
+TOKEN=$(cat /run/agenix/telegram-bot-token)
+curl -s "https://api.telegram.org/bot${TOKEN}/sendMessage" \
+  --data-urlencode "chat_id=82389391" \
+  --data-urlencode "text=Your message here" | jq '{ok, id: .result.message_id}'
+```
+
+`--data-urlencode` handles spaces, newlines, and punctuation safely. Optional:
+add `--data-urlencode "parse_mode=Markdown"` for *bold* / `code` (then escape any
+literal `_ * [ ` characters in the text).
+
+### Emoji / multi-line / special characters
+
+A raw emoji typed directly in the command can make the shell fail with
+`character not in range`. Put rich text in a file via a **quoted** heredoc, then
+send the file with `text@`:
+
+```bash
+TOKEN=$(cat /run/agenix/telegram-bot-token)
+cat > /tmp/tg-msg.txt <<'EOF'
+✅ Deploy finished
+• build: ok
+• tests: 42 passed
+EOF
+curl -s "https://api.telegram.org/bot${TOKEN}/sendMessage" \
+  --data-urlencode "chat_id=82389391" \
+  --data-urlencode "text@/tmp/tg-msg.txt" | jq '{ok, id: .result.message_id}'
+```
+
+## Send a photo
+
+```bash
+TOKEN=$(cat /run/agenix/telegram-bot-token)
+curl -s "https://api.telegram.org/bot${TOKEN}/sendPhoto" \
+  -F "chat_id=82389391" \
+  -F "photo=@/path/to/image.jpg" \
+  -F "caption=Optional caption" | jq '{ok, id: .result.message_id}'
+```
+
+## Send a gallery (album)
+
+For 2–10 photos as one grouped gallery, use `sendMediaGroup` (a `media` JSON array
+of `{type:"photo", media:"attach://fileN"}` with the caption on item 0, plus the
+files as `-F fileN=@...`). A working stdlib reference implementation lives in the
+immich skill: `rpi5/picoclaw/skills/immich-memories/scripts/immich-on-this-day.py`
+(`send_album`).
+
+## Notes
+
+- Always check the response: `{"ok":true,...}` on success; on failure Telegram
+  returns `{"ok":false,"description":"..."}` — surface that description.
+- Never echo the token back to the user or embed it in logs.
+- This bot is the same one picoclaw runs; sending here does not go through
+  picoclaw's agent (it's a direct API call).

--- a/home/claude.nix
+++ b/home/claude.nix
@@ -84,6 +84,10 @@ in
   # subset), and Claude Code's own settings/hooks. Picoclaw picks up the
   # same shared skills via rpi5/picoclaw/picoclaw.nix.
   home.file = sharedSkillFiles // claudeCommandFiles // {
+    # Claude-Code-only skill (NOT shared with codex/pi/picoclaw — picoclaw already
+    # *is* the Telegram bot): how to post messages/photos to Telegram via the bot.
+    ".claude/skills/telegram/SKILL.md".source = ./claude-skills/telegram/SKILL.md;
+
     # Writable settings.json — symlinked to the repo checkout so /voice etc.
     # can update it at runtime.
     ".claude/settings.json".source =


### PR DESCRIPTION
## What

Adds a **Claude-Code-only** skill (`/telegram`) documenting how to post to Telegram from the rpi via the bot's HTTP API — messages, photos, and albums — to Nico's DM, Alfie's DM, or the shared group.

## Why

Worked out the exact Bot API recipe + chat ids while building the immich gallery; capturing it as a skill lets the general Claude Code assistant send notifications/updates to Telegram on its own.

## Contents

- `home/claude-skills/telegram/SKILL.md` — token (`/run/agenix/telegram-bot-token`), a targets table (Nico `82389391` default, Alfie `8627259779`, group `-1003356011841`), and `sendMessage`/`sendPhoto`/`sendMediaGroup` recipes. Includes the heredoc-file workaround for emoji/multiline (a raw emoji inline can make the shell throw `character not in range`).
- `home/claude.nix` — one `home.file` entry wiring it to `~/.claude/skills/` **only** (not via `shared/skills/`, so Codex/pi/picoclaw don't get it — picoclaw already *is* the Telegram bot).

## Verification

- Deployed via `home-manager switch`; confirmed `~/.claude/skills/telegram/SKILL.md` is present and **absent** from `~/.codex/skills/` and `~/.pi/agent/skills/`; the harness now lists `telegram` as an available skill.
- Ran the SKILL's documented `sendMessage` and heredoc-file recipes verbatim → both delivered to Telegram (`ok:true`).

Separate from #285 (immich gallery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)