### PR TITLE
chore(macos): move infisical CLI to homebrew (0.41.90 → 0.43.99)

### DIFF
--- a/home/packages.nix
+++ b/home/packages.nix
@@ -37,7 +37,6 @@
       gnused
       gnugrep
       gzip
-      unstablePkgs.infisical
       unstablePkgs.jujutsu
       jq
       k9s

--- a/macos/components/homebrew.nix
+++ b/macos/components/homebrew.nix
@@ -20,6 +20,7 @@
     "koekeishiya/formulae"
     "dbt-labs/dbt"
     "auth0/auth0-cli"
+    "infisical/get-cli"
     "Sikarugir-App/sikarugir"
     "RhetTbull/osxphotos"
     {
@@ -33,6 +34,7 @@
     "cookcli"
     "dbt-postgres"
     "helm"
+    "infisical"
     "omlx"
     "pinentry-touchid"
     "RhetTbull/osxphotos/osxphotos"


### PR DESCRIPTION
## What
Move the Infisical CLI from the nixpkgs package (added in #319) to a declaratively-managed Homebrew brew:
- `home/packages.nix`: drop `unstablePkgs.infisical`
- `macos/components/homebrew.nix`: add tap `infisical/get-cli` + brew `infisical`

## Why
nixpkgs lags upstream — it pins `0.41.90`, while the official `infisical/get-cli` tap tracks releases (`0.43.99`). The dev-guide assumes current CLI syntax, so we want the upstream version.

## Test
- `darwin-rebuild switch` taps `infisical/get-cli`; `infisical 0.43.99` installs to `/opt/homebrew/bin/infisical` (nix copy removed via `home-manager switch`).
- `infisical secrets --projectId … --env staging --domain http://localhost:8080` (port-forward of `svc/infisical-infisical` via `trusk-staging-ts`) executes and the backend accepts the login token. ✅

## Note
The `darwin-rebuild` homebrew bundle currently aborts early on a **pre-existing, unrelated** untrusted-tap gate for `dbt-labs/dbt` (`dbt-postgres`) — not introduced here. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)