### PR TITLE
fix(sure): tolerate Enable Banking per-account 404 (bump sure-nix)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1003,11 +1003,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782812382,
-        "narHash": "sha256-FxZ9XNipEf0zhl5FNDZC3TJ05L1kPGZsMNdVLbzkUTs=",
+        "lastModified": 1782820753,
+        "narHash": "sha256-Q7AiEa2VF8ISDW/LKfByrvrv9qQCM3SwNvbNYoUV37o=",
         "owner": "nSimonFR",
         "repo": "sure-nix",
-        "rev": "8d9dea7c45540218bd86b75c886879768d3fb387",
+        "rev": "782140f9150938bb225cc67997bb503f77cbddc6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Problem
The Société Générale Enable Banking connection was stuck `requires_update` with a misleading "Session expired. Please reconnect your bank." — but the session was valid for months. One of its two accounts is a **phantom** whose `api_account_id` is a base64 field-path template (not a real UID), so its balances/transactions 404. Upstream Sure maps that 404 like a 401 → marks the whole item `requires_update` and fails the entire sync, so the **working** account never imports.

## Fix
Bumps `sure-nix` to [#13](https://github.com/nSimonFR/sure-nix/pull/13) (`782140f`): treat Enable Banking `:not_found` as a non-fatal per-account skip.

## Test
Rebuilt rpi5, reset the item, forced a sync:
- Phantom account → `Balance/Transactions unavailable (404)… skipping (non-fatal)`
- Real account **"Courant"** imported: balance **3.01**, **135 transactions**, latest today
- Item back to **good**, sync **completed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)