### PR TITLE
fix(nextcloud): make mkServiceConfig `before` optional (unbreak eval)

### DIFF
--- a/rpi5/nextcloud.nix
+++ b/rpi5/nextcloud.nix
@@ -78,7 +78,7 @@ let
   ];
 
   # Shared shape for the Nextcloud orchestration oneshots below.
-  mkServiceConfig = { description, syslog, after, before, requires, script }: {
+  mkServiceConfig = { description, syslog, after, requires, script, before ? [ ] }: {
     inherit description after before requires script;
     wantedBy = [ "multi-user.target" ];
     serviceConfig = {


### PR DESCRIPTION
## What
Follow-up to #317. With the parse error fixed, `rpi5/nextcloud.nix` now **evaluates** — and reveals a second latent bug from `dac8766`:

```
error: function 'mkServiceConfig' called without required argument 'before'
       at rpi5/nextcloud.nix:81
```

The helper required `before`, but `nextcloud-disable-defaults` (last in the cleanup→setup→appstore→disable-defaults chain, so it orders before nothing) omits it. The parse error in #317 had masked this — the module had never successfully evaluated.

## How
`before ? [ ]` — terminal services can omit it; `systemd.services.<n>.before = []` is a harmless no-op. No behavioural change for the three callers that do pass it.

## Validation
`nix eval .#nixosConfigurations.rpi5.config.system.build.toplevel.drvPath` now resolves (was erroring at the assertion/systemd.services eval). Without this, **main still fails to rebuild** despite #317.

🤖 Generated with [Claude Code](https://claude.com/claude-code)