### PR TITLE
feat(agents): wire RTK (Rust Token Killer) into all coding agents

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -949,9 +949,27 @@
         "nixpkgs-unstable": "nixpkgs-unstable",
         "picoclaw-src": "picoclaw-src",
         "ragenix": "ragenix",
+        "rtk-src": "rtk-src",
         "sure-nix": "sure-nix",
         "tiny-llm-gate": "tiny-llm-gate",
         "zen-browser": "zen-browser"
+      }
+    },
+    "rtk-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1781280365,
+        "narHash": "sha256-8nLJ5PVefXmoXQyw6HERfCP06C+l4I+7XLwKFNVNpew=",
+        "owner": "rtk-ai",
+        "repo": "rtk",
+        "rev": "8a7dd7e5570d7744d4b6508479a3674fe8c49286",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rtk-ai",
+        "ref": "v0.42.4",
+        "repo": "rtk",
+        "type": "github"
       }
     },
     "rust-overlay": {

--- a/flake.nix
+++ b/flake.nix
@@ -81,6 +81,17 @@
       flake = false;
     };
 
+    # RTK — Rust Token Killer (rtk-ai/rtk). Source-only input (`flake = false`);
+    # pkgs/rtk.nix builds it with rustPlatform.buildRustPackage and it's exposed
+    # as `pkgs.rtk` via outputs.overlays.rtk. Bumping is a 2-step edit:
+    #   1. change the tag in the URL below (e.g. v0.42.4 → v0.43.0)
+    #   2. bump `version` in pkgs/rtk.nix to match
+    # then `sudo nix flake lock --update-input rtk-src` + rebuild.
+    rtk-src = {
+      url = "github:rtk-ai/rtk/v0.42.4";
+      flake = false;
+    };
+
     # tiny-llm-gate: memory-conscious replacement for LiteLLM.
     # Pinned to a tag; bump the ref to roll forward.
     tiny-llm-gate = {
@@ -145,8 +156,33 @@
         tinyLlmGateUrl = "http://127.0.0.1:4001";
       };
       telegramChatId = 82389391;
+
+      # RTK package overlay — single source of truth so `pkgs.rtk` resolves
+      # identically in NixOS modules (via rpi5/overlays.nix) and standalone
+      # home-manager configs (the homeConfigurations pkgs below). Builds from
+      # the rtk-src flake input; see pkgs/rtk.nix.
+      rtkOverlay = final: _prev: {
+        rtk = final.callPackage ./pkgs/rtk.nix { rtk-src = inputs.rtk-src; };
+      };
     in
     {
+      # Exposed so rpi5/overlays.nix can pull the same overlay (DRY).
+      overlays.rtk = rtkOverlay;
+
+      # `nix build .#rtk` — standalone build target to isolate rtk's heavy LTO
+      # compile from a full rebuild (build it alone first on the rpi5).
+      packages = nixpkgs.lib.genAttrs [ "aarch64-linux" "x86_64-linux" "aarch64-darwin" ] (
+        system:
+        {
+          rtk =
+            (import nixpkgs {
+              inherit system;
+              config.allowUnfree = true;
+              overlays = [ rtkOverlay ];
+            }).rtk;
+        }
+      );
+
       nixosConfigurations.${nixconfig} = nixpkgs.lib.nixosSystem rec {
         system = "x86_64-linux";
         specialArgs = {
@@ -228,6 +264,7 @@
           pkgs = import nixpkgs {
             system = "x86_64-linux";
             config.allowUnfree = true;
+            overlays = [ rtkOverlay ];
           };
           extraSpecialArgs = {
             inherit
@@ -268,6 +305,7 @@
           pkgs = import nixpkgs {
             system = "aarch64-linux";
             config.allowUnfree = true;
+            overlays = [ rtkOverlay ];
           };
           extraSpecialArgs = {
             inherit
@@ -294,6 +332,7 @@
           pkgs = import nixpkgs {
             system = "aarch64-darwin";
             config.allowUnfree = true;
+            overlays = [ rtkOverlay ];
           };
           extraSpecialArgs = {
             inherit

--- a/home/default.nix
+++ b/home/default.nix
@@ -16,6 +16,7 @@
     ./wakatime.nix
     ./editors.nix
     ./pi-coding-agent
+    ./rtk
   ];
 
   fonts.fontconfig.enable = true;

--- a/home/dotfiles/claude-settings.json
+++ b/home/dotfiles/claude-settings.json
@@ -21,6 +21,18 @@
     "deny": []
   },
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "rtk hook claude",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "Notification": [
       {
         "matcher": "",

--- a/home/rtk/codex-AGENTS.md
+++ b/home/rtk/codex-AGENTS.md
@@ -1,0 +1,32 @@
+# RTK - Rust Token Killer (Codex CLI)
+
+**Usage**: Token-optimized CLI proxy for shell commands.
+
+## Rule
+
+Always prefix shell commands with `rtk`.
+
+Examples:
+
+```bash
+rtk git status
+rtk cargo test
+rtk npm run build
+rtk pytest -q
+```
+
+## Meta Commands
+
+```bash
+rtk gain            # Token savings analytics
+rtk gain --history  # Recent command savings history
+rtk proxy <cmd>     # Run raw command without filtering
+```
+
+## Verification
+
+```bash
+rtk --version
+rtk gain
+which rtk
+```

--- a/home/rtk/default.nix
+++ b/home/rtk/default.nix
@@ -1,0 +1,26 @@
+# RTK (Rust Token Killer) — shared home-manager wiring.
+#
+# Puts `rtk` on the user shell PATH and wires the two user-facing agents that
+# read config from $HOME:
+#   - Pi    : transparent rewriting via a `tool_call` extension (delegates to
+#             `rtk rewrite`). Mirrors home/pi-coding-agent/extensions/*.ts.
+#   - Codex : instruction-tier only (Codex has no command-interception hook) —
+#             a global ~/.codex/AGENTS.md telling the model to prefix shell
+#             commands with `rtk`.
+#
+# Claude Code's hook is wired separately in home/dotfiles/claude-settings.json
+# (a PreToolUse Bash hook → `rtk hook claude`), and picoclaw/cyrus are wired in
+# their own NixOS modules. They all rely on `rtk` being on PATH, which this
+# module's home.packages entry provides for the interactive user.
+#
+# `pkgs.rtk` is supplied by the rtk overlay (flake.nix outputs.overlays.rtk),
+# applied to every home-manager pkgs set (standalone configs + the rpi5
+# NixOS-integrated generation via rpi5/overlays.nix).
+{ pkgs, ... }:
+{
+  home.packages = [ pkgs.rtk ];
+
+  home.file.".pi/agent/extensions/rtk.ts".source = ./pi-rtk.ts;
+
+  home.file.".codex/AGENTS.md".source = ./codex-AGENTS.md;
+}

--- a/home/rtk/pi-rtk.ts
+++ b/home/rtk/pi-rtk.ts
@@ -1,0 +1,80 @@
+// RTK Pi extension — rewrites bash commands to use rtk for token savings.
+// Requires: rtk >= 0.23.0 in PATH.
+//
+// This is a thin delegating extension: all rewrite logic lives in `rtk rewrite`,
+// which is the single source of truth (src/discover/registry.rs).
+// To add or change rewrite rules, edit the Rust registry — not this file.
+//
+// Exit code contract for `rtk rewrite`:
+//   0 + stdout  Rewrite found → mutate command
+//   1           No RTK equivalent → pass through unchanged
+//   3 + stdout  Rewrite (advisory) → mutate command
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent"
+import { isToolCallEventType } from "@earendil-works/pi-coding-agent"
+
+const REWRITE_TIMEOUT_MS = 2_000
+const MIN_SUPPORTED_RTK_MINOR = 23
+
+// Parse "X.Y.Z" semver, return [major, minor, patch] or null.
+function parseSemver(raw: string): [number, number, number] | null {
+  const m = raw.trim().match(/(\d+)\.(\d+)\.(\d+)/)
+  if (!m) return null
+  return [parseInt(m[1], 10), parseInt(m[2], 10), parseInt(m[3], 10)]
+}
+
+// Calls `rtk rewrite`; returns the rewritten command or null (pass through).
+async function rewriteCommand(
+  pi: ExtensionAPI,
+  cmd: string,
+  signal?: AbortSignal
+): Promise<string | null> {
+  const result = await pi.exec("rtk", ["rewrite", cmd], {
+    timeout: REWRITE_TIMEOUT_MS,
+    signal,
+  })
+  if (result.killed) return null
+  if (result.code !== 0 && result.code !== 3) return null
+  return result.stdout.trim() || null
+}
+
+export default async function (pi: ExtensionAPI) {
+  // Probe rtk version at load time; disables extension if missing or too old.
+  const ver = await pi.exec("rtk", ["--version"], { timeout: REWRITE_TIMEOUT_MS })
+  if (ver.code !== 0) {
+    console.warn("[rtk] rtk binary not found in PATH — extension disabled")
+    return
+  }
+
+  // Warn and bail if rtk predates 0.23.0 (when `rtk rewrite` was introduced).
+  const parsed = parseSemver(ver.stdout.replace(/^rtk\s+/, ""))
+  if (parsed) {
+    const [major, minor] = parsed
+    if (major === 0 && minor < MIN_SUPPORTED_RTK_MINOR) {
+      console.warn(`[rtk] rtk ${ver.stdout.trim()} is too old (need >= 0.23.0) — extension disabled`)
+      return
+    }
+  }
+
+  pi.on("tool_call", async (event, ctx) => {
+    try {
+      if (!isToolCallEventType("bash", event)) return
+
+      const cmd = event.input.command
+      if (typeof cmd !== "string" || cmd.trim() === "") return
+
+      if (cmd.startsWith("rtk ")) return
+      if (process.env.RTK_DISABLED === "1") return
+
+      // Delegate to RTK.
+      const rewritten = await rewriteCommand(pi, cmd, ctx.signal)
+      if (rewritten && rewritten !== cmd) {
+        event.input.command = rewritten
+      }
+    } catch (err) {
+      // Fail open: never block execution on an unexpected error.
+      console.warn("[rtk] unexpected error in tool_call handler; passing through command", err)
+      return
+    }
+  })
+}

--- a/pkgs/rtk.nix
+++ b/pkgs/rtk.nix
@@ -1,0 +1,48 @@
+# RTK — Rust Token Killer (rtk-ai/rtk). A CLI proxy that rewrites verbose dev
+# commands (`git status` → `rtk git status`, …) so an LLM sees 60–90% fewer
+# tokens of command output.
+#
+# Built from source via the `rtk-src` flake input (flake.nix, `flake = false`),
+# NOT a prebuilt release binary — keeps the build in-tree and reproducible like
+# the repo's other source inputs (picoclaw-src, cyrus-src, gogcli-src).
+#
+# Build notes (verified against v0.42.4):
+#   - Pure-Rust crates.io deps; Cargo.lock has no git sources, so
+#     `cargoLock.lockFile` alone suffices (no outputHashes/vendorHash).
+#   - `rusqlite { features = ["bundled"] }` compiles SQLite's C via the `cc`
+#     crate — stdenv's compiler covers it; no system sqlite, no bindgen/libclang.
+#   - `ureq` uses rustls → no OpenSSL.
+#   - rtk's release profile is `lto = true, codegen-units = 1` → a heavy compile.
+#     On the rpi5 build with `--max-jobs 1 -j1` (won't hit a binary cache).
+{
+  lib,
+  rustPlatform,
+  rtk-src,
+}:
+rustPlatform.buildRustPackage {
+  pname = "rtk";
+  version = "0.42.4"; # keep in sync with the rtk-src tag in flake.nix
+
+  src = rtk-src;
+
+  cargoLock.lockFile = "${rtk-src}/Cargo.lock";
+
+  # Upstream's tests carry fixtures and shell out to real dev tools (git, cargo,
+  # …) not present in the Nix sandbox; smoke-test the built binary instead.
+  doCheck = false;
+
+  doInstallCheck = true;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    $out/bin/rtk --version
+    runHook postInstallCheck
+  '';
+
+  meta = {
+    description = "Rust Token Killer — CLI proxy that compresses dev-command output for LLMs";
+    homepage = "https://github.com/rtk-ai/rtk";
+    license = lib.licenses.asl20;
+    mainProgram = "rtk";
+    platforms = lib.platforms.unix;
+  };
+}

--- a/rpi5/cyrus.nix
+++ b/rpi5/cyrus.nix
@@ -393,6 +393,11 @@ in
         # (no fatal) but skipping them disables write-isolation.
         pkgs.socat
         pkgs.bubblewrap
+        # RTK (Rust Token Killer): the spawned Claude runs `rtk hook claude` as
+        # its PreToolUse Bash hook (installed by cyrus-rtk-hook.service), and the
+        # rewritten `rtk …` commands execute in the agent's shell — both need
+        # rtk on PATH (inherited by the SDK-spawned claude child).
+        pkgs.rtk
       ];
       serviceConfig = {
         Type = "simple";
@@ -423,6 +428,42 @@ in
         # via SIOCGIFCONF, but AF_NETLINK is the modern path libuv prefers.
         RestrictAddressFamilies = [ "AF_INET" "AF_INET6" "AF_UNIX" "AF_NETLINK" ];
       };
+    };
+
+    # ── RTK Claude hook install ────────────────────────────────────────────
+    # The Claude Agent SDK spawns `claude` with HOME=/var/lib/cyrus, so it reads
+    # the user settings at /var/lib/cyrus/.claude/settings.json. Merge in the
+    # same PreToolUse → `rtk hook claude` entry used by the interactive Claude
+    # config (home/dotfiles/claude-settings.json) so cyrus's agent shell-outs get
+    # token-compressed too. Idempotent: the jq merge replaces .hooks.PreToolUse.
+    # NOTE (verify live): whether the SDK honours file-based hooks is unconfirmed
+    # — if a session shows no rewriting, fall back to a CLAUDE.md instruction.
+    systemd.services.cyrus-rtk-hook = {
+      description = "Install the RTK PreToolUse hook into cyrus's Claude settings";
+      wantedBy = [ "multi-user.target" ];
+      before = [ "cyrus.service" ];
+      path = [ pkgs.jq pkgs.coreutils ];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        User = cfg.user;
+        Group = cfg.user;
+      };
+      script = ''
+        set -e
+        SETTINGS_DIR=/var/lib/cyrus/.claude
+        SETTINGS="$SETTINGS_DIR/settings.json"
+        mkdir -p "$SETTINGS_DIR"
+        hook='{"PreToolUse":[{"matcher":"Bash","hooks":[{"type":"command","command":"${pkgs.rtk}/bin/rtk hook claude","timeout":10}]}]}'
+        if [ -f "$SETTINGS" ]; then
+          tmp=$(mktemp)
+          jq --argjson h "$hook" '.hooks = ((.hooks // {}) * $h)' "$SETTINGS" > "$tmp"
+          mv "$tmp" "$SETTINGS"
+        else
+          echo "{}" | jq --argjson h "$hook" '.hooks = $h' > "$SETTINGS"
+        fi
+        echo "Installed RTK PreToolUse hook into $SETTINGS"
+      '';
     };
 
     # ── Default model sync ─────────────────────────────────────────────────

--- a/rpi5/overlays.nix
+++ b/rpi5/overlays.nix
@@ -1,5 +1,5 @@
 # NixOS module: nixpkgs overlays for the RPi5 system.
-{ inputs, ... }:
+{ inputs, outputs, ... }:
 {
   nixpkgs.overlays = [
     # uv 0.9.26 from release-25.11 fails to build on aarch64-linux; use nixpkgs-unstable
@@ -72,5 +72,11 @@
         doInstallCheck = false;
       });
     })
+
+    # RTK (Rust Token Killer) — exposes `pkgs.rtk`, built from the rtk-src flake
+    # input. Defined once in flake.nix (outputs.overlays.rtk) and reused here so
+    # NixOS modules (picoclaw, cyrus) and the NixOS-integrated home-manager
+    # generation resolve the same package as the standalone HM configs.
+    outputs.overlays.rtk
   ];
 }

--- a/rpi5/picoclaw/picoclaw.nix
+++ b/rpi5/picoclaw/picoclaw.nix
@@ -207,6 +207,23 @@ let
       port = 18789;
       log_level = "info";
     };
+
+    # RTK (Rust Token Killer) transparent rewriting via a `before_tool` process
+    # hook (JSON-RPC over stdio — pkg/agent/hook_process.go). The hook rewrites
+    # the `exec` tool's `command` to its `rtk`-prefixed equivalent so picoclaw's
+    # LLM sees 60–90% fewer tokens of command output. `intercept` takes hook
+    # STAGE names (not tool names); `RTK_BIN` is an absolute store path so the
+    # hook finds rtk regardless of PATH. Fails open (see rtk-hook.py).
+    hooks = {
+      enabled = true;
+      processes.rtk = {
+        enabled = true;
+        transport = "stdio";
+        command = [ "${pkgs.python3}/bin/python3" "${./rtk-hook.py}" ];
+        intercept = [ "before_tool" ];
+        env.RTK_BIN = "${pkgs.rtk}/bin/rtk";
+      };
+    };
   };
 
   configFile = pkgs.writeText "picoclaw-config.json" (builtins.toJSON picoclawConfig);
@@ -259,7 +276,10 @@ let
     # Match what an interactive nsimon shell sees: home-manager's own bin
     # (gog/goplaces/summarize live *only* there, not in ~/.nix-profile/bin),
     # user profile, system profile, wrappers, and nix-profile.
-    export PATH="$HOME/.local/state/nix/profiles/home-manager/home-path/bin:/etc/profiles/per-user/nsimon/bin:/run/current-system/sw/bin:/run/wrappers/bin:$HOME/.nix-profile/bin:$PATH"
+    # ${pkgs.rtk}/bin is prepended explicitly so the rtk-prefixed commands the
+    # before_tool hook rewrites to (e.g. `rtk git status`) resolve even before
+    # home-manager activation has linked rtk into home-path/bin.
+    export PATH="${pkgs.rtk}/bin:$HOME/.local/state/nix/profiles/home-manager/home-path/bin:/etc/profiles/per-user/nsimon/bin:/run/current-system/sw/bin:/run/wrappers/bin:$HOME/.nix-profile/bin:$PATH"
     exec ${picoclaw}/bin/picoclaw gateway
   '';
 in

--- a/rpi5/picoclaw/rtk-hook.py
+++ b/rpi5/picoclaw/rtk-hook.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""picoclaw `before_tool` process hook: transparently rewrite `exec` commands
+via `rtk rewrite` so the agent's shell output is token-compressed.
+
+Protocol (picoclaw pkg/agent/hook_process.go): JSON-RPC 2.0 over stdio,
+newline-delimited. picoclaw is the CLIENT; this process is the SERVER. picoclaw
+sends requests; we reply `{"jsonrpc":"2.0","id":<id>,"result":<result>}`:
+
+  hook.hello        params = {name, version, modes}                  → any result obj
+  hook.before_tool  params = ToolCallHookRequest {tool, arguments, …} → {action, …}
+
+For a rewrite we return {"action":"modify","call": <full request with
+arguments.command replaced>} — picoclaw uses `call` verbatim as the new tool
+invocation. Anything else returns {"action":"continue"}. We fail OPEN on any
+error (never block or alter a command we couldn't rewrite cleanly).
+
+`rtk` is located via the RTK_BIN env var (set to an absolute store path by the
+hook config in picoclaw.nix), falling back to PATH lookup.
+"""
+import json
+import os
+import subprocess
+import sys
+
+RTK_BIN = os.environ.get("RTK_BIN", "rtk")
+REWRITE_TIMEOUT_S = 2.0
+
+
+def rewrite(cmd):
+    """Return the rewritten command, or None to pass through.
+
+    `rtk rewrite` exit codes: 0 + stdout = rewrite, 3 + stdout = advisory
+    rewrite, 1 = no equivalent. Returns None (pass through) on any error.
+    """
+    try:
+        p = subprocess.run(
+            [RTK_BIN, "rewrite", cmd],
+            capture_output=True,
+            text=True,
+            timeout=REWRITE_TIMEOUT_S,
+        )
+    except Exception:
+        return None
+    if p.returncode not in (0, 3):
+        return None
+    out = p.stdout.strip()
+    return out or None
+
+
+def handle_before_tool(params):
+    if not isinstance(params, dict) or params.get("tool") != "exec":
+        return {"action": "continue"}
+    args = params.get("arguments")
+    if not isinstance(args, dict):
+        return {"action": "continue"}
+    cmd = args.get("command")
+    if not isinstance(cmd, str) or cmd.strip() == "" or cmd.startswith("rtk "):
+        return {"action": "continue"}
+    new_cmd = rewrite(cmd)
+    if not new_cmd or new_cmd == cmd:
+        return {"action": "continue"}
+    # Echo the full request back with only arguments.command mutated.
+    new_args = dict(args)
+    new_args["command"] = new_cmd
+    new_params = dict(params)
+    new_params["arguments"] = new_args
+    return {"action": "modify", "call": new_params}
+
+
+def handle(method, params):
+    if method == "hook.before_tool":
+        return handle_before_tool(params)
+    if method == "hook.hello":
+        return {"name": "rtk", "version": 1}
+    # We only subscribe to before_tool; answer other interceptor stages safely
+    # if ever invoked.
+    return {"action": "continue"}
+
+
+def main():
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except Exception:
+            continue
+        msg_id = msg.get("id")
+        # Notifications (no id) expect no response.
+        if msg_id is None:
+            continue
+        try:
+            result = handle(msg.get("method"), msg.get("params"))
+        except Exception:
+            result = {"action": "continue"}
+        sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": msg_id, "result": result}) + "\n")
+        sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Wires [RTK](https://github.com/rtk-ai/rtk) (`rtk-ai/rtk` v0.42.4) — the "Rust Token Killer" CLI proxy that rewrites verbose dev commands (`git status` → `rtk git status`, …) so the LLM sees 60–90% fewer tokens of command output — into **all five coding agents** (Claude Code, Pi, Codex, picoclaw, Cyrus) across all hosts.

## Packaging — flake source build (not prebuilt binaries)

RTK isn't in nixpkgs and ships no `flake.nix`. Per the repo's `flake = false` source-input convention (picoclaw-src, cyrus-src, gogcli-src), `rtk-src` is pinned to tag `v0.42.4` and built from source with `rustPlatform.buildRustPackage` (`pkgs/rtk.nix`), exposed as `pkgs.rtk` via a single overlay (`outputs.overlays.rtk`) reused by `rpi5/overlays.nix` (NixOS) and the standalone home-manager pkgs sets. `nix build .#rtk` added as a build target.

- nixpkgs 25.11 `rustc` 1.91.1 meets rtk's `rust-version = 1.91` (stable toolchain).
- `Cargo.lock` has 0 git deps → `cargoLock.lockFile` alone (no vendorHash/outputHashes).
- `rusqlite[bundled]` compiles SQLite via `cc` (no system lib); `ureq` uses rustls (no OpenSSL).

## Per-agent integration

| Agent | Mechanism |
|-------|-----------|
| **Claude Code** | `PreToolUse` Bash hook → `rtk hook claude` (`home/dotfiles/claude-settings.json`) |
| **Pi** | `~/.pi/agent/extensions/rtk.ts` (`tool_call` → `rtk rewrite`) |
| **Codex** | `~/.codex/AGENTS.md` awareness (instruction-tier; no command hook) |
| **picoclaw** | `before_tool` process hook (JSON-RPC/stdio, `rtk-hook.py`) rewriting the `exec` tool's command; `pkgs.rtk` on service PATH |
| **Cyrus** | `pkgs.rtk` on service PATH + `cyrus-rtk-hook` oneshot installing the same PreToolUse hook into `/var/lib/cyrus/.claude/settings.json` |

## Verified live on rpi5

- `nix build .#rtk` → `rtk 0.42.4`; `rtk rewrite 'git status'` → `rtk git status`.
- `nixos-rebuild switch` activated cleanly; `cyrus`, `cyrus-rtk-hook` (installed the hook), and `picoclaw` (runtime `config.json` carries the `before_tool` rtk hook) all active — picoclaw started with no crashloop.
- HM files in place: `~/.codex/AGENTS.md`, `~/.pi/agent/extensions/rtk.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)