### PR TITLE
fix(beast): give alfie her own BG3 Proton prefix (shared NTFS drive)

### DIFF
--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -180,6 +180,8 @@ in
   systemd.tmpfiles.rules = [
     "L+ /home/alfie/.config/hypr/hyprland.conf - - - - ${./dotfiles/hypr/hyprland.conf}"
     "L+ /home/alfie/.config/rofi - - - - ${./dotfiles/rofi}"
+    # Per-user Proton prefix root for alfie (see alfie-bg3-prefix service below).
+    "d /home/alfie/proton-prefixes 0755 alfie users -"
   ];
 
   # umask 002 so nsimon + alfie can both read/write the shared /mnt/games tree.
@@ -194,6 +196,28 @@ in
     DefaultUMask=0002
   '';
   security.loginDefs.settings.UMASK = "002";
+
+  # Give alfie her own Baldur's Gate 3 Proton prefix in her home.
+  # /mnt/games is NTFS (ntfs3, uid=1000), so the shared Proton prefix under
+  # SteamLibrary/steamapps/compatdata/1086940 reads as owned by nsimon (uid 1000).
+  # Wine refuses a prefix that "is not owned by you", so BG3 launched and instantly
+  # died ONLY for alfie (uid 1001), while nsimon's worked. The fix is a per-game Steam
+  # launch option that redirects STEAM_COMPAT_DATA_PATH into alfie's home (ext4, real
+  # ownership). Steam keeps launch options across restarts, but they live in alfie's
+  # home and are not declarative; this oneshot re-asserts the option idempotently at
+  # boot (before display-manager, so Steam is not running) so the fix survives a Steam
+  # config reset and is reproducible from this config. See ./ensure-alfie-bg3-prefix.sh.
+  systemd.services.alfie-bg3-prefix = {
+    description = "Ensure alfie's BG3 Proton prefix redirect (shared NTFS games drive workaround)";
+    before = [ "display-manager.service" ];
+    wantedBy = [ "multi-user.target" ];
+    path = with pkgs; [ bash gawk gnugrep procps coreutils ];
+    serviceConfig = {
+      Type = "oneshot";
+      User = "alfie";
+      ExecStart = "${pkgs.bash}/bin/bash ${./ensure-alfie-bg3-prefix.sh}";
+    };
+  };
 
   environment.systemPackages = with pkgs; [
     cage

--- a/nixos/ensure-alfie-bg3-prefix.sh
+++ b/nixos/ensure-alfie-bg3-prefix.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Ensure alfie's Baldur's Gate 3 Proton prefix is redirected to a path she owns.
+#
+# WHY: /mnt/games is NTFS (ntfs3, mounted uid=1000), so every file there — including
+# the shared Proton prefix at SteamLibrary/steamapps/compatdata/1086940/pfx — is
+# reported as owned by nsimon (uid 1000). Wine refuses a prefix that "is not owned by
+# you", so BG3 launched and instantly died ONLY for alfie (uid 1001), while nsimon's
+# worked. Fix: give alfie a per-user prefix in her home (real ext4 ownership) via a
+# Steam per-game launch option (STEAM_COMPAT_DATA_PATH override).
+#
+# Steam preserves launch options across restarts, but they live in alfie's home and are
+# not declarative. This oneshot re-asserts the option idempotently at boot (ordered
+# before display-manager, so Steam is not running), so the fix survives a Steam config
+# reset and is reproducible from the NixOS config. Safe: backs up, validates brace
+# balance, only writes when the BG3 app block exists and the option is genuinely missing.
+set -uo pipefail
+
+APP=1086940
+PREFIX_PARENT=/home/alfie/proton-prefixes
+OPT="STEAM_COMPAT_DATA_PATH=${PREFIX_PARENT}/${APP} %command%"
+MARKER="proton-prefixes/${APP}"
+
+# Never race Steam's own writes to localconfig.vdf.
+if pgrep -u alfie -x steam >/dev/null 2>&1; then
+  echo "steam is running for alfie; skipping launch-option re-assert"
+  exit 0
+fi
+
+shopt -s nullglob
+found=0
+for LC in /home/alfie/.local/share/Steam/userdata/*/config/localconfig.vdf; do
+  found=1
+  if grep -q "$MARKER" "$LC"; then
+    echo "launch option already present: $LC"
+    continue
+  fi
+
+  tmp="$(mktemp)"
+  awk -v app="$APP" -v opt="$OPT" '
+    function indent(s){ match(s, /^\t*/); return substr(s, 1, RLENGTH) }
+    BEGIN { inapps=0; armed=0; done=0 }
+    {
+      print $0
+      s=$0; gsub(/^[ \t]+|[ \t]+$/, "", s)
+      if (s == "\"apps\"") { inapps=1 }
+      if (inapps && !done && s == "\"" app "\"") { armed=1; next }
+      if (armed && s == "{") {
+        print indent($0) "\t\"LaunchOptions\"\t\t\"" opt "\""
+        armed=0; done=1
+      } else if (armed) { armed=0 }
+    }' "$LC" > "$tmp"
+
+  ob=$(tr -cd '{' < "$tmp" | wc -c)
+  cb=$(tr -cd '}' < "$tmp" | wc -c)
+  if [ "$ob" = "$cb" ] && grep -q "$MARKER" "$tmp"; then
+    cp -a "$LC" "$LC.bak-bg3prefix"
+    cat "$tmp" > "$LC"   # truncate-rewrite preserves owner/mode
+    echo "patched launch option into: $LC"
+  else
+    # BG3 app block not present yet, or validation failed — leave file untouched.
+    echo "no change ($LC): BG3 app block absent or validation failed (braces $ob/$cb)"
+  fi
+  rm -f "$tmp"
+done
+
+[ "$found" = 1 ] || echo "no alfie localconfig.vdf yet; nothing to do"
+exit 0


### PR DESCRIPTION
## Problem
Alfie reported she couldn't launch **Baldur's Gate 3** on beast, while nsimon could. The journal from her last attempt showed the real cause:

```
ProtonFixes[…] INFO: Running protonfixes on "GE-Proton10-33" … All checks successful
wineserver: /mnt/games/SteamLibrary/steamapps/compatdata/1086940/pfx is not owned by you
wine: '/mnt/games/SteamLibrary/steamapps/compatdata/1086940/pfx' is not owned by you
Game Recording - game stopped [gameid=1086940]   ← launched then died instantly
```

`/mnt/games` is NTFS (ntfs3, mounted `uid=1000`), so **every** file there — including the shared Proton prefix — reports as owned by **nsimon (uid 1000)**. Wine refuses a prefix that "is not owned by you", so BG3 died instantly **only for alfie (uid 1001)**. Not a chmod issue: ntfs3 `dmask=0000,fmask=0000` already makes everything 0777, and NTFS ownership is mount-pinned and can't be changed per-file.

## Fix
Give alfie her own Proton prefix in her home (ext4, real ownership) via a per-game Steam launch option:
`STEAM_COMPAT_DATA_PATH=/home/alfie/proton-prefixes/1086940 %command%`

- `systemd.tmpfiles` creates the per-user prefix root.
- `ensure-alfie-bg3-prefix.sh` re-asserts the launch option idempotently at boot (ordered **before** `greetd`/Steam), so the fix is declarative and survives a Steam config reset. Defensive: backs up, validates brace balance, only writes when the BG3 app block exists and the option is genuinely missing.

## Verified on beast
- Rebuilt; service `enabled`, `WantedBy=multi-user.target`, `Before=greetd.service`.
- Manual run is a clean no-op when the option is already present (localconfig sha unchanged, no stray backups).
- Launch option present, prefix dir created.

⚠️ Not yet confirmed via a real GUI launch (headless box, no display) — needs one launch in alfie's session to confirm BG3 reaches the menu. The ownership gate (the sole failure) is resolved by construction.

ℹ️ Point-fix for BG3. Every other Windows game alfie runs from the shared NTFS library will hit the same wall; a general per-user-prefix solution (e.g. a default compat-tool wrapper) is a sensible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)