### PR TITLE
fix(beast): docker_29 + GPU side-logo off (unblock rebuild from main)

### DIFF
--- a/nixos/configuration.nix
+++ b/nixos/configuration.nix
@@ -625,6 +625,7 @@ in
 
   virtualisation.docker = {
     enable = true;
+    package = pkgs.docker_29; # docker_28 unmaintained/insecure on 25.11 nixpkgs (2026-06)
   };
 
   # Libvirt/QEMU for Tobii Eye Tracker VM passthrough

--- a/nixos/packages.nix
+++ b/nixos/packages.nix
@@ -36,7 +36,7 @@ in
     libnotify
     unstablePkgs.code-cursor
     dconf
-    docker
+    docker_29
     dualsensectl
     dunst
     ghostty

--- a/nixos/rgb/lg_sphere_ambient.py
+++ b/nixos/rgb/lg_sphere_ambient.py
@@ -213,12 +213,6 @@ class OpenRGBSink:
         perled = perled or {}
         r, g, b = rgb
         global_col = RGBColor(r, g, b)
-        # ITU-R BT.601 luma — gates the GPU's SINGLE COLOR zone (the FE
-        # GeForce side logo can only do on/off in hardware).
-        lum = (299*r + 587*g + 114*b) // 1000
-        on  = RGBColor(255, 255, 255)
-        off = RGBColor(0, 0, 0)
-        gate = on if lum >= self.gpu_logo_threshold else off
         dead = []
         for dev in self.devices:
             plan = self._zone_plan.get(id(dev))
@@ -232,8 +226,9 @@ class OpenRGBSink:
                 if is_perled and key in perled and len(perled[key]) == n:
                     colors.extend(perled[key])
                 elif gpu_single and 'SINGLE' in zname.upper():
-                    gv = (255,255,255) if gate is on else (0,0,0)
-                    colors.extend([gv] * n)
+                    # GeForce RTX side logo forced off — keep it dark
+                    # regardless of scene luma (gpu_logo_threshold ignored).
+                    colors.extend([(0, 0, 0)] * n)
                 else:
                     colors.extend([(r, g, b)] * n)
             if not colors: continue


### PR DESCRIPTION
Two beast (`nixos/`) changes, needed to rebuild beast from `main`:

1. **docker_29 pin** (the blocker): the 25.11 nixpkgs (2026-06, `f2d6dbf`) marks `docker_28` insecure — *"unmaintained since November 2025, use docker_29 or newer"* — so `.#BeAsT` refuses to evaluate when rebuilt from main. Pins `virtualisation.docker.package` and the CLI to `docker_29` (29.5.3). Verified: `.#BeAsT` toplevel now evaluates clean (→ `25.11.20260623.f2d6dbf`).
2. **GPU side-logo off**: keep the GeForce RTX SINGLE COLOR zone dark unconditionally (drop the BT.601 luma gate). Was uncommitted on beast; captured here so it is not lost.

Without #1, no one can rebuild beast from current main.