### PR TITLE
fix(alfie): redirect every Proton prefix to her home, not just BG3

### DIFF
--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -180,6 +180,8 @@ in
   systemd.tmpfiles.rules = [
     "L+ /home/alfie/.config/hypr/hyprland.conf - - - - ${./dotfiles/hypr/hyprland.conf}"
     "L+ /home/alfie/.config/rofi - - - - ${./dotfiles/rofi}"
+    # Per-user Proton prefix root for alfie (see alfie-proton-prefixes service below).
+    "d /home/alfie/proton-prefixes 0755 alfie users -"
   ];
 
   # umask 002 so nsimon + alfie can both read/write the shared /mnt/games tree.
@@ -194,6 +196,30 @@ in
     DefaultUMask=0002
   '';
   security.loginDefs.settings.UMASK = "002";
+
+  # Give alfie her own Proton prefix for every game on the shared NTFS library.
+  # /mnt/games/SteamLibrary is NTFS (ntfs3, uid=1000), so every game's Proton prefix
+  # under steamapps/compatdata/<appid> reads as owned by nsimon (uid 1000). Wine refuses
+  # a prefix that "is not owned by you", so EVERY Proton game launched and instantly died
+  # ONLY for alfie (uid 1001), while nsimon's worked (native games are unaffected — no
+  # prefix). The fix is a per-game Steam launch option that redirects STEAM_COMPAT_DATA_PATH
+  # into alfie's home (ext4, real ownership), so Proton builds a fresh prefix she owns.
+  # Steam keeps launch options across restarts, but they live in alfie's home and are not
+  # declarative; this oneshot re-asserts them idempotently at boot (before display-manager,
+  # so Steam is not running) so the fix survives a Steam config reset, covers newly-installed
+  # games on the next boot, and is reproducible from this config. See
+  # ./ensure-alfie-proton-prefixes.sh.
+  systemd.services.alfie-proton-prefixes = {
+    description = "Ensure alfie's per-game Proton prefix redirects (shared NTFS games drive workaround)";
+    before = [ "display-manager.service" ];
+    wantedBy = [ "multi-user.target" ];
+    path = with pkgs; [ bash gawk gnugrep procps coreutils ];
+    serviceConfig = {
+      Type = "oneshot";
+      User = "alfie";
+      ExecStart = "${pkgs.bash}/bin/bash ${./ensure-alfie-proton-prefixes.sh}";
+    };
+  };
 
   environment.systemPackages = with pkgs; [
     cage

--- a/nixos/ensure-alfie-proton-prefixes.sh
+++ b/nixos/ensure-alfie-proton-prefixes.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Give alfie her own Proton prefix for every game on the shared NTFS Steam library.
+#
+# WHY: /mnt/games/SteamLibrary is NTFS (ntfs3, mounted uid=1000), so every file there —
+# including each game's Proton prefix under steamapps/compatdata/<appid> — is reported as
+# owned by nsimon (uid 1000) no matter who created it. Wine refuses to use a prefix that
+# "is not owned by you", so EVERY Proton game launched and instantly died for alfie
+# (uid 1001), while nsimon's worked. (Native Linux games are unaffected — they have no
+# prefix.) The fix is a per-game Steam launch option that redirects STEAM_COMPAT_DATA_PATH
+# into alfie's home (ext4, real ownership), so Proton builds a fresh prefix she owns.
+#
+# This generalises the old BG3-only redirect to all installed library titles. Steam keeps
+# launch options across restarts, but they live in alfie's home and are not declarative;
+# this oneshot re-asserts them idempotently at boot (ordered before display-manager, so
+# Steam is not running) so the fix survives a Steam config reset, covers newly-installed
+# games on the next boot, and is reproducible from the NixOS config.
+#
+# Safe by construction: never runs while alfie's Steam is up; backs up before writing;
+# validates brace balance and that the redirect landed before committing; only ever ADDS
+# a redirect for a game that has none — it never clobbers a launch option alfie set herself.
+set -uo pipefail
+
+PREFIX_PARENT=/home/alfie/proton-prefixes
+LIB=/mnt/games/SteamLibrary/steamapps
+
+mkdir -p "$PREFIX_PARENT" 2>/dev/null || true
+
+# Never race Steam's own writes to localconfig.vdf.
+if pgrep -u alfie -x steam >/dev/null 2>&1; then
+  echo "steam is running for alfie; skipping prefix redirect re-assert"
+  exit 0
+fi
+
+# Appids installed on the NTFS library (these are the ones whose prefixes live on ntfs3).
+mapfile -t APPS < <(ls "$LIB"/appmanifest_*.acf 2>/dev/null \
+  | sed 's#.*appmanifest_##; s#\.acf$##' | grep -E '^[0-9]+$' | sort -un)
+if [ "${#APPS[@]}" -eq 0 ]; then
+  echo "no appmanifests under $LIB; nothing to do"
+  exit 0
+fi
+
+# Inject (or create) the LaunchOptions redirect for one appid into a working copy.
+# Reads the working file, writes the patched result to stdout. Idempotent at the caller.
+inject_one() {
+  local app="$1" opt="$2" src="$3"
+  if grep -qE "^[[:space:]]+\"$app\"[[:space:]]*$" "$src"; then
+    # App block exists: add LaunchOptions right after its opening brace.
+    awk -v app="$app" -v opt="$opt" '
+      function indent(s){ match(s, /^\t*/); return substr(s, 1, RLENGTH) }
+      BEGIN { inapps=0; armed=0; done=0 }
+      {
+        print $0
+        s=$0; gsub(/^[ \t]+|[ \t]+$/, "", s)
+        if (s == "\"apps\"") { inapps=1 }
+        if (inapps && !done && s == "\"" app "\"") { armed=1; next }
+        if (armed && s == "{") {
+          print indent($0) "\t\"LaunchOptions\"\t\t\"" opt "\""
+          armed=0; done=1
+        } else if (armed) { armed=0 }
+      }' "$src"
+  else
+    # No app block yet: create a minimal one right after the "apps" { line.
+    awk -v app="$app" -v opt="$opt" '
+      function indent(s){ match(s, /^\t*/); return substr(s, 1, RLENGTH) }
+      BEGIN { armed=0; done=0 }
+      {
+        s=$0; gsub(/^[ \t]+|[ \t]+$/, "", s)
+        if (!done && armed && s == "{") {
+          print $0
+          ind=indent($0) "\t"
+          print ind "\"" app "\""
+          print ind "{"
+          print ind "\t\"LaunchOptions\"\t\t\"" opt "\""
+          print ind "}"
+          armed=0; done=1; next
+        }
+        print $0
+        if (s == "\"apps\"") { armed=1 }
+      }' "$src"
+  fi
+}
+
+# Does this appid's block already carry a LaunchOptions line (custom or ours)? If so, leave
+# it entirely alone — we must not clobber something alfie set deliberately.
+has_launch_options() {
+  local app="$1" src="$2"
+  awk -v app="$app" '
+    function trim(s){ gsub(/^[ \t]+|[ \t]+$/, "", s); return s }
+    BEGIN { inapps=0; inblk=0; depth=0; armed=0; found=0 }
+    {
+      s=trim($0)
+      if (s == "\"apps\"") { inapps=1 }
+      if (inapps && !inblk && !armed && s == "\"" app "\"") { armed=1; next }
+      if (armed && s == "{") { inblk=1; depth=1; armed=0; next }
+      else if (armed) { armed=0 }
+      if (inblk) {
+        if (s == "{") depth++
+        else if (s == "}") { depth--; if (depth==0) inblk=0 }
+        if (index(s, "\"LaunchOptions\"") == 1) found=1
+      }
+    }
+    END { print found }' "$src"
+}
+
+shopt -s nullglob
+found_lc=0
+for LC in /home/alfie/.local/share/Steam/userdata/*/config/localconfig.vdf; do
+  found_lc=1
+  work="$(mktemp)"; cp "$LC" "$work"
+  changed=0
+
+  for APP in "${APPS[@]}"; do
+    OPT="STEAM_COMPAT_DATA_PATH=${PREFIX_PARENT}/${APP} %command%"
+
+    # Already redirected to alfie's prefix? Done.
+    if grep -qF "STEAM_COMPAT_DATA_PATH=${PREFIX_PARENT}/${APP} " "$work"; then
+      continue
+    fi
+    # Custom launch option present? Respect it.
+    if [ "$(has_launch_options "$APP" "$work")" = "1" ]; then
+      echo "skip $APP: existing custom LaunchOptions, leaving untouched"
+      continue
+    fi
+
+    tmp="$(mktemp)"
+    inject_one "$APP" "$OPT" "$work" > "$tmp"
+
+    ob=$(tr -cd '{' < "$tmp" | wc -c)
+    cb=$(tr -cd '}' < "$tmp" | wc -c)
+    if [ "$ob" = "$cb" ] && grep -qF "$OPT" "$tmp"; then
+      mv "$tmp" "$work"
+      changed=1
+      echo "redirect set: $APP"
+    else
+      echo "skip $APP: validation failed (braces $ob/$cb)"
+      rm -f "$tmp"
+    fi
+  done
+
+  if [ "$changed" = 1 ]; then
+    cp -a "$LC" "$LC.bak-prefixes"
+    cat "$work" > "$LC"   # truncate-rewrite preserves owner/mode
+    echo "patched $LC"
+  else
+    echo "no change needed: $LC"
+  fi
+  rm -f "$work"
+done
+
+[ "$found_lc" = 1 ] || echo "no alfie localconfig.vdf yet; nothing to do"
+exit 0


### PR DESCRIPTION
## Problem
alfie (uid 1001) could not launch **any** Proton game from the shared library at `/mnt/games/SteamLibrary`. It's NTFS via ntfs3 mounted `uid=1000`, so every game's Proton prefix under `steamapps/compatdata/<appid>/pfx` reports as owned by `nsimon` (uid 1000) regardless of who created it. Wine refuses a prefix that "is not owned by you", so every Proton game died on launch for alfie while nsimon's worked. Native Linux games are unaffected (no prefix). Only BG3 worked — it was the one game whose prefix had been redirected to her home.

ntfs3 forces the uid at mount time, so chown/chmod can't fix the ownership; the prefix has to live on a real-ownership filesystem.

## Fix
Generalise the BG3-only redirect to the whole library. A per-game Steam launch option `STEAM_COMPAT_DATA_PATH=/home/alfie/proton-prefixes/<appid> %command%` redirects each prefix into alfie's ext4 home, so Proton builds a fresh prefix she owns. Per-game is the only native-game-safe mechanism — Steam has no global launch option, and force-setting a global compat tool would break native titles.

- **`nixos/ensure-alfie-proton-prefixes.sh`** — enumerates installed `appmanifest_*.acf`, injects the redirect into alfie's `localconfig.vdf` for any game lacking a launch option (never clobbers a custom one), backs up to `localconfig.vdf.bak-prefixes`, validates brace balance before committing, and skips while alfie's Steam is running.
- **`nixos/configuration.nix`** — rename `alfie-bg3-prefix.service` → `alfie-proton-prefixes.service`; runs `before display-manager.service` (Steam down) so the fix survives a Steam config reset and auto-covers newly-installed games at next boot. Adds the `/home/alfie/proton-prefixes` tmpfiles root.

## Testing
- Applied live + rebuilt on BeAsT: all **32/32** installed games redirected (braces balanced 864/864, additive-only diff, BG3's custom option preserved, backup saved).
- Service swapped, enabled, and idempotent on re-run ("no change needed").
- Mechanism proven by alfie's existing BG3 prefix at `/home/alfie/proton-prefixes/1086940/pfx` — alfie-owned and fully built by Proton (`system.reg`, `drive_c`) through the Steam runtime, identical mechanism now applied to all games.
- Note: can't headless-test a launch (Proton's bundled `wine` only runs inside Steam's pressure-vessel runtime; bare-shell hits `/lib/ld-linux.so.2: could not open` on NixOS). alfie should launch any game to confirm — first launch builds her prefix (one-time wait).

🤖 Generated with [Claude Code](https://claude.com/claude-code)