### PR TITLE
fix: front-proxy reshuffle — AFFiNE→:8443 root, Cyrus & Sure on 443 path-mux, HA cached widget

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -940,11 +940,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783331663,
-        "narHash": "sha256-33abjqbgkWNTn4XVUsSlfUday6Pt7lDg9LGtKx5GcdQ=",
+        "lastModified": 1783412253,
+        "narHash": "sha256-Dz/rMPE90Ohiq4bRtJ1d1UDFGT94ndo6CqKRWqkJIxk=",
         "owner": "nSimonFR",
         "repo": "sure-nix",
-        "rev": "603cbae0cb519ce95648d78fdb1e780ef4d04f00",
+        "rev": "f609c44501dbcc0a66761791f5ebea2c1a01f141",
         "type": "github"
       },
       "original": {

--- a/rpi5/affine-mcp.nix
+++ b/rpi5/affine-mcp.nix
@@ -64,9 +64,10 @@ in
       mkdir -p /run/affine-mcp
       cat > /run/affine-mcp/env <<ENVEOF
       MCP_TRANSPORT=http
-      # AFFiNE runs under a NestJS global prefix (AFFINE_SERVER_SUB_PATH=/affine in
-      # affine.nix), so its API — GraphQL and /api/* — is served under /affine.
-      AFFINE_BASE_URL=http://127.0.0.1:13010/affine
+      # AFFiNE serves at root on :13010 (no NestJS global prefix — it runs at the
+      # root of its own :8443 Funnel, see affine.nix), so its API (GraphQL,
+      # /api/*) is at the root.
+      AFFINE_BASE_URL=http://127.0.0.1:13010
       AFFINE_API_TOKEN=$(cat ${config.age.secrets.affine-token.path})
       AFFINE_MCP_AUTH_MODE=bearer
       AFFINE_MCP_HTTP_TOKEN=$(cat ${config.age.secrets.affine-mcp-http-token.path})

--- a/rpi5/affine.nix
+++ b/rpi5/affine.nix
@@ -208,13 +208,13 @@ in
       HOME = dataDir;
       AFFINE_SERVER_HOST = "127.0.0.1";
       AFFINE_SERVER_PORT = toString port;
-      # Served under /affine on the shared 443 Funnel (see front-proxy.nix). This sets
-      # config `server.path`, which AFFiNE applies as a NestJS global prefix — so ALL
-      # routes (incl. /graphql, /api/*) remount under /affine. Internal callers on :13010
-      # must include the prefix too (see affine-mcp.nix AFFINE_BASE_URL, and the homepage
-      # widget url in services-registry.nix).
-      AFFINE_SERVER_SUB_PATH = "/affine";
-      AFFINE_SERVER_EXTERNAL_URL = "https://${tailnetFqdn}/affine";
+      # AFFiNE runs at the ROOT of its own Tailscale Funnel on :8443 (see
+      # services-registry.nix). No NestJS global prefix — its SPA router insists
+      # on root paths (a /affine sub-path made the client navigate to root
+      # /workspace/… and never held the base), so serving at root is the only
+      # clean option. Internal callers on :13010 hit routes at root (/graphql,
+      # /api/*) with no prefix.
+      AFFINE_SERVER_EXTERNAL_URL = "https://${tailnetFqdn}:8443";
       DATABASE_URL = dbUrl;
       REDIS_SERVER_HOST = redisHost;
       REDIS_SERVER_PORT = toString redisPort;
@@ -258,15 +258,6 @@ in
       # from "reject if neither matches" to "reject only if a
       # header is present but doesn't match".
       ${pkgs.gnused}/bin/sed -i 's#if(!n&&!a)throw this.logger.error("Invalid Origin","ERROR"#if(!n\&\&!a\&\&(o||i))throw this.logger.error("Invalid Origin","ERROR"#' ${appDir}/dist/main.js
-
-      # NOTE on the /affine sub-path: AFFINE_SERVER_SUB_PATH=/affine moves the
-      # backend (API + assets, served under /affine) and the client router base,
-      # but the self-hosted build still emits root-relative asset URLs (its
-      # frontend publicPath is baked to the CDN and rewritten to "/" at serve
-      # time through several points — not cleanly overridable). So the web UI
-      # requests /js, /styles*.css at the domain root. front-proxy.nix absorbs
-      # this with a catch-all that maps those root asset requests onto the
-      # /affine backend, which is robust across AFFiNE upgrades.
 
       exec ${nodejs}/bin/node ${appDir}/dist/main.js
     '';

--- a/rpi5/cyrus.nix
+++ b/rpi5/cyrus.nix
@@ -1,8 +1,8 @@
 # Cyrus — Linear coding-agent dispatcher (cyrusagents/cyrus, Apache-2.0).
 #
 # Receives Linear webhooks, spawns Claude Code (via @anthropic-ai/claude-agent-sdk)
-# against issues, opens PRs as the configured GitHub user. Public URL via
-# Tailscale Funnel on :8443 → 127.0.0.1:3456.
+# against issues, opens PRs as the configured GitHub user. Public URL via the 443
+# nginx path-mux at /cyrus (front-proxy.nix) → 127.0.0.1:3456 (prefix stripped).
 #
 # Packaging: source comes from the `cyrus-src` flake input (flake.nix,
 # `flake = false`), so it's locked in flake.lock and auto-bumped by
@@ -27,9 +27,10 @@
 #   3. Running `sudo -u cyrus gh auth login` for nSimonFR-ai.
 #
 # Manual: linear.app → Settings → API → OAuth Applications → New
-#   Callback URL:  https://rpi5.gate-mintaka.ts.net:8443/callback
-#                  (must be exact — cyrus hardcodes /callback, not /oauth/callback)
-#   Webhook URL:   https://rpi5.gate-mintaka.ts.net:8443/linear-webhook
+#   Callback URL:  https://rpi5.gate-mintaka.ts.net/cyrus/callback
+#                  (must be exact — cyrus hardcodes /callback, not /oauth/callback;
+#                   nginx strips /cyrus so it lands at cyrus's root /callback)
+#   Webhook URL:   https://rpi5.gate-mintaka.ts.net/cyrus/linear-webhook
 #                  (must be exact — cyrus mounts at /linear-webhook, NOT /webhooks/linear)
 #   Scopes:        write, app:assignable, app:mentionable
 #   Webhook event: "Agent session events"
@@ -71,13 +72,18 @@ in
     port = lib.mkOption {
       type = lib.types.port;
       default = 3456;
-      description = "Internal HTTP port. Public URL on Tailscale Funnel :8443.";
+      description = "Internal HTTP port. Public URL via the 443 path-mux at /cyrus.";
     };
 
     baseUrl = lib.mkOption {
       type = lib.types.str;
-      default = "https://rpi5.gate-mintaka.ts.net:8443";
-      description = "Public URL Linear webhooks reach (Tailscale Funnel).";
+      default = "https://rpi5.gate-mintaka.ts.net/cyrus";
+      description = ''
+        Public base URL Linear/GitHub reach. Cyrus is fronted by the 443 nginx
+        path-mux at /cyrus (front-proxy.nix, prefix stripped), so its OAuth
+        callback + webhook URLs are generated as <baseUrl>/callback,
+        <baseUrl>/linear-webhook, <baseUrl>/github-webhook.
+      '';
     };
 
     claudeDefaultModel = lib.mkOption {
@@ -184,7 +190,7 @@ in
         gh to the owner account and POST it manually:
           gh auth switch --user nSimonFR
           SECRET=$(sudo cat /run/agenix/cyrus-github-webhook-secret)
-          jq -nc --arg s "$SECRET" '{name:"web",active:true,events:["issue_comment","pull_request_review","pull_request_review_comment"],config:{url:"https://rpi5.gate-mintaka.ts.net:8443/github-webhook",content_type:"json",secret:$s,insecure_ssl:"0"}}' \
+          jq -nc --arg s "$SECRET" '{name:"web",active:true,events:["issue_comment","pull_request_review","pull_request_review_comment"],config:{url:"https://rpi5.gate-mintaka.ts.net/cyrus/github-webhook",content_type:"json",secret:$s,insecure_ssl:"0"}}' \
             | gh api -X POST /repos/nSimonFR/<repo>/hooks --input -
           gh auth switch --user nSimonfr-ai
       '';

--- a/rpi5/front-proxy.nix
+++ b/rpi5/front-proxy.nix
@@ -78,6 +78,17 @@ in
         extraConfig = fwdHeaders;
       };
 
+      # Sure (Rails, socket-activated). UNLIKE Nextcloud/Cyrus this is passed
+      # through UNCHANGED (no trailing-slash strip): sure-nix's config.ru mounts
+      # the app under RAILS_RELATIVE_URL_ROOT=/sure via Rack::URLMap, which does
+      # the internal SCRIPT_NAME strip itself. Proxy to the socket-activate port
+      # (13334) so a request wakes Puma; readyProbe hits /sure/up.
+      "/sure" = {
+        proxyPass = "http://127.0.0.1:13334";
+        proxyWebsockets = true;
+        extraConfig = fwdHeaders;
+      };
+
       # CalDAV/CardDAV auto-discovery at the domain root → Nextcloud's DAV endpoint.
       "= /.well-known/caldav"  = { return = "301 /nextcloud/remote.php/dav/"; };
       "= /.well-known/carddav" = { return = "301 /nextcloud/remote.php/dav/"; };

--- a/rpi5/front-proxy.nix
+++ b/rpi5/front-proxy.nix
@@ -1,31 +1,33 @@
 # front-proxy.nix — nginx path-mux on the single public 443 Tailscale Funnel.
 #
-# Tailscale Funnel only permits ports 443/8443/10000, and 8443→Cyrus / 10000→Immich
-# are taken. To expose Nextcloud publicly without evicting anyone, one Funnel on 443
-# points at this vhost, which routes by path to AFFiNE and Nextcloud on the same host:
+# Tailscale Funnel only permits ports 443/8443/10000, and 8443→AFFiNE / 10000→Immich
+# are taken. To expose Nextcloud and Cyrus publicly without a fourth port, one Funnel
+# on 443 points at this vhost, which routes by path:
 #
 #   tailscale funnel --https=443  →  127.0.0.1:8092 (this vhost)
-#     /                 → 301 → /affine/
-#     /affine           → 127.0.0.1:13010  (AFFiNE — prefix PASSED THROUGH: AFFiNE runs
-#                                            under a NestJS global prefix set by
-#                                            AFFINE_SERVER_SUB_PATH=/affine, so it expects
-#                                            the /affine prefix on incoming requests)
+#     /                 → 301 → /nextcloud/
 #     /nextcloud/       → 127.0.0.1:8091/  (Nextcloud — prefix STRIPPED: NC routes at its
 #                                            vhost root; overwritewebroot=/nextcloud only
 #                                            rewrites the links NC generates)
+#     /cyrus/           → 127.0.0.1:3456/  (Cyrus — prefix STRIPPED: cyrus mounts its
+#                                            routes (/callback, /linear-webhook,
+#                                            /github-webhook) at root and only knows its
+#                                            public base via CYRUS_BASE_URL=…/cyrus, so
+#                                            stripping /cyrus lands each at the right route)
 #     /.well-known/{caldav,carddav} → 301 → /nextcloud/remote.php/dav/  (DAV auto-discovery
-#                                            lands at the domain root, which now serves
-#                                            AFFiNE, so redirect it to Nextcloud)
+#                                            lands at the domain root; redirect to Nextcloud)
 #
-# Reuses the nginx instance the Nextcloud module already runs (no extra process). The
-# funnel entry that targets :8092 lives in services-registry.nix (Infrastructure category);
-# AFFiNE + Nextcloud entries carry `proxied = true` so tailscale-serve.nix emits no direct
+# AFFiNE is NOT here anymore — its SPA router insists on root paths, so it runs at the
+# root of its own 8443 Funnel (see affine.nix / services-registry.nix). Reuses the nginx
+# instance the Nextcloud module already runs (no extra process). The funnel entry that
+# targets :8092 lives in services-registry.nix (Infrastructure category); Nextcloud +
+# Cyrus entries carry `proxied = true` so tailscale-serve.nix emits no direct
 # serve/funnel command for them — this vhost fronts them instead.
 { ... }:
 let
   # Headers every proxied location forwards. X-Forwarded-Proto=https is required so
-  # Nextcloud (overwritecondaddr=^127\.0\.0\.1$, overwriteprotocol=https) and AFFiNE
-  # generate https links behind the TLS-terminating Tailscale Funnel.
+  # Nextcloud (overwritecondaddr=^127\.0\.0\.1$, overwriteprotocol=https) generates
+  # https links behind the TLS-terminating Tailscale Funnel.
   fwdHeaders = ''
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
@@ -47,31 +49,8 @@ in
     '';
 
     locations = {
-      # Bare URL used to be AFFiNE at root — send humans to /affine/.
-      "= /" = { return = "301 /affine/"; };
-
-      # AFFiNE human URL + API: forward the /affine prefix intact (NestJS global
-      # prefix — do NOT strip). Handles /affine, /affine/graphql, /affine/*.
-      "/affine" = {
-        proxyPass = "http://127.0.0.1:13010";
-        proxyWebsockets = true; # doc sync (graphql-ws / socket.io)
-        extraConfig = fwdHeaders;
-      };
-
-      # Catch-all: AFFiNE's web UI emits root-relative asset URLs (/js, /styles*.css,
-      # /manifest.json, lazy-loaded chunks) because the self-hosted build's frontend
-      # publicPath can't be pinned to /affine. Map every other root path onto the
-      # /affine backend (which serves the assets under the global prefix). More
-      # specific locations (/affine, /nextcloud/, /.well-known/*) win over this, so
-      # only AFFiNE's stray root assets land here. proxyPass has a URI with a
-      # trailing slash (/affine/) so nginx rewrites the leading "/" → "/affine/"
-      # (e.g. /js/x → /affine/js/x). Without the trailing slash it would emit
-      # /affinejs/x and 404.
-      "/" = {
-        proxyPass = "http://127.0.0.1:13010/affine/";
-        proxyWebsockets = true;
-        extraConfig = fwdHeaders;
-      };
+      # Bare URL → Nextcloud (the main human-facing app on this funnel).
+      "= /" = { return = "301 /nextcloud/"; };
 
       # Nextcloud: trailing slashes on both location and proxyPass strip /nextcloud
       # before forwarding to NC's root vhost.
@@ -86,6 +65,17 @@ in
           proxy_read_timeout 3600s;
           proxy_send_timeout 3600s;
         '';
+      };
+
+      # Cyrus: trailing slash on both strips /cyrus before forwarding. Cyrus's
+      # Fastify server mounts /callback, /linear-webhook, /github-webhook at its
+      # root, so /cyrus/linear-webhook → 3456/linear-webhook. proxyWebsockets in
+      # case any endpoint upgrades (harmless otherwise).
+      "= /cyrus" = { return = "301 /cyrus/"; };
+      "/cyrus/" = {
+        proxyPass = "http://127.0.0.1:3456/";
+        proxyWebsockets = true;
+        extraConfig = fwdHeaders;
       };
 
       # CalDAV/CardDAV auto-discovery at the domain root → Nextcloud's DAV endpoint.

--- a/rpi5/homepage-stats.py
+++ b/rpi5/homepage-stats.py
@@ -11,6 +11,7 @@ Endpoints:
   /paperless — Paperless (documents, inbox)
   /immich    — Immich (photos, videos, storage)
   /karakeep  — Karakeep (bookmarks, favorites, archived, tags) — direct read-only SQLite
+  /homeassistant — Home Assistant (people home, lights on, switches on) — /api/states
 
 Refresh cadence: 86400s (daily). Sure is socket-activated (rpi5/sure.nix)
 with a 600s idle timer; the daily poll wakes it briefly (~10 min), then
@@ -45,7 +46,7 @@ STATE_DIR = os.environ.get("STATE_DIRECTORY", "/var/lib/homepage-stats")
 STATE_FILE = os.path.join(STATE_DIR, "stats.json")
 REFRESH_INTERVAL = 86400  # seconds — see module docstring
 
-stats = {"sure": {}, "openwebui": {}, "paperless": {}, "immich": {}, "karakeep": {}}
+stats = {"sure": {}, "openwebui": {}, "paperless": {}, "immich": {}, "karakeep": {}, "homeassistant": {}}
 stats_lock = threading.Lock()
 
 
@@ -53,14 +54,17 @@ def fetch_sure():
     try:
         env = open(ENV_FILE).read()
         key = [l.split("=", 1)[1].strip() for l in env.strip().split("\n") if "SURE_KEY" in l][0]
+        # Sure is mounted under /sure now (RAILS_RELATIVE_URL_ROOT, see sure.nix),
+        # so its API lives at /sure/api/v1/* — the root path 404s. Hit :13334
+        # (socket-activate) so the daily poll wakes Puma briefly, then it sleeps.
         accts = json.loads(subprocess.check_output([
             CURL, "-sf",
-            "http://127.0.0.1:13334/api/v1/accounts",
+            "http://127.0.0.1:13334/sure/api/v1/accounts",
             "-H", f"X-Api-Key: {key}", "-H", "Accept: application/json"
         ]))
         txns = json.loads(subprocess.check_output([
             CURL, "-sf",
-            "http://127.0.0.1:13334/api/v1/transactions?per_page=1",
+            "http://127.0.0.1:13334/sure/api/v1/transactions?per_page=1",
             "-H", f"X-Api-Key: {key}", "-H", "Accept: application/json"
         ]))
         accounts = accts.get("accounts", [])
@@ -193,6 +197,33 @@ def fetch_karakeep():
             stats["karakeep"]["error"] = str(e)
 
 
+def fetch_homeassistant():
+    # HA is always-on (not socket-activated), so polling it doesn't wake anything.
+    # It's routed through this daily-cached aggregator only for consistency with
+    # the other tiles — note the counts can be up to REFRESH_INTERVAL stale.
+    try:
+        env = open(ENV_FILE).read()
+        token = [l.split("=", 1)[1].strip() for l in env.strip().split("\n") if "HA_TOKEN" in l][0]
+        states = json.loads(subprocess.check_output([
+            CURL, "-sf", "http://127.0.0.1:8123/api/states",
+            "-H", f"Authorization: Bearer {token}", "-H", "Content-Type: application/json"
+        ]))
+
+        def count(prefix, st):
+            return sum(1 for e in states
+                       if e.get("entity_id", "").startswith(prefix) and e.get("state") == st)
+
+        with stats_lock:
+            stats["homeassistant"] = {
+                "people_home": count("person.", "home"),
+                "lights_on":   count("light.", "on"),
+                "switches_on": count("switch.", "on"),
+            }
+    except Exception as e:
+        with stats_lock:
+            stats["homeassistant"]["error"] = str(e)
+
+
 def refresh(initial_fetched_at):
     last_fetched = initial_fetched_at
     while True:
@@ -207,6 +238,7 @@ def refresh(initial_fetched_at):
             fetch_paperless()
             fetch_immich()
             fetch_karakeep()
+            fetch_homeassistant()
             last_fetched = time.time()
             save_cache(last_fetched)
         except Exception as e:
@@ -228,6 +260,8 @@ class Handler(http.server.BaseHTTPRequestHandler):
                 data = dict(stats["immich"])
             elif self.path == "/karakeep":
                 data = dict(stats["karakeep"])
+            elif self.path == "/homeassistant":
+                data = dict(stats["homeassistant"])
             else:
                 data = {k: dict(v) for k, v in stats.items()}
         self.send_response(200)

--- a/rpi5/homepage.nix
+++ b/rpi5/homepage.nix
@@ -83,7 +83,7 @@ in
       HOMEPAGE_VAR_SURE_KEY=$(grep SURE_API_KEY ${config.age.secrets.picoclaw-env.path} | cut -d= -f2)
       HOMEPAGE_VAR_PAPERLESS_KEY=$(cat ${config.age.secrets.paperless-api-token.path})
       HOMEPAGE_VAR_HA_TOKEN=$(grep HA_TOKEN ${config.age.secrets.picoclaw-env.path} | cut -d= -f2)
-      HOMEPAGE_VAR_NEXTCLOUD_PASSWORD=$(cat ${config.age.secrets.nextcloud-homepage-password.path})
+      HOMEPAGE_VAR_NEXTCLOUD_PASSWORD=$(tr -d '\r\n' < ${config.age.secrets.nextcloud-homepage-password.path})
       ENVEOF
     '';
   };

--- a/rpi5/nextcloud.nix
+++ b/rpi5/nextcloud.nix
@@ -345,6 +345,33 @@ in
     wantedBy = [ "local-fs.target" ];
   }];
 
+  # ── serverinfo NC-Token for the homepage widget ──────────────────────────
+  # The homepage Nextcloud widget hits the serverinfo API, which accepts an
+  # `NC-Token` header. Basic auth as nsimon fails (401 — the homepage secret
+  # isn't nsimon's login password, and we won't reset the user's password for a
+  # stats tile). So set the serverinfo monitoring token to the existing
+  # nextcloud-homepage-password value; the widget authenticates with the same
+  # secret via `key` (HOMEPAGE_VAR_NEXTCLOUD_PASSWORD in homepage.nix). occ
+  # invalidates the appconfig cache; idempotent (same value each boot).
+  systemd.services.nextcloud-serverinfo-token = {
+    description = "Set Nextcloud serverinfo NC-Token for the homepage widget";
+    after    = [ "nextcloud-setup.service" "phpfpm-nextcloud.service" ];
+    requires = [ "nextcloud-setup.service" ];
+    wantedBy = [ "multi-user.target" ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+    };
+    script = ''
+      # The secret file has a stray trailing CR (\r); occ would store it as part
+      # of the token, but the widget's NC-Token HTTP header drops the \r → the
+      # stored token (73 bytes) wouldn't match the header (72) → 401. Strip
+      # CR/LF so the stored token is the clean 72-char value.
+      ${config.services.nextcloud.occ}/bin/nextcloud-occ config:app:set serverinfo token \
+        --value="$(tr -d '\r\n' < /run/agenix/nextcloud-homepage-password)"
+    '';
+  };
+
   # ── Pre-seed Nextcloud Mail with a hydroxide-backed ProtonMail account ────
   # Runs once on first activation (sentinel-gated). Reads the bridge password
   # from agenix and registers it with the Mail app via occ. Idempotent.

--- a/rpi5/services-registry.nix
+++ b/rpi5/services-registry.nix
@@ -26,14 +26,15 @@
       widget = {
         type = "nextcloud";
         url = "http://127.0.0.1:8091";
-        username = "nsimon";
-        password = "{{HOMEPAGE_VAR_NEXTCLOUD_PASSWORD}}";
+        # serverinfo NC-Token (set to nextcloud-homepage-password by the
+        # nextcloud-serverinfo-token oneshot). Basic auth as nsimon 401s.
+        key = "{{HOMEPAGE_VAR_NEXTCLOUD_PASSWORD}}";
         fields = [ "freespace" "activeusers" "numfiles" "numshares" ];
       }; }
-    { port = 443;   backend = "http://127.0.0.1:13010"; name = "AFFiNE";         icon = "affine.svg";         category = "Apps"; description = "Collaborative docs"; proxied = true; path = "/affine";
+    { port = 8443; backend = "http://127.0.0.1:13010"; name = "AFFiNE";         icon = "affine.svg";         category = "Apps"; description = "Collaborative docs"; funnel = true;
       widget = {
         type = "customapi";
-        url = "http://127.0.0.1:13010/affine/graphql";
+        url = "http://127.0.0.1:13010/graphql";
         method = "POST";
         headers = { "Content-Type" = "application/json"; "Authorization" = "Bearer {{HOMEPAGE_VAR_AFFINE_TOKEN}}"; };
         requestBody = { query = "{ workspaces { memberCount blobsSize docs(pagination: {first: 0}) { totalCount } } }"; };
@@ -128,18 +129,22 @@
     { port = 4001;  backend = "http://127.0.0.1:4001";  name = "tiny-llm-gate";  icon = "mdi-brain";          category = "Backend"; description = "LLM gateway (OpenAI + Gemini)"; }
     { port = 4040;  backend = "http://127.0.0.1:4040";  name = "Codex Proxy";    icon = "mdi-code-braces";    category = "Backend"; description = "ChatGPT OAuth proxy (token counts + tool_calls)"; }
     { port = 7020;  backend = "http://127.0.0.1:4001/mcp/affine"; name = "AFFiNE MCP"; icon = "mdi-api";       category = "Backend"; description = "AFFiNE MCP gateway (via tiny-llm-gate)"; }
-    # Hydroxide moved 8443 → 8083 (matches its backend port) to free 8443 for
-    # Cyrus's Tailscale Funnel slot (Linear webhooks need a public URL, and
-    # only 443/8443/10000 are funnel-eligible; 443 + 10000 are also taken).
+    # Hydroxide moved 8443 → 8083 (matches its backend port) to free the 8443
+    # Funnel slot (only 443/8443/10000 are funnel-eligible; 443 + 10000 are also
+    # taken). 8443 now fronts AFFiNE at its root origin (see the AFFiNE entry).
     # Devices using https://rpi5.gate-mintaka.ts.net:8443/.well-known/carddav
     # must update to :8083.
     { port = 8083;  backend = "http://127.0.0.1:8083";  name = "Hydroxide";      icon = "mdi-email-outline";  category = "Backend";  description = "ProtonMail bridge (SMTP + CardDAV)"; }
-    { port = 8443;  backend = "http://127.0.0.1:3456";  name = "Cyrus";          icon = "mdi-robot-outline";  category = "Backend"; description = "Linear coding-agent (cyrusagents/cyrus)"; funnel = true; }
+    # Cyrus is fronted by the 443 nginx path-mux at /cyrus (prefix stripped). Its
+    # public URL (CYRUS_BASE_URL in cyrus.nix) is https://…/cyrus, and its
+    # hardcoded root routes (/callback, /linear-webhook, /github-webhook) sit
+    # under it. AFFiNE took the freed 8443 Funnel slot (it needs a root origin).
+    { port = 443;   backend = "http://127.0.0.1:3456";  name = "Cyrus";          icon = "mdi-robot-outline";  category = "Backend"; description = "Linear coding-agent (cyrusagents/cyrus)"; proxied = true; path = "/cyrus"; }
 
     # Infrastructure — not shown on dashboard
     # Single public 443 Funnel → nginx path-mux (front-proxy.nix), which routes
-    # /affine → AFFiNE and /nextcloud → Nextcloud (both `proxied = true` above).
-    { port = 443;   backend = "http://127.0.0.1:8092";  name = "Front Proxy";    icon = "mdi-sitemap";        category = "Infrastructure"; description = "nginx 443 path-mux (/affine, /nextcloud)"; funnel = true; }
+    # /nextcloud → Nextcloud and /cyrus → Cyrus (both `proxied = true` above).
+    { port = 443;   backend = "http://127.0.0.1:8092";  name = "Front Proxy";    icon = "mdi-sitemap";        category = "Infrastructure"; description = "nginx 443 path-mux (/nextcloud, /cyrus)"; funnel = true; }
     { port = 8082;  backend = "http://127.0.0.1:8082";  name = "Homepage";       icon = "homepage.svg";       category = "Infrastructure"; description = "Service dashboard"; }
     { port = 8088;  backend = "http://127.0.0.1:8088";  name = "Claude Notify";  icon = "mdi-bell";           category = "Infrastructure"; description = "Debounced agent → Telegram aggregator"; noSiteMonitor = true; }
   ];

--- a/rpi5/services-registry.nix
+++ b/rpi5/services-registry.nix
@@ -45,7 +45,7 @@
           { field = "data.workspaces.0.blobsSize"; label = "Storage"; format = "bytes"; }
         ];
       }; }
-    { port = 3333;  backend = "http://127.0.0.1:13334"; name = "Sure";           icon = "maybe.svg";          category = "Apps"; description = "Personal finance"; noSiteMonitor = true;
+    { port = 443;   backend = "http://127.0.0.1:13334"; name = "Sure";           icon = "maybe.svg";          category = "Apps"; description = "Personal finance"; noSiteMonitor = true; proxied = true; path = "/sure";
       widget = {
         type = "customapi";
         url = "http://127.0.0.1:8087/sure";
@@ -101,10 +101,19 @@
         ];
       }; }
     { port = 8123;  backend = "http://127.0.0.1:8123";  name = "Home Assistant"; icon = "home-assistant.svg"; category = "Apps"; description = "Home automation";
+      # Routed through the homepage-stats aggregator (:8087, daily-cached) like the
+      # other customapi tiles rather than the native `homeassistant` widget that
+      # polls HA directly. Counts can be up to the aggregator's REFRESH_INTERVAL
+      # (24h) stale — acceptable for a glanceable tile; the aggregator holds the
+      # HA token, so no key is exposed here.
       widget = {
-        type = "homeassistant";
-        url = "http://127.0.0.1:8123";
-        key = "{{HOMEPAGE_VAR_HA_TOKEN}}";
+        type = "customapi";
+        url = "http://127.0.0.1:8087/homeassistant";
+        mappings = [
+          { field = "people_home"; label = "Home";     format = "number"; }
+          { field = "lights_on";   label = "Lights";   format = "number"; }
+          { field = "switches_on"; label = "Switches"; format = "number"; }
+        ];
       }; }
     { port = 3000;  backend = "http://127.0.0.1:8090";  name = "Beszel";         icon = "beszel.svg";         category = "Apps"; description = "System monitoring";
       widget = {

--- a/rpi5/sure.nix
+++ b/rpi5/sure.nix
@@ -100,7 +100,9 @@ in
     backend   = "127.0.0.1:${toString backendPort}";
     idleSec   = 600;
     readyProbe = {
-      url          = "http://127.0.0.1:${toString backendPort}/up";
+      # App mounts under /sure (Rack::URLMap, keyed on RAILS_RELATIVE_URL_ROOT
+      # set on sure-web below), so the root /up now 404s — probe /sure/up.
+      url          = "http://127.0.0.1:${toString backendPort}/sure/up";
       expectStatus = 200;
       timeoutSec   = 60;
     };
@@ -116,12 +118,18 @@ in
     SIDEKIQ_CONCURRENCY  = "1";  # default 5 — personal app only needs 1 worker thread
     MALLOC_ARENA_MAX     = "2";
     RUBY_YJIT_ENABLE     = "0";  # YJIT JIT-compiles into memory; not worth it for low-traffic personal app
+    RAILS_RELATIVE_URL_ROOT = "/sure";  # match sure-web so job/mailer URLs prefix /sure
   } // sureLlmEnv;
   systemd.services.sure-web.environment = {
     WEB_CONCURRENCY  = "0";  # single-process Puma (no forked workers) — saves ~80 MB on RPi5
     RAILS_MAX_THREADS = "3";  # default 5; 3 is plenty for single-user
     MALLOC_ARENA_MAX = "2";
     RUBY_YJIT_ENABLE = "0";
+    # Serve under /sure on the 443 path-mux (front-proxy.nix). sure-nix's
+    # config.ru mounts the app via Rack::URLMap when this is set, so redirects
+    # and path-helpers prefix /sure (assets already do via relative_url_root).
+    # The proxy passes /sure through UNCHANGED — URLMap does the internal strip.
+    RAILS_RELATIVE_URL_ROOT = "/sure";
   } // sureLlmEnv;
 
   # sure-setup (migrations) must run after the password is set


### PR DESCRIPTION
Reshuffles the public Funnel layout so each app runs where it works, and tidies two homepage widgets.

## Front-proxy / Funnel layout
Funnel-eligible ports are only 443 / 8443 / 10000. New split:
- **AFFiNE → root of :8443** — its SPA router insists on root paths (a `/affine` sub-path made it bounce to root `/workspace/…`). `SUB_PATH` dropped, `EXTERNAL_URL→:8443`. No proxy rewrites.
- **Cyrus → 443 path-mux `/cyrus/`** (prefix stripped) — webhook receiver, hardcoded root routes, single `CYRUS_BASE_URL` knob.
- **Sure → 443 path-mux `/sure/`** (prefix **passed through** — Rails needs a real `SCRIPT_NAME`). sure-nix gains a `Rack::URLMap` postPatch keyed on `RAILS_RELATIVE_URL_ROOT`; flake relocked to it (still Sure 0.7.2). Moves off the `:3333` serve.
- **Nextcloud** unchanged (`/nextcloud/`) + homepage serverinfo widget.

## Homepage widgets
- **Home Assistant** tile now reads the `:8087` daily-cached aggregator (new `/homeassistant` endpoint) instead of polling HA directly — consistent with the other tiles. (Counts up to 24h stale; HA is always-on so nothing is woken.)
- Fixed `fetch_sure` in the aggregator to use `/sure/api/v1/*` after the subpath move.

## Verified live
- AFFiNE `:8443` root: `publicPath="/"`, graphql 200.
- Cyrus `/cyrus/`: `POST /cyrus/linear-webhook → 403` (route reached).
- Sure `/sure/`: `302 → /sure/sessions/new`, login 200, assets `/sure/assets/*`, form action `/sure/sessions`, backend `/sure/up → 200`.
- Aggregator: Sure `{net_worth,…}` ✅, Home Assistant `{people_home,lights_on,switches_on}` ✅.

## External re-registration
- ✅ GitHub webhooks (7 repos) → `…/cyrus/github-webhook`.
- ⏳ Linear OAuth app (dashboard): callback `…/cyrus/callback`, webhook `…/cyrus/linear-webhook`.
- ⏳ AFFiNE clients repoint to `:8443`.