### PR TITLE
chore(karakeep,open-webui): signups off + homepage widget; remove crash-looping Open WebUI

### DIFF
--- a/rpi5/configuration.nix
+++ b/rpi5/configuration.nix
@@ -158,7 +158,7 @@ in
     ./tiny-llm-gate.nix
     ./aperture-sync.nix
     ./claude-remote-control.nix
-    ./open-webui.nix
+    # ./open-webui.nix # DISABLED 2026-06-15: venv crash-loop (ExecStart exit 126, "venv/bin/open-webui: Permission denied") since the disk incident. Re-enable + rebuild the venv (rm -rf /var/lib/open-webui/venv) to restore.
     ./homepage.nix
     ./backups.nix
     ./storj-backup.nix

--- a/rpi5/homepage-stats.py
+++ b/rpi5/homepage-stats.py
@@ -10,6 +10,7 @@ Endpoints:
   /openwebui — Open WebUI (models, chats, messages)
   /paperless — Paperless (documents, inbox)
   /immich    — Immich (photos, videos, storage)
+  /karakeep  — Karakeep (bookmarks, favorites, archived, tags) — direct read-only SQLite
 
 Refresh cadence: 86400s (daily). Sure is socket-activated (rpi5/sure.nix)
 with a 600s idle timer; the daily poll wakes it briefly (~10 min), then
@@ -34,12 +35,17 @@ CURL = os.environ.get("CURL_BIN", "curl")
 SQLITE = os.environ.get("SQLITE_BIN", "sqlite3")
 ENV_FILE = "/run/homepage-dashboard/env"
 OWUI_DB = "/var/lib/private/open-webui/data/webui.db"
+# Read karakeep's SQLite directly (read-only) instead of its HTTP API: no API
+# key needed, and — crucially — it never wakes karakeep, so the socket-activated
+# idle-sleep (rpi5/karakeep.nix) is preserved. -readonly avoids creating
+# root-owned -wal/-shm files that would break karakeep (runs as the karakeep user).
+KARAKEEP_DB = "/var/lib/karakeep/db.db"
 PAPERLESS_TOKEN_FILE = "/run/agenix/paperless-api-token"
 STATE_DIR = os.environ.get("STATE_DIRECTORY", "/var/lib/homepage-stats")
 STATE_FILE = os.path.join(STATE_DIR, "stats.json")
 REFRESH_INTERVAL = 86400  # seconds — see module docstring
 
-stats = {"sure": {}, "openwebui": {}, "paperless": {}, "immich": {}}
+stats = {"sure": {}, "openwebui": {}, "paperless": {}, "immich": {}, "karakeep": {}}
 stats_lock = threading.Lock()
 
 
@@ -168,6 +174,25 @@ def fetch_paperless():
             stats["paperless"]["error"] = str(e)
 
 
+def fetch_karakeep():
+    # Read-only direct SQLite query — no API key, never wakes karakeep.
+    def count(sql):
+        return int(subprocess.check_output(
+            [SQLITE, "-readonly", KARAKEEP_DB, sql]
+        ).decode().strip() or 0)
+    try:
+        with stats_lock:
+            stats["karakeep"] = {
+                "bookmarks": count("SELECT COUNT(*) FROM bookmarks;"),
+                "favorites": count("SELECT COUNT(*) FROM bookmarks WHERE favourited = 1;"),
+                "archived":  count("SELECT COUNT(*) FROM bookmarks WHERE archived = 1;"),
+                "tags":      count("SELECT COUNT(*) FROM bookmarkTags;"),
+            }
+    except Exception as e:
+        with stats_lock:
+            stats["karakeep"]["error"] = str(e)
+
+
 def refresh(initial_fetched_at):
     last_fetched = initial_fetched_at
     while True:
@@ -181,6 +206,7 @@ def refresh(initial_fetched_at):
             fetch_openwebui()
             fetch_paperless()
             fetch_immich()
+            fetch_karakeep()
             last_fetched = time.time()
             save_cache(last_fetched)
         except Exception as e:
@@ -200,6 +226,8 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 data = dict(stats["paperless"])
             elif self.path == "/immich":
                 data = dict(stats["immich"])
+            elif self.path == "/karakeep":
+                data = dict(stats["karakeep"])
             else:
                 data = {k: dict(v) for k, v in stats.items()}
         self.send_response(200)

--- a/rpi5/karakeep.nix
+++ b/rpi5/karakeep.nix
@@ -44,6 +44,12 @@ in
 
       DISABLE_NEW_RELEASE_CHECK = "true";
 
+      # Admin account is set up, so lock down public registration: no new
+      # signups and the signup button is hidden in the UI. Existing users
+      # (us) can still sign in. NOT DISABLE_PASSWORD_AUTH — that would disable
+      # the local login form entirely, and no OAuth provider is configured.
+      DISABLE_SIGNUPS = "true";
+
       # ── AI auto-tagging via local inference (tiny-llm-gate → beast Ollama) ──
       OPENAI_API_KEY  = "ollama";                       # value ignored by tiny-llm-gate
       OPENAI_BASE_URL = "${tinyLlmGateUrl}/v1";          # http://127.0.0.1:4001/v1

--- a/rpi5/services-registry.nix
+++ b/rpi5/services-registry.nix
@@ -58,16 +58,17 @@
           { field = "usage";  label = "Storage"; format = "bytes"; }
         ];
       }; }
-    { port = 8181;  backend = "http://127.0.0.1:8181";  name = "Open WebUI";     icon = "open-webui.svg";     category = "Apps"; description = "LLM chat interface"; noSiteMonitor = true;
-      widget = {
-        type = "customapi";
-        url = "http://127.0.0.1:8087/openwebui";
-        mappings = [
-          { field = "models"; label = "Models"; format = "number"; }
-          { field = "chats"; label = "Chats"; format = "number"; }
-          { field = "messages"; label = "Messages"; format = "number"; }
-        ];
-      }; }
+    # Open WebUI DISABLED 2026-06-15 (venv crash-loop, exit 126); re-enable alongside ./open-webui.nix in configuration.nix.
+    # { port = 8181;  backend = "http://127.0.0.1:8181";  name = "Open WebUI";     icon = "open-webui.svg";     category = "Apps"; description = "LLM chat interface"; noSiteMonitor = true;
+    #   widget = {
+    #     type = "customapi";
+    #     url = "http://127.0.0.1:8087/openwebui";
+    #     mappings = [
+    #       { field = "models"; label = "Models"; format = "number"; }
+    #       { field = "chats"; label = "Chats"; format = "number"; }
+    #       { field = "messages"; label = "Messages"; format = "number"; }
+    #     ];
+    #   }; }
     { port = 3400;  backend = "http://127.0.0.1:8200";  name = "Paperless";      icon = "paperless-ngx.svg";  category = "Apps"; description = "Document archive (bills, invoices)"; noSiteMonitor = true;
       widget = {
         type = "customapi";

--- a/rpi5/services-registry.nix
+++ b/rpi5/services-registry.nix
@@ -79,7 +79,20 @@
         ];
       }; }
     # Socket-activated (idle-sleep) — noSiteMonitor so the homepage ping doesn't re-arm the idle timer.
-    { port = 3500;  backend = "http://127.0.0.1:8210";  name = "Karakeep";       icon = "karakeep.svg";       category = "Apps"; description = "Bookmarks + read-later (AI-tagged)"; noSiteMonitor = true; }
+    { port = 3500;  backend = "http://127.0.0.1:8210";  name = "Karakeep";       icon = "karakeep.svg";       category = "Apps"; description = "Bookmarks + read-later (AI-tagged)"; noSiteMonitor = true;
+      # Stats via homepage-stats.py reading karakeep's SQLite read-only (no API
+      # key, never wakes karakeep → preserves idle-sleep). NOT the native
+      # `type = "karakeep"` widget, which would poll the API and keep it awake.
+      widget = {
+        type = "customapi";
+        url = "http://127.0.0.1:8087/karakeep";
+        mappings = [
+          { field = "bookmarks"; label = "Bookmarks"; format = "number"; }
+          { field = "favorites"; label = "Favorites"; format = "number"; }
+          { field = "archived";  label = "Archived";  format = "number"; }
+          { field = "tags";      label = "Tags";      format = "number"; }
+        ];
+      }; }
     { port = 8123;  backend = "http://127.0.0.1:8123";  name = "Home Assistant"; icon = "home-assistant.svg"; category = "Apps"; description = "Home automation";
       widget = {
         type = "homeassistant";


### PR DESCRIPTION
Three rpi5 service-config changes (all deployed live):

**1. Karakeep — disable public signups** (`rpi5/karakeep.nix`)
`DISABLE_SIGNUPS=true` — admin account exists; block new registrations + hide the signup button. Existing users still sign in. (Not `DISABLE_PASSWORD_AUTH` — no OAuth, would lock us out.)

**2. Karakeep — homepage widget** (`rpi5/homepage-stats.py`, `rpi5/services-registry.nix`)
Adds a Karakeep widget (bookmarks / favorites / archived / tags). Reads karakeep's `db.db` via `sqlite3 -readonly` in `homepage-stats.py` (customapi → `:8087/karakeep`), like the OWUI widget. **No API key**, and it **never wakes karakeep** — preserves the socket-activated idle-sleep. (The native `type=karakeep` widget would poll the API and keep karakeep awake.) Verified: `{"bookmarks":0,...}`.

**3. Open WebUI — comment out service + entry** (`rpi5/configuration.nix`, `rpi5/services-registry.nix`)
Was crash-looping (exit 126, `venv/bin/open-webui: Permission denied`, ~every 3 s) since the disk incident. Commented out the import + registry entry to stop the loop; unit is now gone. Re-enable by uncommenting both + rebuilding the venv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)