### PR TITLE
feat(codex): end proxy↔CLI OAuth rotation war (tokenless CLI)

### DIFF
--- a/rpi5/home.nix
+++ b/rpi5/home.nix
@@ -22,6 +22,15 @@
   home = {
     username = username;
     homeDirectory = "/home/${username}";
+
+    # The codex CLI authenticates to the local codex-proxy (:4040) with this API
+    # key (~/.codex/config.toml: env_key = "CODEX_PROXY_KEY") instead of a ChatGPT
+    # login, so ~/.codex/auth.json holds no `tokens` block to rotate the proxy's
+    # shared OAuth lineage out from under it (which used to silently 401 the proxy
+    # and take picoclaw down). Non-secret: the loopback proxy accepts any inbound
+    # key. ⚠️ Never run `codex login` — it re-adds tokens and restarts the war.
+    # See known_issue_codex_proxy_oauth_rotation.
+    sessionVariables.CODEX_PROXY_KEY = "codex-proxy-local";
   };
 
 }


### PR DESCRIPTION
## Problem

picoclaw and `codex` were 401ing while *looking* healthy. codex-proxy (`:4040`) and the `codex` CLI shared **one** ChatGPT OAuth account. OpenAI rotates refresh tokens single-use, so every interactive `codex` run refreshed `~/.codex/auth.json` and **invalidated the proxy's** token → proxy `401 "Not authenticated"` on every completion → picoclaw (`gpt-5.5` → tiny-llm-gate → proxy) silently down for ~2 days while the process, `/auth/status` and `/v1/models` all stayed green.

## Fix — make the CLI tokenless

With **no `tokens` block** in `auth.json`, the CLI holds no OpenAI refresh token, so it cannot rotate the shared lineage. The proxy becomes the sole owner — the war is structurally impossible, so no monitor/watchdog is needed.

Runtime dotfiles (not in Nix — `config.toml` because codex writes its own `[projects]` trust entries; `auth.json` because codex owns it):
- `~/.codex/auth.json`: dropped the `tokens` block.
- `~/.codex/config.toml`: `model=gpt-5.5` (gpt-5.2 is rejected for ChatGPT-account auth); provider authenticates via `env_key=CODEX_PROXY_KEY`.

In this PR (1 file, 9 lines):
- **`rpi5/home.nix`** — sets `CODEX_PROXY_KEY` alongside the other home `sessionVariables` (non-secret; the loopback proxy doesn't validate inbound keys).

## Verified (live)

- ✅ `codex exec` returns `ok` with tokenless `auth.json` + `env_key` + `gpt-5.5`; codex does not recreate a `tokens` block.
- ✅ A clean shell sourcing only the home-manager session-vars has `CODEX_PROXY_KEY` and `codex` works (`home-manager switch` already applied).
- ✅ picoclaw's path (`:4001` gpt-5.5) and the proxy (`:4040`) both return completions; proxy log clean.

## Notes

- The fix and the env var are **already live** (dotfiles + `home-manager switch`).
- ⚠️ Merge before the next `home-manager`/`nixos` rebuild **from main**, else `CODEX_PROXY_KEY` is dropped and `codex` errors `Missing environment variable` (clear failure; picoclaw unaffected; no war). Rollback backups: `~/.codex/{config.toml,auth.json}.bak.*`.
- ⚠️ Never run `codex login` (ChatGPT flow) — it rewrites auth.json with a fresh `tokens` block and restarts the war.

🤖 Generated with [Claude Code](https://claude.com/claude-code)