### PR TITLE
chore(flake): bump inputs, make cyrus auto-bumpable, wire claude-fable-5

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -134,6 +134,22 @@
         "type": "github"
       }
     },
+    "cyrus-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1781105021,
+        "narHash": "sha256-tNr1Q/eBXJ6Dv0+OMA1XhsHWs/aqd/gRG0Cbfv2QuCs=",
+        "owner": "cyrusagents",
+        "repo": "cyrus",
+        "rev": "85ab88fb9c9140911b901af3a41140fe059308df",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cyrusagents",
+        "repo": "cyrus",
+        "type": "github"
+      }
+    },
     "darwin": {
       "inputs": {
         "nixpkgs": [
@@ -550,11 +566,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1779868340,
-        "narHash": "sha256-TK1oFHU2SPXuB1gUX3SnqNujViWiYIPYTuWxXy1wR6U=",
+        "lastModified": 1781157766,
+        "narHash": "sha256-InNpK3w0V6odvKtC5wCXZZiluiWAD6uLElz3to+sQA0=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "93c592a1bf2bfcb7e72b9a5344611efcf72917db",
+        "rev": "0b3a6a2dc43576f223d036ba70a29a2f0de99061",
         "type": "github"
       },
       "original": {
@@ -571,11 +587,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779860322,
-        "narHash": "sha256-L2vtCy4TxB5h4xjavHXoHTwkRcbR46BOWt/IOV/l6X0=",
+        "lastModified": 1781096216,
+        "narHash": "sha256-mjh6aX+6B9pk/mciRqauO2RgkCH7VONBt71V0CqHHNw=",
         "owner": "AlexsJones",
         "repo": "llmfit",
-        "rev": "665a4e15438b061e33974dcbad639f318ef6b5d2",
+        "rev": "2365836fc55b6b5f96622b4fd40cfeaa1e7a5e2f",
         "type": "github"
       },
       "original": {
@@ -619,11 +635,11 @@
         "treefmt-nix": "treefmt-nix_4"
       },
       "locked": {
-        "lastModified": 1779656157,
-        "narHash": "sha256-dA6u30HIKBACOYuzQHHaBIDBFnic4iaNh+nHEj2OLwg=",
+        "lastModified": 1780941735,
+        "narHash": "sha256-QoCAnucKgVpyMsobqdduT1XwyYVX0mq/u8ziHgct5hg=",
         "owner": "LovingMelody",
         "repo": "nix-citizen",
-        "rev": "e818de97b42cd0384efda2d6d257ae2f54bcb259",
+        "rev": "fcdf02b087e1af382e3f00eda9cb3807bc8f57aa",
         "type": "github"
       },
       "original": {
@@ -634,11 +650,11 @@
     },
     "nix-flatpak": {
       "locked": {
-        "lastModified": 1777402031,
-        "narHash": "sha256-6gkfl9y3+ti0Z6dgby8/R4/DRT8sWU0I0TLCIxwWtjk=",
+        "lastModified": 1780908363,
+        "narHash": "sha256-llGS4y3Qh1eUkli3/Y2VY9FV3GOUKFZR1E2BDftt45Q=",
         "owner": "gmodena",
         "repo": "nix-flatpak",
-        "rev": "22a3adbe7c5c8c8a10a635d32c9ef7fc01a6e4b8",
+        "rev": "1df08625f0f8c7d6e300a0e5df7955bbb877d809",
         "type": "github"
       },
       "original": {
@@ -654,11 +670,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1779768228,
-        "narHash": "sha256-/dRavNAx/Mp67xcQQ3JBIMyf0cLoXqKedafB1+wksAE=",
+        "lastModified": 1781064751,
+        "narHash": "sha256-KLhF1KXXGNFXQBLEZWoeMSbxHimMTYZfEilMs6azeY4=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "6e7a8414c0f547a86646eb0b56ebf89e7cc217a2",
+        "rev": "7149d77f66536aaf02c845a9c2a08eb7e57a04c3",
         "type": "github"
       },
       "original": {
@@ -763,11 +779,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1780365719,
-        "narHash": "sha256-QfWfccTN+70ZQ4m2qlU9PiKfz2Yppq94058iJyARNwc=",
+        "lastModified": 1780930886,
+        "narHash": "sha256-rppURzHviaQN131F+nLiLdGfcb0uCd9gGP0E5+iw9MI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ffa10e26ae11d676b2db836259889f1f571cb14f",
+        "rev": "8c3cede7ddc26bd659d2d383b5610efbd2c7a16e",
         "type": "github"
       },
       "original": {
@@ -827,11 +843,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1779536132,
-        "narHash": "sha256-q+fF42iv/geEbHfgSzy3tS0FF/EyD6XTZ98E6yxiBO8=",
+        "lastModified": 1780747962,
+        "narHash": "sha256-IX7G1dlKrOqPOImfbo7ADDfV5yU1+j+MRChI3TL4tAA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3d8f0f3f72a6cd4d93d0ad13203f2ea1cb7e1456",
+        "rev": "cbb5cf358f50aa6acc9efd6113b7bcfbc352cd73",
         "type": "github"
       },
       "original": {
@@ -859,11 +875,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1779887605,
-        "narHash": "sha256-S6QSHMWpBDC410T6iJMd/+WC8iZzRXUZ7ikwYjETb5o=",
+        "lastModified": 1781174944,
+        "narHash": "sha256-aXCJoCT8aftXgbPqYVbWs2+vbCdu5GP9bHVH6ontxRA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e60871b207281391f06d04586686688e630d4576",
+        "rev": "188a792917afa8a0f387f18147252726edd8a957",
         "type": "github"
       },
       "original": {
@@ -916,6 +932,7 @@
     },
     "root": {
       "inputs": {
+        "cyrus-src": "cyrus-src",
         "darwin": "darwin",
         "for-sure": "for-sure",
         "gogcli-src": "gogcli-src",
@@ -1114,11 +1131,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775636079,
-        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
         "type": "github"
       },
       "original": {
@@ -1171,11 +1188,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775636079,
-        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
         "type": "github"
       },
       "original": {
@@ -1194,11 +1211,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779858952,
-        "narHash": "sha256-3GwipanR5N8jvEe6CyQXvO0dWUHD77udH+gL8vYz91o=",
+        "lastModified": 1781173532,
+        "narHash": "sha256-MwnZpL82aQO1I15JH525vz6REI/OULEAmXDp6cIcgNg=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "3f714494e7514108056d3317c9148b9b7ff08022",
+        "rev": "f13e82162fae68af7716147207fa5f868f5ca381",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -88,6 +88,16 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    # Cyrus — Linear coding-agent dispatcher (cyrusagents/cyrus). Source-only
+    # input (`flake = false`): rpi5/cyrus.nix vendors it and builds with pnpm
+    # at service start. Tracks the default branch (no tag), so `nix flake
+    # update` auto-bumps it; cyrus-build.service rebuilds once per rev change.
+    # To pin a specific commit/tag instead, append `/<rev-or-tag>` to the URL.
+    cyrus-src = {
+      url = "github:cyrusagents/cyrus";
+      flake = false;
+    };
+
     # llm-agents.nix: numtide's daily-updated flake of AI coding agent
     # packages. We pull `pi` (pi-coding-agent) from here instead of pinning
     # an upstream tarball ourselves — auto-tracks new releases.

--- a/home/dotfiles/claude-settings.json
+++ b/home/dotfiles/claude-settings.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "model": "claude-fable-5",
   "env": {
     "ANTHROPIC_BASE_URL": "https://ai.gate-mintaka.ts.net"
   },

--- a/rpi5/aperture-sync.nix
+++ b/rpi5/aperture-sync.nix
@@ -27,7 +27,7 @@ let
   # claude-code auto-updates the list; if extraction breaks, the count guard
   # in jq fails the rebuild.
   anthropicModelsFile = pkgs.runCommand "claude-anthropic-models.json" { } ''
-    ${pkgs.gnugrep}/bin/grep -aoE '"claude-(opus|sonnet|haiku)-[a-z0-9-]+"' \
+    ${pkgs.gnugrep}/bin/grep -aoE '"claude-(opus|sonnet|haiku|fable|mythos)-[a-z0-9-]+"' \
       ${unstablePkgs.claude-code}/bin/.claude-wrapped \
       | ${pkgs.gnused}/bin/sed 's/"//g; /-$/d' \
       | sort -u \
@@ -36,7 +36,14 @@ let
       > $out
   '';
 
-  anthropicModels = builtins.fromJSON (builtins.readFile anthropicModelsFile);
+  # Always include claude-fable-5 (Mythos-class, public 2026-06-09). It is
+  # newer than the claude-code binary pinned via nixpkgs-unstable, so the
+  # regex extraction above can't see it yet — list it explicitly so the
+  # Anthropic passthrough provider routes it now. Once a fable-aware
+  # claude-code lands in nixpkgs the regex captures it too (deduped here).
+  anthropicModels = lib.unique (
+    builtins.fromJSON (builtins.readFile anthropicModelsFile) ++ [ "claude-fable-5" ]
+  );
 
   # The inner config that Aperture manages — this gets JSON-encoded into a
   # string value inside the PUT envelope.

--- a/rpi5/cyrus.nix
+++ b/rpi5/cyrus.nix
@@ -4,7 +4,9 @@
 # against issues, opens PRs as the configured GitHub user. Public URL via
 # Tailscale Funnel on :8443 → 127.0.0.1:3456.
 #
-# Packaging: source is vendored as a fixed-output derivation (fetchFromGitHub).
+# Packaging: source comes from the `cyrus-src` flake input (flake.nix,
+# `flake = false`), so it's locked in flake.lock and auto-bumped by
+# `nix flake update` (no manual rev/hash to maintain here).
 # A one-shot `cyrus-build.service` copies the source into /var/lib/cyrus/src and
 # runs `pnpm install --frozen-lockfile && pnpm -r build` on first start (or when
 # the pinned rev changes). Pure-Nix packaging via `pnpm.fetchDeps` was tried and
@@ -31,18 +33,16 @@
 #                  (must be exact — cyrus mounts at /linear-webhook, NOT /webhooks/linear)
 #   Scopes:        write, app:assignable, app:mentionable
 #   Webhook event: "Agent session events"
-{ config, lib, pkgs, unstablePkgs, apertureUrl, ... }:
+{ config, lib, pkgs, unstablePkgs, apertureUrl, inputs, ... }:
 let
   cfg = config.services.cyrus;
 
-  cyrusRev = "5f3ed02a9590318fac4ea36188a41d397a917a0b";
-
-  cyrusSrc = pkgs.fetchFromGitHub {
-    owner = "cyrusagents";
-    repo  = "cyrus";
-    rev   = cyrusRev;
-    hash  = "sha256-j5+DjuTbjX5nUwS5D60IoLo6WcIUJUy8x+OTUrygX8E=";
-  };
+  # Source from the `cyrus-src` flake input (flake.nix). Locked in flake.lock
+  # and auto-bumped by `nix flake update` (tracks the default branch). `.rev`
+  # is the locked commit — used as the cyrus-build rebuild marker so a bump
+  # triggers exactly one rebuild.
+  cyrusSrc = inputs.cyrus-src;
+  cyrusRev = inputs.cyrus-src.rev;
 in
 {
   options.services.cyrus = {


### PR DESCRIPTION
Recovers a flake-bump session whose `claude-remote-control` bridge was OOM-killed mid-rebuild before it could push or open a PR. The single surviving commit (`7aba47a`) is replayed here, rebased cleanly onto current `main`.

## What this does (three logical changes)
1. **Flake bump** (`nix flake update`): `nixpkgs` (→2026-06-11), `nixpkgs-unstable` (→06-08), `llm-agents`, `llmfit`, `nix-citizen`, `nix-flatpak`, `nix-gaming`, `zen-browser`. `nixos-raspberrypi` unchanged (no kernel rebuild); `sure-nix`/`for-sure` already at default-branch HEADs.
2. **cyrus → `cyrus-src` flake input**: converts `rpi5/cyrus.nix` from a hand-pinned `fetchFromGitHub` (rev+hash) to a `flake = false` input, so `nix flake update` auto-bumps it. Bumped `5f3ed02` → `85ab88f` in the process.
3. **Claude Fable 5** (`claude-fable-5`, public 2026-06-09 — verified exact API id against Anthropic docs): widen the `aperture-sync.nix` model-extraction regex to include the fable/mythos tiers and explicitly add `claude-fable-5` (the pinned `claude-code-2.1.158` binary predates fable, so regex extraction can't see it yet); set it as the default model in `claude-settings.json`.

## Recovery / crash context
- The prior bridge session committed this, kicked off `nixos-rebuild`, and was OOM-killed at ~18:18 during the rebuild's **final concurrent-rustc stretch** (`pi`/Tauri + `llmfit`) — the known rpi5 OOM-thrash-on-rebuild failure mode. The box did **not** hard-reset; the bridge just died (no auto-restart).
- The `nixos-rebuild` ran **detached**, survived, and **succeeded**: **system generation 742 is already built from this exact tree** (version string `…188a792` == this branch's `flake.lock` `nixpkgs_7` pin; aperture already serves `claude-fable-5`; cyrus active). So for the running rpi5, merging this is largely a formality.
- ⚠️ The `model: claude-fable-5` default only goes *live* once a checkout carrying this change sits at `/home/nsimon/nic-os` — `~/.claude/settings.json` is an out-of-store symlink into that path. Fable is already *usable* via aperture; this flips the *default*.

Verified locally with `nixos-rebuild dry-activate --flake .#rpi5` (no switch).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)