### PR TITLE
chore(flake): roll-forward bump; restore Nextcloud to 33.0.5

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -137,11 +137,11 @@
     "cyrus-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1781105021,
-        "narHash": "sha256-tNr1Q/eBXJ6Dv0+OMA1XhsHWs/aqd/gRG0Cbfv2QuCs=",
+        "lastModified": 1782156464,
+        "narHash": "sha256-2VFKrRmrbrzGjumhQZHfvvKQ7pX2mE97YFE+KIHmheU=",
         "owner": "cyrusagents",
         "repo": "cyrus",
-        "rev": "85ab88fb9c9140911b901af3a41140fe059308df",
+        "rev": "8cf7de6ad3e5cd0e5d0adaa99ae892e5ad568e3c",
         "type": "github"
       },
       "original": {
@@ -434,7 +434,10 @@
     },
     "git-hooks": {
       "inputs": {
-        "flake-compat": "flake-compat_3",
+        "flake-compat": [
+          "nix-gaming",
+          "flake-compat"
+        ],
         "gitignore": "gitignore",
         "nixpkgs": [
           "nix-gaming",
@@ -442,11 +445,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1778507602,
-        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
+        "lastModified": 1781733627,
+        "narHash": "sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco+3u0=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
+        "rev": "3bbec39bc90eadfa031e6f3b77272f3f60803e39",
         "type": "github"
       },
       "original": {
@@ -566,11 +569,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1781157766,
-        "narHash": "sha256-InNpK3w0V6odvKtC5wCXZZiluiWAD6uLElz3to+sQA0=",
+        "lastModified": 1782198869,
+        "narHash": "sha256-7HsiKhCUxnsldqGQRF8sDV/9t6N15Jb3PBZYR/9RJFA=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "0b3a6a2dc43576f223d036ba70a29a2f0de99061",
+        "rev": "238eb2728ede4b4e5ac3ec276bc81732b8df0b69",
         "type": "github"
       },
       "original": {
@@ -597,6 +600,7 @@
       "original": {
         "owner": "AlexsJones",
         "repo": "llmfit",
+        "rev": "2365836fc55b6b5f96622b4fd40cfeaa1e7a5e2f",
         "type": "github"
       }
     },
@@ -635,11 +639,11 @@
         "treefmt-nix": "treefmt-nix_4"
       },
       "locked": {
-        "lastModified": 1780941735,
-        "narHash": "sha256-QoCAnucKgVpyMsobqdduT1XwyYVX0mq/u8ziHgct5hg=",
+        "lastModified": 1782155169,
+        "narHash": "sha256-G27O3FHzFhFZWd+G9DQFK1wGkYdpPyOCt/Hcq2OZ1O4=",
         "owner": "LovingMelody",
         "repo": "nix-citizen",
-        "rev": "fcdf02b087e1af382e3f00eda9cb3807bc8f57aa",
+        "rev": "dc7fd3444c9326121ad7b1b88ff5cede2198c94f",
         "type": "github"
       },
       "original": {
@@ -665,16 +669,17 @@
     },
     "nix-gaming": {
       "inputs": {
+        "flake-compat": "flake-compat_3",
         "flake-parts": "flake-parts_3",
         "git-hooks": "git-hooks",
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1781064751,
-        "narHash": "sha256-KLhF1KXXGNFXQBLEZWoeMSbxHimMTYZfEilMs6azeY4=",
+        "lastModified": 1782187221,
+        "narHash": "sha256-yx7LbLu5TC+P0GzXaaC4jbqsKvriI8zwqrFvy9HsWnY=",
         "owner": "fufexan",
         "repo": "nix-gaming",
-        "rev": "7149d77f66536aaf02c845a9c2a08eb7e57a04c3",
+        "rev": "5a04f6faefec29fcbdab73c18be6f3cc0842e2d8",
         "type": "github"
       },
       "original": {
@@ -779,11 +784,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1780930886,
-        "narHash": "sha256-rppURzHviaQN131F+nLiLdGfcb0uCd9gGP0E5+iw9MI=",
+        "lastModified": 1781607440,
+        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8c3cede7ddc26bd659d2d383b5610efbd2c7a16e",
+        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
         "type": "github"
       },
       "original": {
@@ -843,11 +848,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1780747962,
-        "narHash": "sha256-IX7G1dlKrOqPOImfbo7ADDfV5yU1+j+MRChI3TL4tAA=",
+        "lastModified": 1781607440,
+        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cbb5cf358f50aa6acc9efd6113b7bcfbc352cd73",
+        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
         "type": "github"
       },
       "original": {
@@ -875,11 +880,11 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1781174944,
-        "narHash": "sha256-aXCJoCT8aftXgbPqYVbWs2+vbCdu5GP9bHVH6ontxRA=",
+        "lastModified": 1782201750,
+        "narHash": "sha256-pJQN2M24qA0a3p6KB0C19tWm/AcrEjA8DwQ1NGf2VgA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "188a792917afa8a0f387f18147252726edd8a957",
+        "rev": "f2d6dbfdc1d667f1ede7bd1136fc134e377e0fb9",
         "type": "github"
       },
       "original": {
@@ -1229,11 +1234,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781173532,
-        "narHash": "sha256-MwnZpL82aQO1I15JH525vz6REI/OULEAmXDp6cIcgNg=",
+        "lastModified": 1782144240,
+        "narHash": "sha256-RgCWSv7AJZCwPhCzz+J0lvwp1WBz9ouvCnnlmvu0xfw=",
         "owner": "0xc000022070",
         "repo": "zen-browser-flake",
-        "rev": "f13e82162fae68af7716147207fa5f868f5ca381",
+        "rev": "d1693556428967f8b4eef128feb090421ddcaf15",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -65,8 +65,11 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    # Pinned to the 2026-06-10 rev: newer llmfit pulls sysinfo 0.39.3, which
+    # requires rustc 1.95, but release-25.11 ships rustc 1.91 → build fails.
+    # Unpin (drop the rev to track the branch again) once nixpkgs rustc >= 1.95.
     llmfit = {
-      url = "github:AlexsJones/llmfit";
+      url = "github:AlexsJones/llmfit/2365836fc55b6b5f96622b4fd40cfeaa1e7a5e2f";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 


### PR DESCRIPTION
## Roll-forward flake bump — restores Nextcloud, recovers from the gen-750 downgrade

### Background
A prior automated session ran *"bump all flakes then safe rebuild, then pr"* but ran `nix flake update` in its **worktree**, then ran the actual `nixos-rebuild-safe switch` from `/home/nsimon/nic-os` — which was on the **stale `fix-picoclaw-sure-base-url` branch (Jun 7)**. So **generation 750 was built from an old lock**: root `nixpkgs` = `e60871b` (May 27) → **Nextcloud code `33.0.3.2` < installed data `33.0.5.1`**. Nextcloud refuses the downgrade (it would corrupt data), so `nextcloud-setup`/`nextcloud-update-db`/`nextcloud-cron` failed, `switch-to-configuration` exited `4`, and the system went `degraded` with Nextcloud down. The activation also restarted the remote-control bridge, killing that session mid-switch.

### This PR
A clean roll-forward bump off `main`, of **all flake inputs except `nixos-raspberrypi`**:
- root `nixpkgs`: `188a792` (Jun 11) → `f2d6dbfd` (Jun 23) → **nextcloud33 = `33.0.5`** (≥ installed data, verified via `nix eval`).
- also: `cyrus-src`, `llm-agents`, `nix-citizen`, `nix-gaming`, `nixpkgs-unstable`, `zen-browser` (+ transitive).
- tag-pinned source inputs (`picoclaw-src`, `rtk-src`, `gogcli-src`, `goplaces-src`, `tiny-llm-gate`) unchanged.

**`llmfit` pinned to its 2026-06-10 rev** (in `flake.nix`): the latest rev pulls `sysinfo 0.39.3`, which requires **rustc 1.95**, but release-25.11 ships **rustc 1.91** → build fails (exit 101). Unpin once nixpkgs rustc ≥ 1.95.

**`nixos-raspberrypi` intentionally not bumped** — it carries its own pinned nixpkgs (the kernel), already at the cached gen-749 pin. Bumping it risks an uncached multi-hour kernel build that OOM-resets the Pi, for no benefit to this fix.

### Rollout
Built as the **boot default** (`nixos-rebuild-safe boot`) → **generation 751**, with **no live activation** (so the bridge isn't bounced again). Home-manager is integrated via the NixOS module and `home-manager-nsimon.service` is enabled, so it rebuilds and activates with gen 751.

**Applied on the next reboot.** On boot, gen 751 brings Nextcloud back up — `occ upgrade` `33.0.5.1` → `33.0.5` is a no-op/upgrade, no downgrade. Until then the running system remains gen 750 (Nextcloud still down).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
