### PR TITLE
chore(flake): bump sure-nix → Sure v0.7.2

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -940,11 +940,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782820753,
-        "narHash": "sha256-Q7AiEa2VF8ISDW/LKfByrvrv9qQCM3SwNvbNYoUV37o=",
+        "lastModified": 1783331663,
+        "narHash": "sha256-33abjqbgkWNTn4XVUsSlfUday6Pt7lDg9LGtKx5GcdQ=",
         "owner": "nSimonFR",
         "repo": "sure-nix",
-        "rev": "782140f9150938bb225cc67997bb503f77cbddc6",
+        "rev": "603cbae0cb519ce95648d78fdb1e780ef4d04f00",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What
Bumps the `sure-nix` input `782140f` → `603cbae`, moving the packaged Sure app **0.7.1-hotfix.1 → 0.7.2** (upstream `we-promise/sure` latest stable, 2026-07-01).

The sure-nix side landed in [nSimonFR/sure-nix#14](https://github.com/nSimonFR/sure-nix/pull/14): regenerated gemset + refreshed hashes, and **rebased the enable-banking patch** onto v0.7.2 (dropped the `handle_sync_error` hunk that upstream now implements via `session_level:`; kept the two non-fatal per-account 404 skips).

## Verified live on rpi5
- `sure-web` runs `/nix/store/…-sure-0.7.2`; web + worker `active`; `:13334` → 200.
- 0.7.1→0.7.2 Rails migrations ran clean ("Finished Sure — database migrations"), Puma up on Ruby 3.4.8.
- No failed systemd units.

🤖 Generated with [Claude Code](https://claude.com/claude-code)