### PR TITLE
fix(sure): honor self-hosted Lunchflow base_url (bump sure-nix)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1003,11 +1003,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781537232,
-        "narHash": "sha256-lodLhsVYfktvZhDgWqKUmuPRWJWQvHHj4xN/7wa/ULw=",
+        "lastModified": 1782812382,
+        "narHash": "sha256-FxZ9XNipEf0zhl5FNDZC3TJ05L1kPGZsMNdVLbzkUTs=",
         "owner": "nSimonFR",
         "repo": "sure-nix",
-        "rev": "ef921bdab007d10d690c2ab0312dced807aedb86",
+        "rev": "8d9dea7c45540218bd86b75c886879768d3fb387",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Problem
Sumeria + Swile accounts in Sure stopped syncing ~Jun 13. Root cause: upstream Sure's `LunchflowItem#effective_base_url` validates the configured `base_url` then **discards it**, always returning the hardcoded `https://lunchflow.app` SaaS URL. Sure therefore hit the public SaaS with our local connector's API key → `403 Access forbidden`, fetching nothing. The for-sure connector itself was healthy the whole time.

## Fix
Bumps `sure-nix` to [#12](https://github.com/nSimonFR/sure-nix/pull/12) (`8d9dea7`), which patches `effective_base_url` to `base_url.presence || DEFAULT_BASE_URL`.

## Test
Rebuilt rpi5 with the patched sure-nix and forced a sync:
- Importer reached `127.0.0.1:8340` — **no 403**; 5 accounts updated, 49 new txns stored.
- Sumeria Current 69.15 → **13.79**, Savings 81.15 → **0.24**, entries now through Jun 28–29 (were stuck at Jun 13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)