### PR TITLE
chore(claude): allow Monitor(*) without prompting

### DIFF
--- a/home/dotfiles/claude-settings.json
+++ b/home/dotfiles/claude-settings.json
@@ -16,6 +16,7 @@
       "WebSearch(*)",
       "NotebookEdit(*)",
       "Task(*)",
+      "Monitor(*)",
       "mcp__*"
     ],
     "deny": []


### PR DESCRIPTION
## Summary
- Adds `Monitor(*)` to the user-level allow list in the home-manager-managed Claude settings.

## Why
Persistent monitors (CI/review watchers, queue health probes) otherwise prompt for confirmation every time, breaking long-running background flows.

## Test plan
- [ ] Rebuild home-manager: `home-manager switch`
- [ ] Confirm `~/.claude/settings.json` (symlink) reflects the new entry
- [ ] Start a Monitor in Claude Code — should run without prompt