### PR TITLE
feat(claude): cap-aware auto-resume for interactive sessions via claude-auto-retry

### DIFF
--- a/home/claude.nix
+++ b/home/claude.nix
@@ -65,8 +65,46 @@ let
         --set GITHUB_TOKEN ""
     '';
   });
+
+  # claude-auto-retry (https://github.com/cheapestinference/claude-auto-retry):
+  # watches an interactive Claude session for a usage-cap message, waits out the
+  # reset window (timezone-aware), and auto-sends `continue` via tmux send-keys.
+  # The published npm package is dependency-free pure ESM, so we just vendor the
+  # tarball and wrap its entrypoints with node — no buildNpmPackage needed.
+  # Exposes two bins: `claude-auto-retry` (status/logs/version CLI) and
+  # `claude-car-launcher` (the wrapper the `claude` shell function calls).
+  # PATH is prefixed with tmux/procps/which so the forked monitor finds them
+  # regardless of the caller's environment.
+  claudeAutoRetry = pkgs.stdenvNoCC.mkDerivation rec {
+    pname = "claude-auto-retry";
+    version = "0.2.2";
+    src = pkgs.fetchurl {
+      url = "https://registry.npmjs.org/claude-auto-retry/-/claude-auto-retry-${version}.tgz";
+      hash = "sha256-HnyMESM6LxzbexWE+vB0b/iFy8ywsaT43BvPRBaMajw=";
+    };
+    nativeBuildInputs = [ pkgs.makeWrapper ];
+    dontConfigure = true;
+    dontBuild = true;
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out/share/claude-auto-retry $out/bin
+      cp -r . $out/share/claude-auto-retry/
+      runtimePath=${lib.makeBinPath [ pkgs.tmux pkgs.procps pkgs.which ]}
+      makeWrapper ${pkgs.nodejs}/bin/node $out/bin/claude-auto-retry \
+        --add-flags $out/share/claude-auto-retry/bin/cli.js \
+        --prefix PATH : "$runtimePath"
+      makeWrapper ${pkgs.nodejs}/bin/node $out/bin/claude-car-launcher \
+        --add-flags $out/share/claude-auto-retry/src/launcher.js \
+        --prefix PATH : "$runtimePath"
+      runHook postInstall
+    '';
+  };
 in
 {
+  # claude-auto-retry CLI (`claude-auto-retry status|logs`) + the
+  # `claude-car-launcher` the `claude` shell function routes through.
+  home.packages = [ claudeAutoRetry ];
+
   programs.claude-code = {
     enable = true;
     package = claudeCodePkg;
@@ -113,6 +151,17 @@ in
       source = pkgs.writeShellScript "claude-rc" ''
         exec "${claudeCodePkg}/bin/claude" remote-control "$@"
       '';
+    };
+
+    # claude-auto-retry config (read at runtime by the monitor). marginSeconds
+    # waits a bit past the parsed reset; fallbackWaitHours bounds the wait when
+    # no reset time is parseable; retryMessage is what's sent via send-keys.
+    ".claude-auto-retry.json".text = builtins.toJSON {
+      maxRetries = 5;
+      pollIntervalSeconds = 5;
+      marginSeconds = 60;
+      fallbackWaitHours = 5;
+      retryMessage = "continue";
     };
 
     # PostToolUse hook: mirror writes under

--- a/home/dotfiles/zsh/aliases.zsh
+++ b/home/dotfiles/zsh/aliases.zsh
@@ -18,8 +18,25 @@ alias vpn-on='tailscale up --exit-node=rpi5 --accept-routes && echo "✅ Exit no
 alias vpn-off='tailscale up --exit-node= --accept-routes && echo "❌ Exit node disabled (direct internet)"'
 alias vpn-status='tailscale status | grep -E "(rpi5|exit node)" || echo "Exit node: disabled"'
 
-# Claude Code: env vars are set by the Nix wrapper (claude.nix)
-alias claude='command claude --dangerously-skip-permissions --remote-control'
+# Claude Code: env vars are set by the Nix wrapper (claude.nix). This is a
+# function (not an alias) so it routes interactive sessions through
+# claude-auto-retry, which waits out a usage-cap window and auto-sends
+# `continue` once it resets. It must be a function because a same-named alias
+# would shadow it. The CLAUDE_AUTO_RETRY_ACTIVE guard mirrors the tool's own
+# wrapper: once inside an auto-retry-managed session, fall through to the raw
+# wrapped binary. Our standard flags are injected in both paths.
+# `claude-car-launcher` comes from the claudeAutoRetry package (home/claude.nix).
+claude() {
+  if [ "$CLAUDE_AUTO_RETRY_ACTIVE" = "1" ]; then
+    command claude --dangerously-skip-permissions --remote-control "$@"
+    return $?
+  fi
+  export CLAUDE_AUTO_RETRY_ACTIVE=1
+  claude-car-launcher --dangerously-skip-permissions --remote-control "$@"
+  local _e=$?
+  unset CLAUDE_AUTO_RETRY_ACTIVE
+  return $_e
+}
 cc()     { command claude --continue "$@"; }
 cr()     { command claude --resume "$@"; }
 


### PR DESCRIPTION
## What

Routes interactive Claude Code sessions (rpi5 + Mac) through [claude-auto-retry](https://github.com/cheapestinference/claude-auto-retry) so a usage-cap hit no longer stalls the session: the tool waits out the reset window (timezone-aware) and auto-sends \`continue\`.

This is **Workstream 1** of the cap-aware auto-resume effort. Cyrus re-dispatch (gleaner) is a separate, in-progress workstream.

## How

- **Packaging** (`home/claude.nix`): the published npm package is dependency-free pure ESM, so it's vendored as a small `fetchurl` + `makeWrapper` derivation (no `buildNpmPackage`). Exposes `claude-auto-retry` (status/logs CLI) and `claude-car-launcher` (what the shell function calls). The forked monitor gets tmux/procps/which on PATH.
- **Shell wiring** (`home/dotfiles/zsh/aliases.zsh`): the `claude` **alias** becomes a **function** — an alias would shadow the tool's function and bypass it. The function routes through `claude-car-launcher`, preserving \`--dangerously-skip-permissions --remote-control\`, with a \`CLAUDE_AUTO_RETRY_ACTIVE\` recursion guard. \`cc\`/\`cr\`/\`claude-local\`/\`claude-beast\`/\`claude-direct\` use \`command claude\` and are unaffected.
- **Config** (`~/.claude-auto-retry.json`): `retryMessage:"continue"`, `marginSeconds:60`, `fallbackWaitHours:5`.

Cross-platform — applies on both rpi5 and the Mac (`home/claude.nix` is shared), so the Mac picks it up on its next `home-manager switch`.

## Why this approach

Claude Code already retries *short* 429s internally; the unmet need is the multi-hour **usage cap**, which a proxy can't hold across. An external pane-watcher that waits + re-sends \`continue\` is the realistic mechanism for interactive sessions, and adopting the mature MIT tool beats rebuilding it.

## Validation

- `home-manager build` + `switch` clean on rpi5.
- Package bins work; `src/` siblings + `type:module` intact.
- Monitor state machine logic test: detect cap → wait → send \`continue\` after reset (foreground-guarded) → reset on clear — **PASS**.
- Real-tmux adapter test (throwaway session): capture-pane + send-keys roundtrip + foreground detection — **PASS**.
- Live: interactive zsh resolves \`claude\` to the function; bins on PATH; config written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)