### PR TITLE
feat(home): add infisical CLI

### DIFF
--- a/home/packages.nix
+++ b/home/packages.nix
@@ -37,6 +37,7 @@
       gnused
       gnugrep
       gzip
+      unstablePkgs.infisical
       unstablePkgs.jujutsu
       jq
       k9s


### PR DESCRIPTION
## What
Add the [Infisical](https://infisical.com/docs/cli/overview) CLI to `home/packages.nix` (`unstablePkgs.infisical`, matching the atuin/cursor-cli/jujutsu pattern).

## Why
Needed to load Trusk service secrets into local dev per the `trusk-k8s` infisical dev-guide (`infisical login` / `secrets` / `run` / `export`). Installed declaratively rather than via brew.

## Notes
- Stable and unstable both pin `0.41.90` today; `unstablePkgs` keeps it tracking unstable on future lock bumps.
- Apply on the Mac with `home-manager switch --flake .#nsimon@nBookPro` (already activated locally).
- Usage on the personal tailnet: the guide's `--domain …svc.cluster.local` isn't routable here; port-forward `svc/infisical-infisical` via the `trusk-staging-ts` context and point `--domain` at `http://localhost:8080`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)