### PR TITLE
fix(claude): drop unsupported "mcp__*" allow rule

### DIFF
--- a/home/dotfiles/claude-settings.json
+++ b/home/dotfiles/claude-settings.json
@@ -16,7 +16,6 @@
       "NotebookEdit(*)",
       "Task(*)",
       "Monitor(*)",
-      "mcp__*",
       "Monitor",
       "Skill",
       "Agent",
@@ -30,7 +29,6 @@
       "CronCreate",
       "CronList",
       "CronDelete",
-      "mcp__*",
       "mcp__claude_ai_Figma__get_screenshot",
       "mcp__claude_ai_Figma__get_metadata",
       "mcp__claude_ai_Figma__get_variable_defs",
@@ -185,8 +183,8 @@
       }
     ]
   },
-  "model": "opus",
   "effortLevel": "high",
+  "tui": "fullscreen",
   "skipDangerousModePermissionPrompt": true,
   "agentPushNotifEnabled": true,
   "voiceEnabled": true,


### PR DESCRIPTION
Claude Code `/doctor` flagged an invalid permission rule:

> Invalid permission rule "mcp__*" was skipped: Wildcard tool name "mcp__*" is not supported in allow rules.

`permissions.allow` only accepts globs in the tool position after a literal `mcp__<server>__` prefix. The explicit per-server entries (`mcp__firecrawl`, `mcp__trusk-grafana`, `mcp__claude_ai_Figma__*`, …) already cover those servers, so the two `mcp__*` lines were redundant and are removed.

Also rolls in two already-live working-tree edits to the same file:
- unpin the default model (`"model": "opus"` removed)
- set `"tui": "fullscreen"`

The live `~/.claude/settings.json` (home-manager symlink) already reflected these via an impure rebuild; this commit makes them durable. The stale `/doctor` warning clears on the next session restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)