### PR TITLE
fix(nextcloud): hoist mkServiceConfig to top-level let (unbreak parse)

### DIFF
--- a/rpi5/nextcloud.nix
+++ b/rpi5/nextcloud.nix
@@ -76,6 +76,19 @@ let
     "viewer"
     "workflowengine"
   ];
+
+  # Shared shape for the Nextcloud orchestration oneshots below.
+  mkServiceConfig = { description, syslog, after, before, requires, script }: {
+    inherit description after before requires script;
+    wantedBy = [ "multi-user.target" ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      StandardOutput = "journal";
+      StandardError = "journal";
+      SyslogIdentifier = syslog;
+    };
+  };
 in
 {
   # ── PostgreSQL: nextcloud_production database + nextcloud_user ─────────────
@@ -245,20 +258,6 @@ in
   # the same app (see [[known_issue_nextcloud_extraapps_appstore_dup]]).
   # Order: cleanup → setup → appstore-enable → disable-defaults.
 
-  let
-    mkServiceConfig = { description, syslog, after, before, requires, script }: {
-      inherit description after before requires script;
-      wantedBy = [ "multi-user.target" ];
-      serviceConfig = {
-        Type = "oneshot";
-        RemainAfterExit = true;
-        StandardOutput = "journal";
-        StandardError = "journal";
-        SyslogIdentifier = syslog;
-      };
-    };
-  in
-  {
     systemd.services.nextcloud-cleanup = mkServiceConfig {
       description = "Nextcloud: cleanup store-apps duplicates and stale maintenance mode";
       syslog = "nextcloud-cleanup";
@@ -318,7 +317,6 @@ in
         done
       '';
     };
-  }
 
   # ── Bind-mount /mnt/data/cloud → user-files dir ────────────────────────────
   # Tailscale Drive shares /mnt/data/cloud (see tailscale-serve.nix). Bind-


### PR DESCRIPTION
## What
`rpi5/nextcloud.nix` does not parse on `main`. Commit `dac8766` left a bare `let … in { … }` block in the **middle** of the module's top-level attribute set, which is a Nix syntax error:

```
$ nix-instantiate --parse rpi5/nextcloud.nix
error: syntax error, unexpected LET, expecting INHERIT  (line 248)
```

This blocks **every** `nixos-rebuild` off `main`, not just one feature. The running rpi5 (generation 762, built 06-25) only survives because it predates the break — the next rebuild from `main` would have failed at parse time.

## How
- Hoist the `mkServiceConfig` helper into the file's **top-level `let`** (alongside `port`/`datadir`/…).
- Remove the illegal inner `let … in {` wrapper and its closing `}`, so the four `systemd.services.*` orchestration oneshots sit directly in the module attrset.
- **No behavioural change** — `mkServiceConfig` is used identically; service bodies are untouched (kept their indentation for a minimal diff).

## Validation
- `nix-instantiate --parse rpi5/nextcloud.nix` → OK (was failing).
- Full evaluation happens at the follow-up `nixos-rebuild` deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)