### PR TITLE
feat(notify): central debounced agent→Telegram aggregator (kill spam)

### DIFF
--- a/home/claude.nix
+++ b/home/claude.nix
@@ -42,11 +42,9 @@ let
     value.source = "${sharedSkillsDir}/${name}/SKILL.md";
   }) claudeSlashCommandSkills);
 
-  notifyScript = (import ../shared/telegram-notify.nix { inherit pkgs telegramChatId; }) {
+  notifyScript = (import ../shared/telegram-notify.nix { inherit pkgs; }) {
     name = "claude";
-    header = "🤖 *Claude Code*";
-    stateDir = "/tmp/claude-notify-state";
-    tokenPath = config.age.secrets.telegram-bot-token.path;
+    source = "Claude Code";
   };
   claudeCodePkg = unstablePkgs.claude-code.overrideAttrs (old: {
     nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ pkgs.makeWrapper ];

--- a/home/pi-coding-agent/default.nix
+++ b/home/pi-coding-agent/default.nix
@@ -21,11 +21,9 @@ let
     '';
   };
 
-  notifyScript = (import ../../shared/telegram-notify.nix { inherit pkgs telegramChatId; }) {
+  notifyScript = (import ../../shared/telegram-notify.nix { inherit pkgs; }) {
     name = "pi";
-    header = "🤖 *Pi Coding Agent*";
-    stateDir = "/tmp/pi-notify-state";
-    tokenPath = config.age.secrets.telegram-bot-token.path;
+    source = "Pi Coding Agent";
   };
 in
 {

--- a/rpi5/claude-notify-aggregator.nix
+++ b/rpi5/claude-notify-aggregator.nix
@@ -1,0 +1,41 @@
+# Central debounced Telegram notifier for agent notifications.
+#
+# All agent notification hooks across every machine (Claude Code `Notification`
+# hook + Pi `agent_end` extension, on rpi5/BeAsT/nBookPro) POST to this service
+# over the tailnet. It pools them into one shared stream and sends a single
+# Telegram digest only after a quiet period (or at most every MAX seconds),
+# replacing the old per-machine /tmp coalescing that fired immediately and
+# spammed thousands of messages a day. See ./claude-notify-aggregator.py.
+#
+# Bound to 127.0.0.1:8088; exposed tailnet-wide via Tailscale Serve
+# (Infrastructure entry in services-registry.nix → no homepage tile).
+{
+  pkgs,
+  telegramChatId,
+  ...
+}:
+{
+  systemd.services.claude-notify-aggregator = {
+    description = "Debounced Telegram notifier for Claude/Pi agent notifications (:8088)";
+    wantedBy = [ "multi-user.target" ];
+    after = [ "network-online.target" ];
+    wants = [ "network-online.target" ];
+    serviceConfig = {
+      Type = "simple";
+      Restart = "on-failure";
+      RestartSec = "10s";
+      # Runs as root to read the root-owned /run/agenix/telegram-bot-token,
+      # matching the monitoring.nix alert timers.
+      ExecStart = "${pkgs.python3}/bin/python3 ${./claude-notify-aggregator.py}";
+      NoNewPrivileges = true;
+      ProtectHome = true;
+      Environment = [
+        "NOTIFY_PORT=8088"
+        "NOTIFY_QUIET_SECONDS=300"
+        "NOTIFY_MAX_SECONDS=900"
+        "NOTIFY_CHAT_ID=${builtins.toString telegramChatId}"
+        "NOTIFY_TOKEN_PATH=/run/agenix/telegram-bot-token"
+      ];
+    };
+  };
+}

--- a/rpi5/claude-notify-aggregator.py
+++ b/rpi5/claude-notify-aggregator.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Central debounced Telegram notifier for Claude Code / Pi agent notifications.
+
+Every agent notification hook across every machine — the Claude Code
+`Notification` hook and the Pi `agent_end` extension, on rpi5/BeAsT/nBookPro —
+POSTs `{host, project, message, source}` to /notify here over the tailnet.
+
+Events are pooled into a single shared stream and a digest is sent to Telegram
+only after things go quiet (NOTIFY_QUIET_SECONDS), or, under continuous
+activity, at most once every NOTIFY_MAX_SECONDS (so a never-idle fleet still
+gets a periodic digest instead of being starved). Each new event *resets* the
+quiet timer, so a flurry of sessions refreshing/finishing collapses into one
+message.
+
+This replaces the old per-machine /tmp coalescing (shared/telegram-notify.nix),
+which fired immediately on the first event in a 60s window and could not pool
+across hosts — the source of the thousands-of-messages-a-day spam.
+"""
+import json
+import os
+import socket
+import threading
+import time
+import urllib.parse
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+PORT = int(os.environ.get("NOTIFY_PORT", "8088"))
+QUIET_SECONDS = int(os.environ.get("NOTIFY_QUIET_SECONDS", "300"))
+MAX_SECONDS = int(os.environ.get("NOTIFY_MAX_SECONDS", "900"))
+CHAT_ID = os.environ.get("NOTIFY_CHAT_ID", "")
+TOKEN_PATH = os.environ.get("NOTIFY_TOKEN_PATH", "/run/agenix/telegram-bot-token")
+MAX_LINES = int(os.environ.get("NOTIFY_MAX_LINES", "40"))
+TELEGRAM_LIMIT = 3900
+
+# Short hostname of this box; used to decide whether to prefix a line with the
+# originating host (local events stay terse, remote events are disambiguated).
+SELF_HOST = socket.gethostname().split(".")[0].lower()
+
+_lock = threading.Lock()
+# Insertion-ordered mapping: formatted-line -> occurrence count (dedup with ×N).
+_pending = {}
+_first_ts = 0.0  # when the current batch started accumulating
+_last_ts = 0.0   # most recent event (drives the quiet/debounce window)
+
+
+def _read_token():
+    # Read fresh every flush so OAuth/token rotation is picked up without a restart.
+    try:
+        with open(TOKEN_PATH) as f:
+            return f.read().strip()
+    except OSError:
+        return ""
+
+
+def _format_line(host, project, message):
+    host = (host or "unknown").split(".")[0]
+    label = project or "unknown"
+    if host.lower() != SELF_HOST:
+        label = f"{host}/{label}"
+    return f"📁 {label}: {message or 'waiting for input'}"
+
+
+def add_event(host, project, message):
+    global _first_ts, _last_ts
+    line = _format_line(host, project, message)
+    now = time.time()
+    with _lock:
+        if not _pending:
+            _first_ts = now
+        _pending[line] = _pending.get(line, 0) + 1
+        _last_ts = now
+
+
+def _send(text):
+    token = _read_token()
+    if not token or not CHAT_ID:
+        return
+    data = urllib.parse.urlencode({"chat_id": CHAT_ID, "text": text}).encode()
+    url = f"https://api.telegram.org/bot{token}/sendMessage"
+    try:
+        urllib.request.urlopen(url, data=data, timeout=10).read()
+    except Exception:
+        pass  # best effort — drop on failure rather than retry/spam
+
+
+def _build_text(pending):
+    lines = ["🤖 Claude Code"]
+    items = list(pending.items())
+    for line, count in items[:MAX_LINES]:
+        lines.append(line + (f" ×{count}" if count > 1 else ""))
+    if len(items) > MAX_LINES:
+        lines.append(f"… +{len(items) - MAX_LINES} more")
+    text = "\n".join(lines)
+    if len(text) > TELEGRAM_LIMIT:
+        text = text[:TELEGRAM_LIMIT] + "\n… (truncated)"
+    return text
+
+
+def flusher():
+    while True:
+        time.sleep(5)
+        now = time.time()
+        with _lock:
+            if not _pending:
+                continue
+            quiet = now - _last_ts >= QUIET_SECONDS
+            capped = now - _first_ts >= MAX_SECONDS
+            if not (quiet or capped):
+                continue
+            snapshot = dict(_pending)
+            _pending.clear()
+        _send(_build_text(snapshot))
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *args):
+        pass  # silence per-request stderr logging
+
+    def _respond(self, code=200, body=b"ok"):
+        self.send_response(code)
+        self.send_header("Content-Type", "text/plain")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        self._respond()  # trivial health endpoint
+
+    def do_POST(self):
+        if self.path.rstrip("/") not in ("/notify", ""):
+            self._respond(404, b"not found")
+            return
+        try:
+            length = int(self.headers.get("Content-Length", "0"))
+            payload = json.loads(self.rfile.read(length) or b"{}")
+        except Exception:
+            self._respond(400, b"bad request")
+            return
+        add_event(
+            str(payload.get("host", "")),
+            str(payload.get("project", "")),
+            str(payload.get("message", "")),
+        )
+        self._respond()
+
+
+def main():
+    threading.Thread(target=flusher, daemon=True).start()
+    ThreadingHTTPServer(("127.0.0.1", PORT), Handler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/rpi5/configuration.nix
+++ b/rpi5/configuration.nix
@@ -158,6 +158,7 @@ in
     ./tiny-llm-gate.nix
     ./aperture-sync.nix
     ./claude-remote-control.nix
+    ./claude-notify-aggregator.nix
     # ./open-webui.nix # DISABLED 2026-06-15: venv crash-loop (ExecStart exit 126, "venv/bin/open-webui: Permission denied") since the disk incident. Re-enable + rebuild the venv (rm -rf /var/lib/open-webui/venv) to restore.
     ./homepage.nix
     ./backups.nix

--- a/rpi5/services-registry.nix
+++ b/rpi5/services-registry.nix
@@ -132,5 +132,6 @@
 
     # Infrastructure — not shown on dashboard
     { port = 8082;  backend = "http://127.0.0.1:8082";  name = "Homepage";       icon = "homepage.svg";       category = "Infrastructure"; description = "Service dashboard"; }
+    { port = 8088;  backend = "http://127.0.0.1:8088";  name = "Claude Notify";  icon = "mdi-bell";           category = "Infrastructure"; description = "Debounced agent → Telegram aggregator"; noSiteMonitor = true; }
   ];
 }

--- a/shared/telegram-notify.nix
+++ b/shared/telegram-notify.nix
@@ -1,86 +1,41 @@
-# Shared Telegram notify hook used by both Claude Code (settings.json hook)
-# and pi-coding-agent (TS extension shell-out).
+# Shared agent-notification hook used by both Claude Code (settings.json
+# `Notification` hook) and pi-coding-agent (`agent_end` extension shell-out).
 #
-# Reads JSON `{message?, cwd?}` on stdin; aggregates lines fired within
-# `windowSeconds` into a single Telegram message via editMessageText.
+# Reads JSON `{message?, cwd?}` on stdin and best-effort POSTs the event to the
+# central debounced aggregator on rpi5 (see rpi5/claude-notify-aggregator.{py,nix}),
+# which pools events from every machine + agent into one stream and sends a single
+# Telegram digest after a quiet period. This hook holds no state and never talks
+# to Telegram directly — it just forwards and exits 0, so a missed POST (rpi5
+# down / tailnet hiccup) silently drops one notification rather than spamming.
 {
   pkgs,
-  telegramChatId,
 }:
 {
   name,
-  header,
-  stateDir,
-  tokenPath,
-  windowSeconds ? 60,
+  source,
 }:
 pkgs.writeShellScript "${name}-telegram-notify" ''
-  CHAT_ID="${builtins.toString telegramChatId}"
-
-  # Token candidates: eval-time path → HM-context agenix → system-context agenix
-  for candidate in "${tokenPath}" "/run/user/$(id -u)/agenix/telegram-bot-token" "/run/agenix/telegram-bot-token"; do
-    if [[ -f "$candidate" ]]; then
-      TOKEN_FILE="$candidate"
-      break
-    fi
-  done
-  [[ -z "''${TOKEN_FILE:-}" ]] && exit 0
-  BOT_TOKEN=$(cat "$TOKEN_FILE")
-  [[ -z "$BOT_TOKEN" ]] && exit 0
-
   PAYLOAD=$(cat)
   MESSAGE=$(echo "$PAYLOAD" | ${pkgs.jq}/bin/jq -r '.message // empty')
   CWD=$(echo "$PAYLOAD" | ${pkgs.jq}/bin/jq -r '.cwd // ""')
-  PROJECT=$(basename "$CWD")
-  NOTIF_LINE="📁 $PROJECT: ''${MESSAGE:-waiting for input}"
+  PROJECT=$(${pkgs.coreutils}/bin/basename "''${CWD:-unknown}")
+  HOST=$(${pkgs.coreutils}/bin/uname -n)
 
-  STATE_DIR="${stateDir}"
-  LOCK_DIR="$STATE_DIR/lock"
-  STATE_FILE="$STATE_DIR/state"
-  WINDOW=${builtins.toString windowSeconds}
+  BODY=$(${pkgs.jq}/bin/jq -nc \
+    --arg host "$HOST" \
+    --arg project "$PROJECT" \
+    --arg message "$MESSAGE" \
+    --arg source "${source}" \
+    '{host:$host, project:$project, message:$message, source:$source}')
 
-  mkdir -p "$STATE_DIR"
-
-  # mkdir is atomic on macOS/Linux; bound retries so a stale lock can't wedge.
-  ATTEMPTS=0
-  until mkdir "$LOCK_DIR" 2>/dev/null; do
-    sleep 0.1
-    ATTEMPTS=$((ATTEMPTS + 1))
-    [[ $ATTEMPTS -gt 40 ]] && exit 0
+  # rpi5 hits the aggregator on loopback; other hosts fall back to the tailnet
+  # FQDN. -m 4 bounds the wait so the hook can't hang the agent.
+  for url in "http://127.0.0.1:8088/notify" "https://rpi5.gate-mintaka.ts.net:8088/notify"; do
+    if ${pkgs.curl}/bin/curl -fsS -m 4 -X POST "$url" \
+         -H 'Content-Type: application/json' \
+         --data-raw "$BODY" >/dev/null 2>&1; then
+      break
+    fi
   done
-  trap 'rmdir "$LOCK_DIR" 2>/dev/null' EXIT TERM INT HUP
-
-  NOW=$(date +%s)
-  MSG_ID=""
-  LAST_TS=0
-  if [[ -f "$STATE_FILE" ]]; then
-    MSG_ID=$(sed -n '1p' "$STATE_FILE")
-    LAST_TS=$(sed -n '2p' "$STATE_FILE")
-  fi
-  ELAPSED=$((NOW - ''${LAST_TS:-0}))
-
-  if [[ -n "$MSG_ID" && $ELAPSED -lt $WINDOW ]]; then
-    PREV_LINES=$(tail -n +3 "$STATE_FILE")
-    NEW_TEXT="${header}
-''${PREV_LINES}
-''${NOTIF_LINE}"
-    ${pkgs.curl}/bin/curl -s -X POST \
-      "https://api.telegram.org/bot''${BOT_TOKEN}/editMessageText" \
-      --data-urlencode "chat_id=''${CHAT_ID}" \
-      --data-urlencode "message_id=''${MSG_ID}" \
-      --data-urlencode "text=''${NEW_TEXT}" \
-      --data-urlencode "parse_mode=Markdown" \
-      > /dev/null
-    { echo "$MSG_ID"; echo "$NOW"; echo "$PREV_LINES"; echo "$NOTIF_LINE"; } > "$STATE_FILE"
-  else
-    NEW_TEXT="${header}
-''${NOTIF_LINE}"
-    RESPONSE=$(${pkgs.curl}/bin/curl -s -X POST \
-      "https://api.telegram.org/bot''${BOT_TOKEN}/sendMessage" \
-      --data-urlencode "chat_id=''${CHAT_ID}" \
-      --data-urlencode "text=''${NEW_TEXT}" \
-      --data-urlencode "parse_mode=Markdown")
-    NEW_MSG_ID=$(echo "$RESPONSE" | ${pkgs.jq}/bin/jq -r '.result.message_id // empty')
-    [[ -n "$NEW_MSG_ID" ]] && { echo "$NEW_MSG_ID"; echo "$NOW"; echo "$NOTIF_LINE"; } > "$STATE_FILE"
-  fi
+  exit 0
 ''


### PR DESCRIPTION
## Problem
~12 concurrent agent sessions across machines (rpi5/BeAsT/nBookPro) were generating **thousands of Telegram messages a day**. The old `Notification`/`agent_end` hook coalesced only within a **60s window using per-machine `/tmp` state**, so it fired immediately on the first event in each window and could not pool across hosts.

## Fix
One central debounced aggregator on rpi5 that every agent hook POSTs to over the tailnet. It pools events into a single shared stream and sends **one Telegram digest only after a quiet period** (or at most once per max window under continuous load).

| File | Change |
|---|---|
| `rpi5/claude-notify-aggregator.py` | New stdlib HTTP server on `127.0.0.1:8088`. Each event resets a quiet timer (`NOTIFY_QUIET_SECONDS=300`); under continuous activity a digest still flushes at most every `NOTIFY_MAX_SECONDS=900`. Dedups identical lines (`×N`), prefixes remote hosts, reads the bot token fresh per flush, drops silently on failure. |
| `rpi5/claude-notify-aggregator.nix` | New systemd service (root, for the root-owned `telegram-bot-token`); windows + chat id via env. |
| `rpi5/configuration.nix` | Import the module. |
| `rpi5/services-registry.nix` | Tailscale Serve entry on `8088`, `Infrastructure` category → **no homepage tile**. |
| `shared/telegram-notify.nix` | Stateful bash → ~25-line best-effort POST to the aggregator (loopback on rpi5, tailnet FQDN elsewhere), `exit 0` so a missed POST drops one notification instead of spamming. |
| `home/claude.nix`, `home/pi-coding-agent/default.nix` | New `{name, source}` factory signature (drop `stateDir`/`tokenPath`/`header`). |

## Behaviour
- **Debounce, not fixed window:** a flurry of sessions refreshing/finishing collapses into one message.
- **Shared pool across computers:** every machine + agent feeds the one rpi5 service.
- **Silent drop** when the aggregator is unreachable (rpi5 down / tailnet hiccup) rather than retry/spam.

## Validation
- `py_compile` ✅
- Unit test: dedup `×N`, FQDN→short-host normalization, remote-host prefix, both flush triggers (quiet + max) ✅
- Server integration: `GET /`→200, `POST /notify`→200 + pooled, bad path→404 ✅
- All 6 Nix files `nix-instantiate --parse` ✅; `telegramChatId` resolves via rpi5 specialArgs (matches `monitoring.nix`) ✅

> Reconstructed from a prior session whose worktree was removed before the changes were committed (root disk was 100% full, blocking deploy; disk is now healthy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)