### PR TITLE
fix(beast): permit insecure electron-39.8.10 for nsimon HM

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -269,6 +269,9 @@
           pkgs = import nixpkgs {
             system = "x86_64-linux";
             config.allowUnfree = true;
+            # VSCode bundles electron-39.8.10, flagged insecure on 25.11
+            # (2026-06) nixpkgs. Permit it so the HM switch (notify hook) builds.
+            config.permittedInsecurePackages = [ "electron-39.8.10" ];
             overlays = [ rtkOverlay ];
           };
           extraSpecialArgs = {


### PR DESCRIPTION
## Why
Rebuilding beast from `main` upgraded it to the 25.11 (2026-06-29) nixpkgs, which marks **`electron-39.8.10` insecure** (bundled by VSCode in nsimon's home-manager). This blocks `home-manager switch` for `nsimon@BeAsT` — the switch that installs the **new aggregator notify hook** (the Telegram spam fix, #316). Without it, beast keeps the old `/tmp`-stateful hook that POSTs straight to Telegram.

## Change
One line, scoped to the `nsimon@BeAsT` homeConfiguration only:
```nix
config.permittedInsecurePackages = [ "electron-39.8.10" ];
```

## Validated
`nix eval .#homeConfigurations."nsimon@BeAsT".activationPackage.drvPath` on beast now resolves with **no insecure/electron error** (returns the generation `.drv`). System rebuild of beast from `main` is already done (gen 172, docker_29). After merge: beast `home-manager switch` → hook points at the rpi5 aggregator.

Drop this once VSCode bumps off electron-39.8.10.