### PR TITLE
fix(mcp): point firecrawl at self-hosted staging tailnet endpoint

### DIFF
--- a/home/mcp.nix
+++ b/home/mcp.nix
@@ -39,7 +39,11 @@ let
     "trusk-github"      = { type = "http"; url = "https://ai-gitnexus-mcp.tail271d7a.ts.net/mcp"; };
     "trusk-context7"    = { type = "sse";  url = "https://ai-supergateway-context7.tail271d7a.ts.net/sse"; };
     "trusk-steampipe"   = { type = "sse";  url = "https://ai-steampipe-mcp.tail271d7a.ts.net/sse"; };
-    firecrawl           = { type = "http"; url = "https://mcp.firecrawl.dev/fc-c6a062b4ff1849d3991eeb116c0632a4/v2/mcp"; };
+    # Self-hosted Firecrawl on the work tailnet (staging). Migrated off the
+    # public cloud (mcp.firecrawl.dev) per Tristan's 2026-07-06 announcement:
+    # no rate limiting, query freely. Only reachable over the work Tailscale
+    # tunnel — same reachability caveat as the trusk-* gateways above.
+    firecrawl           = { type = "http"; url = "https://ai-firecrawl-mcp.tail271d7a.ts.net/mcp"; };
 
     # Private — secrets loaded at runtime via wrapper scripts
     GitHub  = { command = "${githubMcp}"; };


### PR DESCRIPTION
Migrate the `firecrawl` MCP off the public cloud (`mcp.firecrawl.dev`, API-keyed and rate-limited) to the **self-hosted staging** server on the work tailnet, per [Tristan's 2026-07-06 announcement](https://trusk.slack.com/archives/C01DTGRAYRK/p1783346654287419) — no rate limiting, query freely.

```json
"firecrawl": { "type": "http", "url": "https://ai-firecrawl-mcp.tail271d7a.ts.net/mcp" }
```

- Keeps the server key `firecrawl` so tool names (`mcp__firecrawl__*`) and skill references (deep-research, etc.) stay stable.
- Now **tailnet-only** — same reachability caveat as the other `trusk-*` gateways (breaks off the work tunnel, unlike the old cloud URL).

**Verified:** `home-manager switch` regenerates the `--mcp-config` JSON with the new URL. Takes effect in a new `claude` session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VY2JWsJphYsnzFaMfvmkCr