### PR TITLE
feat(karakeep): AI-tagged bookmark service on rpi5 (idle-sleep, tailnet-only)

### DIFF
--- a/rpi5/configuration.nix
+++ b/rpi5/configuration.nix
@@ -145,6 +145,7 @@ in
     ./immich.nix
     ./sure.nix
     ./paperless.nix
+    ./karakeep.nix
     ./nextcloud.nix
     ./sumeria-mitm.nix
     ./hydroxide.nix

--- a/rpi5/karakeep.nix
+++ b/rpi5/karakeep.nix
@@ -1,0 +1,98 @@
+# rpi5/karakeep.nix
+#
+# Karakeep (ex-Hoarder) — AI-tagged bookmark / read-later app. Native nixpkgs
+# 25.11 `services.karakeep` module: builds for aarch64, stores everything in
+# SQLite under /var/lib/karakeep (no Postgres setup), and auto-manages its own
+# Meilisearch instance for full-text search.
+#
+# AI auto-tagging/summaries run through tiny-llm-gate → beast Ollama (local,
+# zero external cost). No agenix secret: karakeep-init generates MEILI_MASTER_KEY
+# + NEXTAUTH_SECRET into /var/lib/karakeep/settings.env on first boot.
+#
+# Memory-constrained RPi5: the stack (web + workers + Meilisearch) sleeps after
+# 10 min idle via the socket-activation pattern (rpi5/lib/socket-activate.nix,
+# same as paperless), returning to ~0 RAM at rest.
+#
+# Local headless Chromium (screenshots + full-page archival) is DISABLED: nixpkgs
+# has no cached aarch64 build at our pinned rev, so browser.enable = true would
+# compile Chromium from source on the Pi (multi-hour, OOM-thrash risk). Karakeep
+# keeps link crawling, readable-text extraction, favicons, AI tagging/summaries,
+# embeddings and full-text search without it. To restore screenshots later,
+# offload the browser to beast (x86_64, cached) and set BROWSER_WEB_URL.
+{ config, pkgs, lib, tailnetFqdn, tinyLlmGateUrl, ... }:
+let
+  webPort   = 13200;   # karakeep-web PORT (real backend bind)
+  proxyPort = 8210;    # socket-activate proxy listen; Tailscale Serve points here
+  servePort = 3500;    # external tailnet HTTPS port (see services-registry.nix)
+in
+{
+  services.karakeep = {
+    enable = true;
+    browser.enable = false;      # local Chromium disabled — no cached aarch64 build (see header)
+    meilisearch.enable = true;   # auto-enables services.meilisearch (:7700, dev/keyless on localhost)
+
+    extraEnvironment = {
+      PORT = toString webPort;
+
+      # Bind localhost only (Next.js honours HOSTNAME). The only tailnet ingress
+      # is the socket-activate proxy → Tailscale Serve; :13200 must never be
+      # reachable directly on the tailnet interface.
+      HOSTNAME = "127.0.0.1";
+
+      # Public URL behind the Tailscale Serve proxy — used for NextAuth callbacks.
+      NEXTAUTH_URL = "https://${tailnetFqdn}:${toString servePort}";
+
+      DISABLE_NEW_RELEASE_CHECK = "true";
+
+      # ── AI auto-tagging via local inference (tiny-llm-gate → beast Ollama) ──
+      OPENAI_API_KEY  = "ollama";                       # value ignored by tiny-llm-gate
+      OPENAI_BASE_URL = "${tinyLlmGateUrl}/v1";          # http://127.0.0.1:4001/v1
+      INFERENCE_TEXT_MODEL  = "gemma4:e4b";              # text tagging/summaries on beast
+      INFERENCE_IMAGE_MODEL = "gemma4:e4b";              # image tagging (drop if not multimodal)
+      EMBEDDING_TEXT_MODEL  = "text-embedding-3-small";  # → qwen3-embedding:8b via gate alias
+    };
+  };
+
+  # No PrivateUsers override needed: the only karakeep unit that sets
+  # PrivateUsers=true is karakeep-browser, which we don't enable. The remaining
+  # units (karakeep-init/-workers/-web) run as the static `karakeep` user with
+  # PrivateTmp only, which works fine on the RPi5 (no user namespaces).
+
+  # Order the search backend ahead of the consumers so a cold wake doesn't hit
+  # Meilisearch before it is listening. meilisearch is a sleepWith worker below
+  # (wantedBy = karakeep-web), so this only adds ordering — no dependency cycle.
+  systemd.services.karakeep-web.after     = [ "meilisearch.service" ];
+  systemd.services.karakeep-workers.after = [ "meilisearch.service" ];
+
+  # ── Socket-activated idle sleep (rpi5/lib/socket-activate.nix) ─────────────
+  # The proxy on :8210 lazily starts karakeep-web on first connection and stops
+  # the stack after idleSec. socketActivate clears the boot-time
+  # wantedBy=multi-user.target on the realUnit and on each sleepWith worker,
+  # rebinding them to karakeep-web's lifecycle (wantedBy + partOf). karakeep-init
+  # is intentionally left on its default lifecycle: it's a RemainAfterExit oneshot
+  # (~0 RAM) that must run at boot to generate /var/lib/karakeep/settings.env (a
+  # persistent StateDirectory file) before the first wake.
+  #
+  # Behavior change to flag (like paperless): while asleep, a bookmark saved via
+  # the extension/app first wakes the stack; the worker then crawls + AI-tags it
+  # asynchronously.
+  services.socketActivate.karakeep = {
+    enable   = true;
+    realUnit = "karakeep-web.service";
+    listen   = [ "127.0.0.1:${toString proxyPort}" ];
+    backend  = "127.0.0.1:${toString webPort}";
+    idleSec  = 600;
+    readyProbe = {
+      # Next.js cold start binds ~seconds after systemd marks the unit active.
+      # /api/health is karakeep's health endpoint; confirmed against the live
+      # backend during bring-up.
+      url          = "http://127.0.0.1:${toString webPort}/api/health";
+      expectStatus = 200;
+      timeoutSec   = 60;
+    };
+    workers = {
+      "karakeep-workers.service".policy = "sleepWith";
+      "meilisearch.service".policy      = "sleepWith";
+    };
+  };
+}

--- a/rpi5/services-registry.nix
+++ b/rpi5/services-registry.nix
@@ -15,7 +15,7 @@
 { }:
 {
   entries = [
-    # Apps: Nextcloud → AFFiNE → Sure → Immich → Open WebUI → Paperless → Home Assistant
+    # Apps: Nextcloud → AFFiNE → Sure → Immich → Open WebUI → Paperless → Karakeep → Home Assistant
     { port = 8085;  backend = "http://127.0.0.1:8091";  name = "Nextcloud";      icon = "nextcloud.svg";      category = "Apps"; description = "Files + Contacts + Calendar (DAV)";
       widget = {
         type = "nextcloud";
@@ -77,6 +77,8 @@
           { field = "inbox"; label = "Inbox"; format = "number"; }
         ];
       }; }
+    # Socket-activated (idle-sleep) — noSiteMonitor so the homepage ping doesn't re-arm the idle timer.
+    { port = 3500;  backend = "http://127.0.0.1:8210";  name = "Karakeep";       icon = "karakeep.svg";       category = "Apps"; description = "Bookmarks + read-later (AI-tagged)"; noSiteMonitor = true; }
     { port = 8123;  backend = "http://127.0.0.1:8123";  name = "Home Assistant"; icon = "home-assistant.svg"; category = "Apps"; description = "Home automation";
       widget = {
         type = "homeassistant";


### PR DESCRIPTION
## What

Adds **Karakeep** (ex-Hoarder) — an AI-tagged bookmark / read-later app — to the rpi5 stack, wired the house way.

- New module `rpi5/karakeep.nix`, import in `configuration.nix`, and a `services-registry.nix` tile.
- Native nixpkgs 25.11 `services.karakeep` (SQLite + auto-managed Meilisearch). `karakeep` + `meilisearch` are cached for aarch64; no source builds.
- **No agenix secret**: `karakeep-init` self-generates `MEILI_MASTER_KEY` + `NEXTAUTH_SECRET` into `/var/lib/karakeep/settings.env`.

## Design decisions

- **Idle-sleep** via the existing `services.socketActivate` (paperless pattern): web + workers + Meilisearch sleep after 10 min idle → ~0 RAM at rest, wake on first hit. `karakeep-init` stays as the boot-time `settings.env` generator.
- **AI auto-tagging/summaries/embeddings** via `tiny-llm-gate → beast Ollama` (`gemma4:e4b`; `text-embedding-3-small` → `qwen3-embedding:8b`). Zero external cost.
- **`HOSTNAME=127.0.0.1`** so the web tier binds localhost only — the sole tailnet ingress is the proxy → Tailscale Serve `:3500`.
- **Local headless Chromium DISABLED** (`browser.enable = false`): nixpkgs has no cached aarch64 Chromium at our pinned rev, so enabling it would compile Chromium from source on the Pi (OOM-thrash risk). Crawl + AI tagging + text extraction + full-text search all work without it. Screenshots/archival can be restored later by offloading the browser to beast (x86_64) and setting `BROWSER_WEB_URL`.

Ports: tailnet `3500` → proxy `8210` → web `13200`; meilisearch `7700`.

## Verification (live on rpi5)

- ✅ Rebuild switched to the new generation; `karakeep-init` + `karakeep-proxy.socket` started, `settings.env` generated (both keys present).
- ✅ Idle at boot: web/workers/meilisearch inactive, `karakeep-proxy.socket` listening on `127.0.0.1:8210`. `karakeep-browser` correctly absent.
- ✅ Wake via proxy: `curl :8210/` → 307; proxy pulled up web + workers + meilisearch.
- ✅ `readyProbe`: `/api/health` → 200 `{"status":"ok"}`.
- ✅ Web bound to `127.0.0.1:13200` (not `0.0.0.0`).
- ✅ Full external path: `https://rpi5.gate-mintaka.ts.net:3500/api/health` → 200.
- ✅ Homepage tile rendered.
- ✅ AI path: tiny-llm-gate chat (`gemma4:e4b`) + embeddings (`text-embedding-3-small`) both respond.
- ✅ Idle-sleep wiring: `karakeep-web` has `StopWhenUnneeded=yes`, `WantedBy=` empty.

## Follow-ups (out of scope)

- Sign up (first account becomes admin), then set `DISABLE_SIGNUPS=true`.
- Homepage stats widget (bookmark count) — needs an API token created after first login.
- Optional: offload the browser to beast to restore screenshots/archival.

## Note (unrelated)

During verification, `open-webui.service` was found crashlooping (`exit 126`, venv entrypoint `Permission denied`) — this **pre-dates this change** (first failure 13:29, before the rebuild at 14:01) and is unrelated to Karakeep. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)