### PR TITLE
fix(atuin): supervise sync daemon via launchd on macOS

### DIFF
--- a/home/atuin.nix
+++ b/home/atuin.nix
@@ -10,6 +10,40 @@ let
   # unstablePkgs.atuin). If the daemon and the client diverge, the client talks
   # to a stale daemon binary over the socket and sync silently lapses.
   atuinBin = "${unstablePkgs.atuin}/bin/atuin";
+  dataDir = "${config.home.homeDirectory}/.local/share/atuin";
+
+  # launchd's KeepAlive can only relaunch a daemon it started — it cannot adopt
+  # one it didn't. If an orphaned atuin daemon (e.g. one left over from before
+  # this agent existed, or surviving an atuin version bump) already holds the
+  # pidfile lock + socket, `atuin daemon start` exits on the busy lock (18.16.1
+  # takes the `force = false` path and never probes/stops the holder), so launchd
+  # just crash-loops while clients keep talking to the stale daemon. Adopt first:
+  # stop whatever currently holds the pidfile, clear the stale socket, then exec
+  # the daemon so launchd tracks the new process. On a normal (re)start the
+  # recorded pid is already dead, so nothing is killed.
+  atuinDaemonStart = pkgs.writeShellScript "atuin-daemon-start" ''
+    set -u
+    export PATH="${pkgs.coreutils}/bin:$PATH"
+    pidfile="${dataDir}/atuin-daemon.pid"
+    if [ -r "$pidfile" ]; then
+      oldpid="$(head -n1 "$pidfile" 2>/dev/null || true)"
+      case "$oldpid" in
+        "" | *[!0-9]*) ;; # absent or not a bare pid — ignore
+        *)
+          if kill -0 "$oldpid" 2>/dev/null; then
+            kill "$oldpid" 2>/dev/null || true
+            n=0
+            while kill -0 "$oldpid" 2>/dev/null && [ "$n" -lt 10 ]; do
+              sleep 0.5
+              n=$((n + 1))
+            done
+          fi
+          ;;
+      esac
+    fi
+    rm -f "${dataDir}/atuin.sock"
+    exec ${atuinBin} daemon start
+  '';
 in
 {
   # Keep atuin's sync daemon (`daemon.enabled = true` in dotfiles/atuin.toml)
@@ -46,18 +80,25 @@ in
     };
   };
 
+  # launchd opens StandardOutPath/StandardErrorPath before exec'ing the program
+  # and will NOT create a missing parent directory, so on a fresh profile (or
+  # after the atuin data dir is wiped) bootstrap would fail with an I/O error
+  # and the daemon would never start. Guarantee the dir exists before the
+  # launchd agents are (re)bootstrapped.
+  home.activation = lib.mkIf pkgs.stdenv.isDarwin {
+    atuinDataDir = lib.hm.dag.entryBefore [ "setupLaunchAgents" ] ''
+      run mkdir -p "${dataDir}"
+    '';
+  };
+
   launchd.agents.atuin-daemon = lib.mkIf pkgs.stdenv.isDarwin {
     enable = true;
     config = {
-      ProgramArguments = [
-        atuinBin
-        "daemon"
-        "start"
-      ];
+      ProgramArguments = [ "${atuinDaemonStart}" ];
       RunAtLoad = true;
       KeepAlive = true;
-      StandardOutPath = "${config.home.homeDirectory}/.local/share/atuin/daemon.out.log";
-      StandardErrorPath = "${config.home.homeDirectory}/.local/share/atuin/daemon.err.log";
+      StandardOutPath = "${dataDir}/daemon.out.log";
+      StandardErrorPath = "${dataDir}/daemon.err.log";
     };
   };
 }

--- a/home/atuin.nix
+++ b/home/atuin.nix
@@ -1,24 +1,63 @@
-{ unstablePkgs, ... }:
 {
-  # Keep atuin's sync daemon alive headlessly so background hooks (e.g. the
-  # Claude Code Bash PostToolUse hook) and history written outside an
-  # interactive shell session still sync to api.atuin.sh. The shell init
-  # `atuin init zsh` only spawns a daemon when zsh starts, so on a
-  # mostly-headless box the socket dies and sync silently lapses.
-  systemd.user.services.atuin-daemon = {
-    Unit = {
-      Description = "Atuin sync daemon";
-      After = [ "network-online.target" ];
-      Wants = [ "network-online.target" ];
+  lib,
+  pkgs,
+  config,
+  unstablePkgs,
+  ...
+}:
+let
+  # Keep this in lockstep with the atuin CLI on PATH (home/packages.nix uses
+  # unstablePkgs.atuin). If the daemon and the client diverge, the client talks
+  # to a stale daemon binary over the socket and sync silently lapses.
+  atuinBin = "${unstablePkgs.atuin}/bin/atuin";
+in
+{
+  # Keep atuin's sync daemon (`daemon.enabled = true` in dotfiles/atuin.toml)
+  # alive headlessly so background hooks (e.g. the Claude Code Bash PostToolUse
+  # hook in home/scripts/claude-bash-history.sh) and history written outside an
+  # interactive shell still sync to api.atuin.sh. `atuin init zsh` does NOT
+  # start the daemon on its own, so without a real process supervisor the daemon
+  # dies — or, worse, lingers on a stale binary after an atuin version bump —
+  # and sync quietly stops. Each platform gets its native supervisor; the
+  # supervisor restarts the daemon on the new binary whenever atuinBin changes,
+  # which closes the version-skew gap.
+  #
+  # 2026-06-15: the macOS box had been running an orphaned 18.15.2 daemon since
+  # April because only the Linux (systemd) path existed — darwin had no
+  # equivalent and home-manager silently ignored the systemd block here. Hence
+  # the launchd agent below.
+
+  systemd.user.services = lib.mkIf pkgs.stdenv.isLinux {
+    atuin-daemon = {
+      Unit = {
+        Description = "Atuin sync daemon";
+        After = [ "network-online.target" ];
+        Wants = [ "network-online.target" ];
+      };
+      Install = {
+        WantedBy = [ "default.target" ];
+      };
+      Service = {
+        Type = "simple";
+        ExecStart = "${atuinBin} daemon start";
+        Restart = "on-failure";
+        RestartSec = "5s";
+      };
     };
-    Install = {
-      WantedBy = [ "default.target" ];
-    };
-    Service = {
-      Type = "simple";
-      ExecStart = "${unstablePkgs.atuin}/bin/atuin daemon start";
-      Restart = "on-failure";
-      RestartSec = "5s";
+  };
+
+  launchd.agents.atuin-daemon = lib.mkIf pkgs.stdenv.isDarwin {
+    enable = true;
+    config = {
+      ProgramArguments = [
+        atuinBin
+        "daemon"
+        "start"
+      ];
+      RunAtLoad = true;
+      KeepAlive = true;
+      StandardOutPath = "${config.home.homeDirectory}/.local/share/atuin/daemon.out.log";
+      StandardErrorPath = "${config.home.homeDirectory}/.local/share/atuin/daemon.err.log";
     };
   };
 }


### PR DESCRIPTION
## Problem

On **macOS (nBookPro)**, atuin background sync had silently lapsed for ~6.5 weeks. Root cause: the daemon keepalive in `home/atuin.nix` was a `systemd.user.services` unit — **Linux-only**. home-manager silently ignores it on darwin, so the Mac's daemon had no supervisor. An orphaned **atuin 18.15.2** daemon (started Apr 29) kept running and holding the socket after home-manager bumped atuin to **18.16.1**; its background sync never recovered until a manual `atuin sync`.

The same wedged daemon also silently breaks the Claude Code Bash-history hook (`home/scripts/claude-bash-history.sh`), which shells out to `atuin`.

`rpi5` and `BeAsT` were unaffected — systemd kept their daemons current through the version bump.

## Fix

- Gate the `systemd.user.services.atuin-daemon` unit to Linux (`lib.mkIf pkgs.stdenv.isLinux`).
- Add `launchd.agents.atuin-daemon` for darwin (`RunAtLoad` + `KeepAlive`), pinned to the same `unstablePkgs.atuin` as the CLI on PATH so client and daemon never diverge.
- The plist embeds the atuin store path, so home-manager's `setupLaunchAgents` restarts the daemon on every atuin bump — **closing the version-skew gap permanently**.

## Verification

- Evaluated all three home configs: nBookPro renders the launchd agent (no systemd); `rpi5` + `BeAsT` keep systemd (no launchd) — Linux behavior unchanged.
- Applied on nBookPro via `home-manager switch`: launchd agent `org.nix-community.home.atuin-daemon` now owns the daemon — running 18.16.1, `Healthy: true`, actively syncing, PID stable (no crash loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)