### PR TITLE
feat(front-proxy): expose Nextcloud publicly via 443 path-mux

### DIFF
--- a/rpi5/affine-mcp.nix
+++ b/rpi5/affine-mcp.nix
@@ -64,7 +64,9 @@ in
       mkdir -p /run/affine-mcp
       cat > /run/affine-mcp/env <<ENVEOF
       MCP_TRANSPORT=http
-      AFFINE_BASE_URL=http://127.0.0.1:13010
+      # AFFiNE runs under a NestJS global prefix (AFFINE_SERVER_SUB_PATH=/affine in
+      # affine.nix), so its API — GraphQL and /api/* — is served under /affine.
+      AFFINE_BASE_URL=http://127.0.0.1:13010/affine
       AFFINE_API_TOKEN=$(cat ${config.age.secrets.affine-token.path})
       AFFINE_MCP_AUTH_MODE=bearer
       AFFINE_MCP_HTTP_TOKEN=$(cat ${config.age.secrets.affine-mcp-http-token.path})

--- a/rpi5/affine.nix
+++ b/rpi5/affine.nix
@@ -208,7 +208,13 @@ in
       HOME = dataDir;
       AFFINE_SERVER_HOST = "127.0.0.1";
       AFFINE_SERVER_PORT = toString port;
-      AFFINE_SERVER_EXTERNAL_URL = "https://${tailnetFqdn}";
+      # Served under /affine on the shared 443 Funnel (see front-proxy.nix). This sets
+      # config `server.path`, which AFFiNE applies as a NestJS global prefix — so ALL
+      # routes (incl. /graphql, /api/*) remount under /affine. Internal callers on :13010
+      # must include the prefix too (see affine-mcp.nix AFFINE_BASE_URL, and the homepage
+      # widget url in services-registry.nix).
+      AFFINE_SERVER_SUB_PATH = "/affine";
+      AFFINE_SERVER_EXTERNAL_URL = "https://${tailnetFqdn}/affine";
       DATABASE_URL = dbUrl;
       REDIS_SERVER_HOST = redisHost;
       REDIS_SERVER_PORT = toString redisPort;
@@ -239,7 +245,7 @@ in
       # endpoints via DI, so link-preview/image-proxy requests go to
       # the cloud worker instead of our local server.
       CLOUD="https://affine-worker.toeverything.workers.dev"
-      SELF="https://${tailnetFqdn}"
+      SELF="https://${tailnetFqdn}/affine"
       for f in ${appDir}/static/js/*.js; do
         if grep -q "$CLOUD" "$f" 2>/dev/null; then
           ${pkgs.gnused}/bin/sed -i "s|$CLOUD|$SELF|g" "$f"
@@ -252,6 +258,15 @@ in
       # from "reject if neither matches" to "reject only if a
       # header is present but doesn't match".
       ${pkgs.gnused}/bin/sed -i 's#if(!n&&!a)throw this.logger.error("Invalid Origin","ERROR"#if(!n\&\&!a\&\&(o||i))throw this.logger.error("Invalid Origin","ERROR"#' ${appDir}/dist/main.js
+
+      # NOTE on the /affine sub-path: AFFINE_SERVER_SUB_PATH=/affine moves the
+      # backend (API + assets, served under /affine) and the client router base,
+      # but the self-hosted build still emits root-relative asset URLs (its
+      # frontend publicPath is baked to the CDN and rewritten to "/" at serve
+      # time through several points — not cleanly overridable). So the web UI
+      # requests /js, /styles*.css at the domain root. front-proxy.nix absorbs
+      # this with a catch-all that maps those root asset requests onto the
+      # /affine backend, which is robust across AFFiNE upgrades.
 
       exec ${nodejs}/bin/node ${appDir}/dist/main.js
     '';

--- a/rpi5/configuration.nix
+++ b/rpi5/configuration.nix
@@ -147,6 +147,7 @@ in
     ./paperless.nix
     ./karakeep.nix
     ./nextcloud.nix
+    ./front-proxy.nix
     ./sumeria-mitm.nix
     ./hydroxide.nix
     ./vaultwarden.nix

--- a/rpi5/front-proxy.nix
+++ b/rpi5/front-proxy.nix
@@ -1,0 +1,96 @@
+# front-proxy.nix — nginx path-mux on the single public 443 Tailscale Funnel.
+#
+# Tailscale Funnel only permits ports 443/8443/10000, and 8443→Cyrus / 10000→Immich
+# are taken. To expose Nextcloud publicly without evicting anyone, one Funnel on 443
+# points at this vhost, which routes by path to AFFiNE and Nextcloud on the same host:
+#
+#   tailscale funnel --https=443  →  127.0.0.1:8092 (this vhost)
+#     /                 → 301 → /affine/
+#     /affine           → 127.0.0.1:13010  (AFFiNE — prefix PASSED THROUGH: AFFiNE runs
+#                                            under a NestJS global prefix set by
+#                                            AFFINE_SERVER_SUB_PATH=/affine, so it expects
+#                                            the /affine prefix on incoming requests)
+#     /nextcloud/       → 127.0.0.1:8091/  (Nextcloud — prefix STRIPPED: NC routes at its
+#                                            vhost root; overwritewebroot=/nextcloud only
+#                                            rewrites the links NC generates)
+#     /.well-known/{caldav,carddav} → 301 → /nextcloud/remote.php/dav/  (DAV auto-discovery
+#                                            lands at the domain root, which now serves
+#                                            AFFiNE, so redirect it to Nextcloud)
+#
+# Reuses the nginx instance the Nextcloud module already runs (no extra process). The
+# funnel entry that targets :8092 lives in services-registry.nix (Infrastructure category);
+# AFFiNE + Nextcloud entries carry `proxied = true` so tailscale-serve.nix emits no direct
+# serve/funnel command for them — this vhost fronts them instead.
+{ ... }:
+let
+  # Headers every proxied location forwards. X-Forwarded-Proto=https is required so
+  # Nextcloud (overwritecondaddr=^127\.0\.0\.1$, overwriteprotocol=https) and AFFiNE
+  # generate https links behind the TLS-terminating Tailscale Funnel.
+  fwdHeaders = ''
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
+  '';
+in
+{
+  services.nginx.virtualHosts."front-proxy" = {
+    # Only vhost on this port; Tailscale terminates TLS and forwards plain HTTP here.
+    listen = [ { addr = "127.0.0.1"; port = 8092; ssl = false; } ];
+
+    # Emit relative Location headers on our `return 301`s. Otherwise nginx builds
+    # absolute redirects from its own listen socket (http://<host>:8092/…), leaking
+    # the internal port and downgrading to http. Relative headers let the browser
+    # resolve against the original https://<host>/ request.
+    extraConfig = ''
+      absolute_redirect off;
+    '';
+
+    locations = {
+      # Bare URL used to be AFFiNE at root — send humans to /affine/.
+      "= /" = { return = "301 /affine/"; };
+
+      # AFFiNE human URL + API: forward the /affine prefix intact (NestJS global
+      # prefix — do NOT strip). Handles /affine, /affine/graphql, /affine/*.
+      "/affine" = {
+        proxyPass = "http://127.0.0.1:13010";
+        proxyWebsockets = true; # doc sync (graphql-ws / socket.io)
+        extraConfig = fwdHeaders;
+      };
+
+      # Catch-all: AFFiNE's web UI emits root-relative asset URLs (/js, /styles*.css,
+      # /manifest.json, lazy-loaded chunks) because the self-hosted build's frontend
+      # publicPath can't be pinned to /affine. Map every other root path onto the
+      # /affine backend (which serves the assets under the global prefix). More
+      # specific locations (/affine, /nextcloud/, /.well-known/*) win over this, so
+      # only AFFiNE's stray root assets land here. proxyPass has a URI with a
+      # trailing slash (/affine/) so nginx rewrites the leading "/" → "/affine/"
+      # (e.g. /js/x → /affine/js/x). Without the trailing slash it would emit
+      # /affinejs/x and 404.
+      "/" = {
+        proxyPass = "http://127.0.0.1:13010/affine/";
+        proxyWebsockets = true;
+        extraConfig = fwdHeaders;
+      };
+
+      # Nextcloud: trailing slashes on both location and proxyPass strip /nextcloud
+      # before forwarding to NC's root vhost.
+      "= /nextcloud" = { return = "301 /nextcloud/"; };
+      "/nextcloud/" = {
+        proxyPass = "http://127.0.0.1:8091/";
+        proxyWebsockets = true;
+        extraConfig = ''
+          ${fwdHeaders}
+          client_max_body_size 10G;      # large file uploads
+          proxy_request_buffering off;   # stream uploads rather than buffer to disk
+          proxy_read_timeout 3600s;
+          proxy_send_timeout 3600s;
+        '';
+      };
+
+      # CalDAV/CardDAV auto-discovery at the domain root → Nextcloud's DAV endpoint.
+      "= /.well-known/caldav"  = { return = "301 /nextcloud/remote.php/dav/"; };
+      "= /.well-known/carddav" = { return = "301 /nextcloud/remote.php/dav/"; };
+    };
+  };
+}

--- a/rpi5/homepage.nix
+++ b/rpi5/homepage.nix
@@ -23,12 +23,17 @@ let
   # which would otherwise keep idle-stoppable backends pinned in memory.
   mkTile = e:
     let
+      # Port 443 is the bare-URL funnel (Front Proxy path-mux) — omit the :port
+      # suffix and append the entry's path (e.g. /affine, /nextcloud) if it has one.
+      url = "https://${tailnetFqdn}"
+            + lib.optionalString (e.port != 443) ":${toString e.port}"
+            + (e.path or "");
       base = {
         icon = e.icon;
-        href = "https://${tailnetFqdn}:${toString e.port}";
+        href = url;
         inherit (e) description;
       } // lib.optionalAttrs (! (e.noSiteMonitor or false)) {
-        siteMonitor = "https://${tailnetFqdn}:${toString e.port}";
+        siteMonitor = url;
       };
       widgetAttr = if e ? widget then { inherit (e) widget; } else {};
     in base // widgetAttr;

--- a/rpi5/nextcloud.nix
+++ b/rpi5/nextcloud.nix
@@ -11,11 +11,11 @@
 # password set via a oneshot ALTER USER service, secrets via agenix.
 { config, pkgs, lib, pgHost, pgPort, redisHost, redisPort, tailnetFqdn, ... }:
 let
-  # Internal nginx port. Tailscale Serve exposes Nextcloud at :8085 on the
-  # tailnet (the slot freed by filebrowser — see services-registry.nix) and
-  # forwards to this port on 127.0.0.1.
+  # Internal nginx port. Nextcloud is served at https://<tailnetFqdn>/nextcloud on the
+  # public 443 Tailscale Funnel via the nginx path-mux (front-proxy.nix), which strips
+  # the /nextcloud prefix and forwards to this port on 127.0.0.1. `overwritewebroot`
+  # below makes Nextcloud generate its links under /nextcloud to match.
   port = 8091;
-  servePort = 8085; # external tailnet port (used in trusted_domains)
 
   # Datadir on the data HDD. Nextcloud manages this tree exclusively:
   # per-user files at /mnt/data/nextcloud/data/<user>/files/, plus internal
@@ -186,10 +186,13 @@ in
 
     # Default settings; the module merges these into config.php.
     settings = {
-      trusted_domains   = [ tailnetFqdn "${tailnetFqdn}:${toString servePort}" ];
+      trusted_domains   = [ tailnetFqdn ];
       trusted_proxies   = [ "127.0.0.1" ];
       overwriteprotocol = "https";
-      overwritehost     = "${tailnetFqdn}:${toString servePort}";
+      overwritehost     = tailnetFqdn; # bare host on the 443 Funnel (no port suffix)
+      # Served behind the nginx path-mux at /nextcloud (front-proxy.nix strips the
+      # prefix); overwritewebroot makes Nextcloud regenerate its links under /nextcloud.
+      overwritewebroot  = "/nextcloud";
       overwritecondaddr = "^127\\.0\\.0\\.1$";
 
       # Default phone region for unparsed numbers in addressbooks (Contacts app

--- a/rpi5/picoclaw/picoclaw.nix
+++ b/rpi5/picoclaw/picoclaw.nix
@@ -315,7 +315,7 @@ in
 
     [storage nc_remote]
     type = "caldav"
-    url = "https://rpi5.gate-mintaka.ts.net:8085/remote.php/dav/"
+    url = "https://rpi5.gate-mintaka.ts.net/nextcloud/remote.php/dav/"
     username = "nsimon"
     password.fetch = ["command", "cat", "/run/agenix/nextcloud-homepage-password"]
 

--- a/rpi5/picoclaw/skills/caldav-calendar/SKILL.md
+++ b/rpi5/picoclaw/skills/caldav-calendar/SKILL.md
@@ -7,7 +7,7 @@ metadata: {"openclaw":{"emoji":"📅","os":["linux"],"requires":{"bins":["vdirsy
 
 # CalDAV Calendar (vdirsyncer + khal)
 
-> **PERSONAL calendar only.** This skill is wired to the user's Nextcloud (`https://rpi5.gate-mintaka.ts.net:8085`). Work/Trusk calendar access goes through the `gog` skill instead.
+> **PERSONAL calendar only.** This skill is wired to the user's Nextcloud (`https://rpi5.gate-mintaka.ts.net/nextcloud`). Work/Trusk calendar access goes through the `gog` skill instead.
 
 **vdirsyncer** syncs CalDAV calendars to local `.ics` files. **khal** reads and writes them. On the rpi5 both binaries come from `home.packages` and the configs (`~/.config/vdirsyncer/config`, `~/.config/khal/config`) are Nix-managed in `rpi5/picoclaw/picoclaw.nix`; the Nextcloud password is read at sync time from `/run/agenix/nextcloud-homepage-password` via vdirsyncer's `password.fetch`.
 
@@ -111,4 +111,4 @@ Useful paths:
 - Local cache: `~/.local/share/vdirsyncer/calendars/<calendar>/*.ics`
 - vdirsyncer status: `~/.local/share/vdirsyncer/status/`
 - khal db: `~/.local/share/khal/khal.db`
-- Source of truth: `https://rpi5.gate-mintaka.ts.net:8085/remote.php/dav/`
+- Source of truth: `https://rpi5.gate-mintaka.ts.net/nextcloud/remote.php/dav/`

--- a/rpi5/services-registry.nix
+++ b/rpi5/services-registry.nix
@@ -10,13 +10,19 @@
 # instead of `tailscale serve` (tailnet-only). Display order in homepage
 # follows list order regardless of funnel flag.
 #
+# `proxied = true` marks an entry that is fronted by the nginx path-mux
+# (see front-proxy.nix): tailscale-serve.nix emits NO serve/funnel command
+# for it (the single Front Proxy funnel on 443 fronts it instead), but
+# homepage still renders its tile. Such entries carry `path` (e.g. "/affine")
+# so the homepage tile links to https://<host><path>.
+#
 # Widget: optional homepage widget config (type + extra fields).
 #   Secrets use {{HOMEPAGE_VAR_NAME}} syntax resolved from environmentFile.
 { }:
 {
   entries = [
     # Apps: Nextcloud → AFFiNE → Sure → Immich → Open WebUI → Paperless → Karakeep → Home Assistant
-    { port = 8085;  backend = "http://127.0.0.1:8091";  name = "Nextcloud";      icon = "nextcloud.svg";      category = "Apps"; description = "Files + Contacts + Calendar (DAV)";
+    { port = 443;   backend = "http://127.0.0.1:8091";  name = "Nextcloud";      icon = "nextcloud.svg";      category = "Apps"; description = "Files + Contacts + Calendar (DAV)"; proxied = true; path = "/nextcloud";
       widget = {
         type = "nextcloud";
         url = "http://127.0.0.1:8091";
@@ -24,10 +30,10 @@
         password = "{{HOMEPAGE_VAR_NEXTCLOUD_PASSWORD}}";
         fields = [ "freespace" "activeusers" "numfiles" "numshares" ];
       }; }
-    { port = 443;   backend = "http://127.0.0.1:13010"; name = "AFFiNE";         icon = "affine.svg";         category = "Apps"; description = "Collaborative docs"; funnel = true;
+    { port = 443;   backend = "http://127.0.0.1:13010"; name = "AFFiNE";         icon = "affine.svg";         category = "Apps"; description = "Collaborative docs"; proxied = true; path = "/affine";
       widget = {
         type = "customapi";
-        url = "http://127.0.0.1:13010/graphql";
+        url = "http://127.0.0.1:13010/affine/graphql";
         method = "POST";
         headers = { "Content-Type" = "application/json"; "Authorization" = "Bearer {{HOMEPAGE_VAR_AFFINE_TOKEN}}"; };
         requestBody = { query = "{ workspaces { memberCount blobsSize docs(pagination: {first: 0}) { totalCount } } }"; };
@@ -131,6 +137,9 @@
     { port = 8443;  backend = "http://127.0.0.1:3456";  name = "Cyrus";          icon = "mdi-robot-outline";  category = "Backend"; description = "Linear coding-agent (cyrusagents/cyrus)"; funnel = true; }
 
     # Infrastructure — not shown on dashboard
+    # Single public 443 Funnel → nginx path-mux (front-proxy.nix), which routes
+    # /affine → AFFiNE and /nextcloud → Nextcloud (both `proxied = true` above).
+    { port = 443;   backend = "http://127.0.0.1:8092";  name = "Front Proxy";    icon = "mdi-sitemap";        category = "Infrastructure"; description = "nginx 443 path-mux (/affine, /nextcloud)"; funnel = true; }
     { port = 8082;  backend = "http://127.0.0.1:8082";  name = "Homepage";       icon = "homepage.svg";       category = "Infrastructure"; description = "Service dashboard"; }
     { port = 8088;  backend = "http://127.0.0.1:8088";  name = "Claude Notify";  icon = "mdi-bell";           category = "Infrastructure"; description = "Debounced agent → Telegram aggregator"; noSiteMonitor = true; }
   ];

--- a/rpi5/tailscale-serve.nix
+++ b/rpi5/tailscale-serve.nix
@@ -5,8 +5,13 @@ let
   ts = "${pkgs.tailscale}/bin/tailscale";
 
   isFunnel  = e: e ? funnel && e.funnel;
-  serveEntries  = builtins.filter (e: !(isFunnel e)) registry.entries;
-  funnelEntries = builtins.filter isFunnel registry.entries;
+  # `proxied` entries are fronted by the nginx path-mux (front-proxy.nix) behind the
+  # single Front Proxy funnel on 443 — they must NOT get their own serve/funnel command
+  # (a second bind on 443 would conflict). They still appear as homepage tiles.
+  isProxied = e: e ? proxied && e.proxied;
+  directEntries = builtins.filter (e: !(isProxied e)) registry.entries;
+  serveEntries  = builtins.filter (e: !(isFunnel e)) directEntries;
+  funnelEntries = builtins.filter isFunnel directEntries;
 
   serveUp   = lib.concatMapStringsSep "\n  " (e: "${ts} serve   --bg --https=${toString e.port} ${e.backend}") serveEntries;
   funnelUp  = lib.concatMapStringsSep "\n  " (e: "${ts} funnel  --bg --https=${toString e.port} ${e.backend}") funnelEntries;


### PR DESCRIPTION
## What

Exposes **Nextcloud to the public web** (Tailscale Funnel). All three Funnel ports (443→AFFiNE, 8443→Cyrus, 10000→Immich) were taken, so instead of evicting a service this consolidates **443 behind the already-running nginx** as a path-mux front proxy (zero extra process):

```
funnel --https=443 → nginx front vhost (127.0.0.1:8092)
   /                 → 301 → /affine/
   /affine           → 127.0.0.1:13010         (AFFiNE, prefix passed through)
   /nextcloud/       → 127.0.0.1:8091/         (Nextcloud, prefix stripped)
   /.well-known/{caldav,carddav} → 301 → /nextcloud/remote.php/dav/
   / (catch-all)     → 127.0.0.1:13010/affine/ (AFFiNE root-relative assets)
```

Immich (10000) and Cyrus (8443) funnels untouched.

## AFFiNE under a sub-path — the tricky part

`AFFINE_SERVER_SUB_PATH=/affine` moves AFFiNE's **backend** (NestJS global prefix: API + assets served under `/affine`, confirmed) and the client router base. But the **self-hosted build emits root-relative asset URLs** — its frontend `publicPath` is baked to a CDN (`prod.affineassets.com`) and rewritten to `/` at serve time through several points that aren't cleanly overridable (a JS patch on the obvious `env.selfhosted?"/":e.publicPath` line had no effect — the served value comes from elsewhere). So the web UI requests `/js`, `/styles*.css` at the domain root.

Rather than patch AFFiNE's minified bundle (fragile across upgrades), the front proxy **catch-all** maps those root asset requests onto the `/affine` backend. Robust, upgrade-proof, no binary patching.

## Files
- **new** `rpi5/front-proxy.nix` (nginx vhost; `absolute_redirect off` so 301s stay relative and don't leak `:8092`/http) + import in `configuration.nix`
- `services-registry.nix`: `proxied` flag; AFFiNE/Nextcloud → proxied tiles w/ `path`; new 443 Front Proxy funnel entry
- `tailscale-serve.nix`: skip `proxied` entries
- `homepage.nix`: `mkTile` omits `:443`, appends `path`
- `affine.nix` (SUB_PATH + external URL), `affine-mcp.nix` (base URL +/affine), `nextcloud.nix` (overwritewebroot), picoclaw CalDAV URL + skill doc

## Verified live on rpi5 (rebuilt from this branch)
- `/affine` UI: every referenced asset + JS chunk 200; `/affine/graphql` → `serverConfig{name:"NicOS AFFiNE",version:"0.26.6"}`
- root → relative `301 /affine/`; `/nextcloud/` → login, `status.php` installed v33.0.6; `.well-known/caldav` → relative DAV redirect; DAV endpoint 401 (auth-gated)
- homepage AFFiNE widget reaches `/affine/graphql`; nginx/affine/affine-mcp/nextcloud/tailscale-serve/picoclaw all active

## ⚠️ Cutover (post-merge)
- Existing devices syncing Nextcloud at `:8085` must repoint to `https://<host>/nextcloud/remote.php/dav/` (full cutover — `overwritehost` is singular).
- AFFiNE Google Calendar OAuth redirect URI may need updating in Google Cloud console (now under `/affine`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)