### PR TITLE
feat(claude): add claude-direct alias for clean-room direct CC sessions

### DIFF
--- a/home/dotfiles/zsh/aliases.zsh
+++ b/home/dotfiles/zsh/aliases.zsh
@@ -32,6 +32,10 @@ alias claude-local='ANTHROPIC_BASE_URL=http://localhost:8000 ANTHROPIC_API_KEY=o
 # claude-beast: Claude Code → Beast gemma4:e4b (RTX 3080 Ti) via litellm proxy (port 4001)
 alias claude-beast='ANTHROPIC_BASE_URL=http://localhost:4001 ANTHROPIC_API_KEY=litellm-local ANTHROPIC_MODEL=openai/gemma4:e4b command claude --dangerously-skip-permissions --remote-control'
 
+# claude-direct: CC → api.anthropic.com (no Aperture). Uses --settings, not a shell
+# ANTHROPIC_BASE_URL prefix (which CC ignores — ~/.claude/settings.json env wins).
+alias claude-direct='command claude --dangerously-skip-permissions --remote-control --settings "{\"env\":{\"ANTHROPIC_BASE_URL\":\"https://api.anthropic.com\"}}"'
+
 # pi: pi-coding-agent via Aperture → tiny-llm-gate → codex-proxy / beast Ollama.
 # All routes go through https://ai.gate-mintaka.ts.net for observability.
 # Pass any tlg model id as $1 to override the default, e.g.


### PR DESCRIPTION
## What
`claude-direct` alias: runs Claude Code against `api.anthropic.com` (no Aperture) by overriding `ANTHROPIC_BASE_URL` via `--settings`. Keeps your normal `~/.claude` (skills/hooks/creds) — no separate config dir.

## Why (from debugging "claude.ai connectors don't show in /mcp")
- A **shell-set `ANTHROPIC_BASE_URL` is ignored** by CC — the `env` block in `~/.claude/settings.json` wins. (So `claude-local`/`claude-beast` likely hit Aperture, not localhost — worth a follow-up.) The reliable override is `--settings`.
- **The connectors don't need this.** CC fetches the connector list from `api.anthropic.com/v1/mcp_servers` directly (bypassing Aperture), so an empty `/mcp` list is a **stale first-party Keychain token**, fixed by `/login` in the normal session — not a base-URL/gateway problem.

## Test
`claude-direct` → runs against api.anthropic.com with the normal config; verified it authenticates (returns a response) after a fresh `/login`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)