### PR TITLE
feat(picoclaw): reply to all group messages, not only @mentions

### DIFF
--- a/rpi5/picoclaw/picoclaw.nix
+++ b/rpi5/picoclaw/picoclaw.nix
@@ -121,10 +121,14 @@ let
       ];
       use_markdown_v2 = false;
       streaming.enabled = true;
-      # In group chats, only respond when the bot is @mentioned (otherwise it
-      # answers every message). `require_mention_in_groups` is silently
-      # ignored by picoclaw's schema — the real key is `group_trigger.mention_only`.
-      group_trigger.mention_only = true;
+      # Respond to every message in group chats, not only when @mentioned.
+      # `mention_only = false` is picoclaw's permissive default; the only group
+      # the bot is in is "nSimon, ServaTilis and Alfie", so this makes it reply
+      # to all of Alfie's messages there. (`require_mention_in_groups` is
+      # silently ignored by picoclaw's schema — the real key is
+      # `group_trigger.mention_only`.) Setting is global per channel: picoclaw
+      # has no per-chat granularity.
+      group_trigger.mention_only = false;
     };
 
     tools = {


### PR DESCRIPTION
Sets `group_trigger.mention_only = false` so ServaTilis (picoclaw) responds to **every** message in the "nSimon, ServaTilis and Alfie" Telegram group, instead of only when @mentioned.

Requested: have the bot handle all of Alfie's messages, not just the ones tagging it.

### Notes
- picoclaw has **no per-chat granularity** — `group_trigger.mention_only` is global per Telegram channel. That group is the only one the bot is in, so there is no collateral. DMs already respond to everything regardless of this flag.
- Applied live on rpi5 (`home-manager switch`); service restarted, built config confirmed `mention_only: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)