### PR TITLE
chore(sure): bump sure-nix lock to Sure v0.7.1-hotfix.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1001,11 +1001,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778527217,
-        "narHash": "sha256-wovk3aueRHD7RpEFePp5buptiv/lHQqxxp3ceLrmr8Q=",
+        "lastModified": 1781537232,
+        "narHash": "sha256-lodLhsVYfktvZhDgWqKUmuPRWJWQvHHj4xN/7wa/ULw=",
         "owner": "nSimonFR",
         "repo": "sure-nix",
-        "rev": "cb22c1aad082d5d659c3b233e9c5d8b8bfe2db27",
+        "rev": "ef921bdab007d10d690c2ab0312dced807aedb86",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Bumps the `sure-nix` flake input lock so the rpi5 builds **Sure v0.7.1-hotfix.1** (was 0.6.9), following the merge of [nSimonFR/sure-nix#11](https://github.com/nSimonFR/sure-nix/pull/11).

**Verified live on rpi5**: Sure 0.7.1-hotfix.1 builds from source, boots via `sure-proxy.socket`, and serves (HTTP 302 on `:3333`). Already deployed to the running generation.

dawarich is intentionally **not** included — nixpkgs unstable only has 1.7.11 (upstream latest is 1.8.1), pending a decision on whether the point bump is worth it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)