### PR TITLE
fix(linear-skill): self-heal $LINEAR_KEY from agenix when shell lacks it

### DIFF
--- a/shared/skills/linear/SKILL.md
+++ b/shared/skills/linear/SKILL.md
@@ -20,7 +20,19 @@ Two Linear workspaces are available:
 
 **Default to `$LINEAR_KEY` (nsimon workspace) for all queries unless the user explicitly asks about Trusk.**
 
-Keys are format `lin_api_…`. All API calls go to `https://api.linear.app/graphql` with header `Authorization: $LINEAR_KEY` (no `Bearer` prefix — Linear personal keys are sent raw). If `LINEAR_KEY` is unset, stop and tell the user.
+Keys are format `lin_api_…`. All API calls go to `https://api.linear.app/graphql` with header `Authorization: $LINEAR_KEY` (no `Bearer` prefix — Linear personal keys are sent raw).
+
+**If `$LINEAR_KEY` is unset, resolve it before giving up.** Interactive nsimon shells source it from `secrets.zsh`, but systemd-spawned agents (e.g. `claude-remote-control`) run with a minimal env and their Bash subshells don't. On rpi5 the same keys live in the system agenix file `/run/agenix/picoclaw-env` (KEY=VAL, owner `nsimon`, always present — no dependency on picoclaw running). Run this once at the start of a Linear task:
+
+```bash
+# Self-heal LINEAR_KEY / LINEAR_KEY_TRUSK if the shell didn't export them.
+if [ -z "$LINEAR_KEY" ] && [ -r /run/agenix/picoclaw-env ]; then
+  export LINEAR_KEY=$(sed -n 's/^LINEAR_KEY=//p' /run/agenix/picoclaw-env)
+  export LINEAR_KEY_TRUSK=$(sed -n 's/^LINEAR_KEY_TRUSK=//p' /run/agenix/picoclaw-env)
+fi
+```
+
+Only if `$LINEAR_KEY` is still empty after this, stop and tell the user.
 
 ```bash
 # Sanity check — should print your name
@@ -51,6 +63,9 @@ All examples use the default nsimon workspace (`$LINEAR_KEY`). For trusk, swap `
 
 ```bash
 linear_q() {
+  # Self-heal LINEAR_KEY for systemd-spawned agents (see "How auth works here").
+  [ -z "$LINEAR_KEY" ] && [ -r /run/agenix/picoclaw-env ] && \
+    export LINEAR_KEY=$(sed -n 's/^LINEAR_KEY=//p' /run/agenix/picoclaw-env)
   curl -sS -X POST https://api.linear.app/graphql \
     -H "Authorization: $LINEAR_KEY" \
     -H "Content-Type: application/json" \


### PR DESCRIPTION
## Problem

The shared Linear skill (`shared/skills/linear/SKILL.md`) assumed every nsimon shell inherits `$LINEAR_KEY` from `secrets.zsh`. That holds for interactive login shells, but **systemd-spawned agents** (e.g. `claude-remote-control`) run with a minimal `Environment=` and their Bash-tool subshells re-init from a shell snapshot that doesn't source `secrets.zsh`. Result: any Linear task from a remote-control session dead-ended at "`LINEAR_KEY` unset, stop and tell the user", even though the key is decrypted on disk.

## Fix

Add a guarded fallback that resolves `LINEAR_KEY` / `LINEAR_KEY_TRUSK` from the **system** agenix file `/run/agenix/picoclaw-env` (KEY=VAL format, owner `nsimon`, always present on rpi5 — no dependency on the picoclaw process running). Folded into:

- the **How auth works here** section (explicit snippet + explanation), and
- the **`linear_q`** helper (automatic, every invocation self-heals).

Guarded on `[ -z "$LINEAR_KEY" ] && [ -r /run/agenix/picoclaw-env ]`, so it's a no-op on machines without that file (macos/interactive shells already have the key).

## Verification

Reproduced the empty-env case in a fresh Bash subshell, ran the fallback, and authenticated successfully:

```
resolved LINEAR_KEY length: 48
Nicolas SIMON
```

Takes effect for deployed agents after the next `home-manager switch` (the skill is symlinked from the nix store).

🤖 Generated with [Claude Code](https://claude.com/claude-code)