### PR TITLE
fix(mcp): point Trusk MCP gateways at work-tailnet nodes

### DIFF
--- a/home/mcp.nix
+++ b/home/mcp.nix
@@ -24,13 +24,21 @@ let
   mcpServers = {
     # Public — no secrets
     Linear              = { type = "sse"; url = "https://mcp.linear.app/sse"; };
-    "trusk-k8s"         = { type = "http"; url = "http://gateway-mcp.dev-tools.svc.cluster.local:8080/mcp"; };
-    "trusk-argocd"      = { type = "http"; url = "http://gateway-mcp.dev-tools.svc.cluster.local:3000/mcp"; };
-    "trusk-grafana"     = { type = "http"; url = "http://gateway-mcp.dev-tools.svc.cluster.local:8000/mcp"; };
-    "trusk-datadog"     = { type = "http"; url = "http://gateway-mcp.dev-tools.svc.cluster.local:9000/mcp"; };
-    "trusk-github"      = { type = "http"; url = "http://supergateway-mcp.dev-tools.svc.cluster.local:7001/mcp"; };
-    "trusk-context7"    = { type = "http"; url = "http://supergateway-mcp.dev-tools.svc.cluster.local:7002/mcp"; };
-    "trusk-steampipe"   = { type = "http"; url = "http://steampipe-mcp-server.dev-tools.svc.cluster.local:9194/mcp"; };
+    # Work-tailnet MCP gateways. Migrated off the in-cluster
+    # *.dev-tools.svc.cluster.local services — those are no longer routable
+    # from the laptop (the cluster pod subnet isn't advertised over the work
+    # tunnel and cluster CoreDNS is unreachable), so the old URLs time out.
+    # These tailnet nodes resolve over the work Tailscale tunnel (utun) and
+    # serve valid TLS via `tailscale serve`. Verified 2026-06-15.
+    # Transport note: the gateway/gitnexus nodes speak streamable-HTTP at
+    # /mcp; context7 + steampipe (supergateway-based) speak SSE at /sse.
+    "trusk-k8s"         = { type = "http"; url = "https://ai-gateway-mcp-k8s.tail271d7a.ts.net/mcp"; };
+    "trusk-argocd"      = { type = "http"; url = "https://ai-gateway-mcp-argocd.tail271d7a.ts.net/mcp"; };
+    "trusk-grafana"     = { type = "http"; url = "https://ai-gateway-mcp-grafana.tail271d7a.ts.net/mcp"; };
+    "trusk-datadog"     = { type = "http"; url = "https://ai-gateway-mcp-datadog.tail271d7a.ts.net/mcp"; };
+    "trusk-github"      = { type = "http"; url = "https://ai-gitnexus-mcp.tail271d7a.ts.net/mcp"; };
+    "trusk-context7"    = { type = "sse";  url = "https://ai-supergateway-context7.tail271d7a.ts.net/sse"; };
+    "trusk-steampipe"   = { type = "sse";  url = "https://ai-steampipe-mcp.tail271d7a.ts.net/sse"; };
     firecrawl           = { type = "http"; url = "https://mcp.firecrawl.dev/fc-c6a062b4ff1849d3991eeb116c0632a4/v2/mcp"; };
 
     # Private — secrets loaded at runtime via wrapper scripts

--- a/macos/scripts/tun2proxy-work.sh
+++ b/macos/scripts/tun2proxy-work.sh
@@ -11,18 +11,6 @@ TUN2PROXY="/opt/homebrew/opt/tun2proxy/bin/tun2proxy-bin"
 GW="10.0.0.1"
 MARKER="# WORK-TAILSCALE-MANAGED"
 
-# Cluster-internal MCP hostnames that Claude Code can't resolve via
-# /etc/resolver/cluster.local (its HTTP client bypasses macOS's split-horizon
-# resolver). We dig each via the cluster CoreDNS reached over tun2proxy and
-# pin the answer into /etc/hosts under the same MARKER. See home/mcp.nix for
-# the URLs that reference these names.
-CLUSTER_DNS="192.168.64.10"
-CLUSTER_HOSTS=(
-  "gateway-mcp.dev-tools.svc.cluster.local"
-  "supergateway-mcp.dev-tools.svc.cluster.local"
-  "steampipe-mcp-server.dev-tools.svc.cluster.local"
-)
-
 # Wait for work tailscaled
 for _ in $(seq 1 30); do $TS --socket=$SOCK status >/dev/null 2>&1 && break; sleep 2; done
 
@@ -50,14 +38,6 @@ for p in (data.get('Peer') or {}).values():
     DNS)    echo "$value $extra $MARKER" ;;
   esac
 done > /tmp/hosts.work
-
-# Resolve cluster.local MCP hostnames via cluster CoreDNS and append.
-# Claude Code's MCP HTTP transport doesn't honor /etc/resolver/cluster.local,
-# so /etc/hosts is the only path that works for it.
-for h in "${CLUSTER_HOSTS[@]}"; do
-  ip=$(/usr/bin/dig +short +time=2 +tries=1 "@$CLUSTER_DNS" "$h" 2>/dev/null | /usr/bin/head -1)
-  [ -n "$ip" ] && echo "$ip $h $MARKER" >> /tmp/hosts.work
-done
 
 # Update /etc/hosts atomically
 grep -v "$MARKER" /etc/hosts > /tmp/hosts.clean 2>/dev/null || true


### PR DESCRIPTION
## Problem

All seven Trusk MCP servers in `home/mcp.nix` pointed at in-cluster
`*.dev-tools.svc.cluster.local` URLs. Those are no longer routable from the
laptop — the cluster pod subnet isn't advertised over the work tunnel and
cluster CoreDNS (`192.168.64.10`) is unreachable — so every connection timed
out and the servers never loaded in a Claude Code / Cursor session.

## Fix

The gateways now run as dedicated **work-tailnet nodes** served over HTTPS via
`tailscale serve`. Repointed all seven (verified live with an MCP `initialize`
handshake):

| server | new endpoint | transport |
|---|---|---|
| trusk-k8s / argocd / grafana / datadog | `ai-gateway-mcp-{k8s,argocd,grafana,datadog}.tail271d7a.ts.net/mcp` | http |
| trusk-github | `ai-gitnexus-mcp.tail271d7a.ts.net/mcp` | http |
| trusk-context7 | `ai-supergateway-context7.tail271d7a.ts.net/sse` | **sse** |
| trusk-steampipe | `ai-steampipe-mcp.tail271d7a.ts.net/sse` | **sse** |

`context7` and `steampipe` are supergateway-based and speak SSE at `/sse`
(not streamable-HTTP), so their transport changes from `http` to `sse`.

Also drops the now-dead `cluster.local` `/etc/hosts` pinning from
`macos/scripts/tun2proxy-work.sh` — nothing references those hostnames anymore
now that the URLs resolve over normal tailnet DNS.

## Verification

After `home-manager switch`, `claude mcp list` against the regenerated
`--mcp-config`:

```
trusk-argocd    (HTTP) - ✓ Connected
trusk-context7  (SSE)  - ✓ Connected
trusk-datadog   (HTTP) - ✓ Connected
trusk-github    (HTTP) - ✓ Connected
trusk-grafana   (HTTP) - ✓ Connected
trusk-k8s       (HTTP) - ✓ Connected
trusk-steampipe (SSE)  - ✓ Connected
```

## Apply

`home-manager switch --flake path:.#nsimon@nBookPro` (already run locally;
regenerates the wrapped `claude --mcp-config`). No `darwin-rebuild` needed for
the `home/` change; the `tun2proxy-work.sh` cleanup applies on the next normal
`darwin-rebuild switch`.

## Out of band (not in this PR)

- Pruned 7 orphaned dead-cluster MCP entries from runtime `~/.claude.json`
  (`k8s/argocd/grafana/github-mcp/context7/steampipe/searxncrawl`).
- Removed stale `# CLUSTER-MCP-MANAGED` lines from `/etc/hosts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)