### PR TITLE
fix(claude): auto-resume on "session limit" hard-cap (mac bump + rpi5 banner)

### DIFF
--- a/home/claude.nix
+++ b/home/claude.nix
@@ -156,12 +156,22 @@ in
     # claude-auto-retry config (read at runtime by the monitor). marginSeconds
     # waits a bit past the parsed reset; fallbackWaitHours bounds the wait when
     # no reset time is parseable; retryMessage is what's sent via send-keys.
+    # customPatterns: the vendored 0.2.2 LIMIT_PATTERNS don't match Claude
+    # Code's current hard-cap wording "You've hit your session limit · resets
+    # 6pm" (the word "session"/"weekly" sits between "your" and "limit", which
+    # the built-in `your\s*limit` regex rejects), so a real cap was never
+    # detected and never auto-resumed. These custom patterns are matched
+    # against the full captured pane text and cover the session/weekly wording.
     ".claude-auto-retry.json".text = builtins.toJSON {
       maxRetries = 5;
       pollIntervalSeconds = 5;
       marginSeconds = 60;
       fallbackWaitHours = 5;
       retryMessage = "continue";
+      customPatterns = [
+        "hit your (session|weekly|usage) limit"
+        "(session|weekly) limit reached"
+      ];
     };
 
     # PostToolUse hook: mirror writes under

--- a/home/claude.nix
+++ b/home/claude.nix
@@ -77,10 +77,14 @@ let
   # regardless of the caller's environment.
   claudeAutoRetry = pkgs.stdenvNoCC.mkDerivation rec {
     pname = "claude-auto-retry";
-    version = "0.2.2";
+    # >=0.4 detects Claude Code's current hard-cap wording "You've hit your
+    # session/weekly limit" (0.2.2's LIMIT_PATTERNS required `your`/`the`
+    # adjacent to `limit`, so the qualifier word broke detection and caps were
+    # never auto-resumed). Fixed upstream, so no local pattern override needed.
+    version = "0.5.1";
     src = pkgs.fetchurl {
       url = "https://registry.npmjs.org/claude-auto-retry/-/claude-auto-retry-${version}.tgz";
-      hash = "sha256-HnyMESM6LxzbexWE+vB0b/iFy8ywsaT43BvPRBaMajw=";
+      hash = "sha256-tH4XxtjlTgvX5Ovp3d/U26m2uMjd9BozFmC6clMlt5s=";
     };
     nativeBuildInputs = [ pkgs.makeWrapper ];
     dontConfigure = true;
@@ -156,22 +160,12 @@ in
     # claude-auto-retry config (read at runtime by the monitor). marginSeconds
     # waits a bit past the parsed reset; fallbackWaitHours bounds the wait when
     # no reset time is parseable; retryMessage is what's sent via send-keys.
-    # customPatterns: the vendored 0.2.2 LIMIT_PATTERNS don't match Claude
-    # Code's current hard-cap wording "You've hit your session limit · resets
-    # 6pm" (the word "session"/"weekly" sits between "your" and "limit", which
-    # the built-in `your\s*limit` regex rejects), so a real cap was never
-    # detected and never auto-resumed. These custom patterns are matched
-    # against the full captured pane text and cover the session/weekly wording.
     ".claude-auto-retry.json".text = builtins.toJSON {
       maxRetries = 5;
       pollIntervalSeconds = 5;
       marginSeconds = 60;
       fallbackWaitHours = 5;
       retryMessage = "continue";
-      customPatterns = [
-        "hit your (session|weekly|usage) limit"
-        "(session|weekly) limit reached"
-      ];
     };
 
     # PostToolUse hook: mirror writes under

--- a/rpi5/claude-rc-autoresume.py
+++ b/rpi5/claude-rc-autoresume.py
@@ -9,19 +9,23 @@ the cap window resets.
 
 Per tick (driven by a systemd timer) it:
   1. Enumerates active bridge sessions from ~/.claude/sessions/*.json.
-  2. Reads the tail of each session's conversation JSONL and finds the most
-     recent `rate_limit_event`. If that event's status is a *blocking* one
-     (the session is capped, not merely warned) it records resetsAt.
+  2. Reads the tail of each session's conversation JSONL and detects a hard cap
+     from either signal: a structured `rate_limit_event` with a *blocking*
+     status, or an `isApiErrorMessage` assistant banner ("You've hit your
+     session limit · resets 6pm"). resetsAt comes from the event or is parsed
+     out of the banner text.
   3. Once now >= resetsAt + margin, and the conversation has not advanced past
      the cap event, it resumes the session:
        - DRY-RUN (default): logs + Telegram-notifies the planned resume.
        - LIVE: `claude -p --resume <sessionId> "<message>"` in the session cwd.
   4. A state file makes each (sessionId, resetsAt) act at most once.
 
-DRY-RUN is the default because a real cap-denial event has not yet been
-observed in the wild — only `allowed_warning`. Dry-run is self-documenting:
-it logs every rate_limit_event it sees and whether it deems it blocking, so the
-first real cap reveals the true status string before any live action is taken.
+The real hard cap does NOT arrive as a structured `rate_limit_event` — those
+only carry warnings (status=allowed_warning, rateLimitType=seven_day). An actual
+cap is an assistant message flagged isApiErrorMessage with the banner text
+"You've hit your session limit · resets <time> (<tz>)", which detect_cap() now
+matches and whose reset time parse_reset_epoch() extracts. CRC_DRY_RUN=1 logs
+the planned resume instead of performing it.
 
 Config is via environment (set by the NixOS service):
   CRC_DRY_RUN            "1" (default) = log/notify only; "0" = perform resume
@@ -38,11 +42,18 @@ Config is via environment (set by the NixOS service):
 """
 import json
 import os
+import re
 import subprocess
 import sys
 import time
 import urllib.request
+from datetime import datetime, timedelta
 from pathlib import Path
+
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:  # pragma: no cover — zoneinfo is stdlib on py>=3.9
+    ZoneInfo = None
 
 HOME = Path(os.environ.get("HOME", "/home/nsimon"))
 DRY_RUN = os.environ.get("CRC_DRY_RUN", "1") != "0"
@@ -126,22 +137,129 @@ def tail_lines(path, n):
         return []
 
 
-def last_rate_limit_event(lines):
-    """Return (status, resets_at, rate_type) of the last rate_limit_event, or None."""
+# The bridge writes a real hard-cap NOT as a structured rate_limit_event but as
+# an assistant message flagged isApiErrorMessage whose text is the human banner
+# "You've hit your session limit · resets 6pm (Europe/Paris)". Structured
+# rate_limit_event records only ever carry *warnings* (status=allowed_warning,
+# rateLimitType=seven_day). So we detect both: a structured event with a
+# blocking status, or the banner (and parse its reset time from the text).
+BANNER_RE = re.compile(
+    r"(?:hit|reached|exceeded)\b.{0,40}?\blimit\b"  # "hit your session limit"
+    r"|usage limit"
+    r"|rate limit"
+    r"|out of\b.{0,20}?usage",
+    re.I | re.S,
+)
+_RESET_ABS_RE = re.compile(
+    r"resets?\s+(?:at\s+)?(\d{1,2})(?::(\d{2}))?\s*([ap]m)\b", re.I
+)
+_RESET_REL_RE = re.compile(
+    r"(?:resets?\s+in|try again in)\s+(\d+)\s*(hours?|minutes?|h|m)\b", re.I
+)
+_TZ_RE = re.compile(r"\(([A-Za-z]+(?:/[A-Za-z_+-]+)?)\)")
+
+
+def parse_reset_epoch(text, now=None):
+    """Parse a reset time out of a cap banner into an epoch (UTC seconds), or None.
+
+    Handles "resets 6pm (Europe/Paris)", "resets at 3:30pm (UTC)", "Resets 2pm"
+    (no tz -> local), and relative "resets in 5 hours". Absolute times resolve to
+    the next future occurrence in the stated timezone. Returns None if no time is
+    parseable, so the caller never resumes on an unknown reset window.
+    """
+    rel = _RESET_REL_RE.search(text)
+    if rel:
+        n = int(rel.group(1))
+        unit = rel.group(2).lower()
+        secs = n * 3600 if unit.startswith("h") else n * 60
+        return int((now.timestamp() if now else time.time())) + secs
+
+    m = _RESET_ABS_RE.search(text)
+    if not m:
+        return None
+    hour = int(m.group(1)) % 12
+    if m.group(3).lower() == "pm":
+        hour += 12
+    minute = int(m.group(2) or 0)
+
+    tz = None
+    tzm = _TZ_RE.search(text)
+    if tzm and ZoneInfo:
+        try:
+            tz = ZoneInfo(tzm.group(1))
+        except Exception:  # noqa: BLE001 — unknown tz -> fall back to local
+            tz = None
+    if now is None:
+        base = datetime.now(tz)
+    else:
+        # Anchor to when the cap occurred (the banner's own timestamp), in the
+        # reset's timezone, so "resets 6pm" resolves to the same-day 6pm even
+        # when we detect the cap a few minutes/hours later.
+        base = now.astimezone(tz) if tz else now
+    target = base.replace(hour=hour, minute=minute, second=0, microsecond=0)
+    if target <= base:
+        target += timedelta(days=1)
+    return int(target.timestamp())
+
+
+def _message_text(obj):
+    msg = obj.get("message") or {}
+    content = msg.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return " ".join(
+            b.get("text", "")
+            for b in content
+            if isinstance(b, dict) and b.get("type") == "text"
+        )
+    return ""
+
+
+def _is_api_error(obj):
+    msg = obj.get("message") or {}
+    return bool(obj.get("isApiErrorMessage") or msg.get("isApiErrorMessage"))
+
+
+def _parse_ts(ts):
+    """Parse a JSONL record's ISO-8601 timestamp into an aware datetime, or None."""
+    if not ts:
+        return None
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def detect_cap(lines):
+    """Return (resets_at, label) for the most recent hard cap, or None.
+
+    Scans newest-first for either a blocking structured rate_limit_event or an
+    isApiErrorMessage banner. Non-blocking structured events (warnings) are
+    skipped so an older real cap below them is still found. resets_at may be None
+    when a banner's reset time can't be parsed — the caller then skips rather
+    than resuming blind.
+    """
     for line in reversed(lines):
-        if '"rate_limit_event"' not in line:
+        if "rate_limit_event" not in line and "isApiErrorMessage" not in line:
             continue
         try:
             obj = json.loads(line)
         except Exception:  # noqa: BLE001
             continue
+
         info = obj.get("rate_limit_info") or {}
         if obj.get("type") == "rate_limit_event" and info:
-            return (
-                info.get("status"),
-                info.get("resetsAt"),
-                info.get("rateLimitType"),
-            )
+            status = info.get("status")
+            if status in BLOCKING and info.get("resetsAt"):
+                return (int(info["resetsAt"]), f"event:{status}:{info.get('rateLimitType')}")
+            continue  # warning/non-blocking — keep scanning older lines
+
+        if _is_api_error(obj):
+            text = _message_text(obj)
+            if text and BANNER_RE.search(text):
+                anchor = _parse_ts(obj.get("timestamp"))
+                return (parse_reset_epoch(text, now=anchor), f"banner:{text.strip()[:70]}")
     return None
 
 
@@ -205,13 +323,15 @@ def main():
         jsonl = jsonl_path_for(cwd, sid)
         if not jsonl:
             continue
-        ev = last_rate_limit_event(tail_lines(jsonl, TAIL_LINES))
-        if not ev:
+        cap = detect_cap(tail_lines(jsonl, TAIL_LINES))
+        if not cap:
             continue
-        status, resets_at, rate_type = ev
-        blocking = status in BLOCKING
-        log(f"session {sid[:8]}: last rate_limit_event status={status} blocking={blocking} resetsAt={resets_at} type={rate_type}")
-        if not blocking or not resets_at:
+        resets_at, label = cap
+        log(f"session {sid[:8]}: cap detected [{label}] resetsAt={resets_at}")
+        if not resets_at:
+            # Banner matched but its reset time was unparseable — never resume
+            # blind (we'd risk hammering an unreset cap). Surface it and move on.
+            log(f"session {sid[:8]}: reset time unparseable — skipping")
             continue
         n_capped += 1
         key = f"{sid}:{resets_at}"
@@ -219,11 +339,11 @@ def main():
             continue  # already handled this cap window
         if now < int(resets_at) + MARGIN:
             wait = int(resets_at) + MARGIN - now
-            log(f"session {sid[:8]} capped ({rate_type}); reset in {wait}s — waiting")
+            log(f"session {sid[:8]} capped [{label}]; reset in {wait}s — waiting")
             continue
         # Reset window has passed: act once, and only if not already advanced.
         resume(session, jsonl)
-        state[key] = {"sessionId": sid, "cwd": cwd, "resetsAt": resets_at, "actedAt": now, "dryRun": DRY_RUN}
+        state[key] = {"sessionId": sid, "cwd": cwd, "resetsAt": resets_at, "label": label, "actedAt": now, "dryRun": DRY_RUN}
         n_acted += 1
     save_state(state)
     log(f"tick done: sessions={n_sessions} capped={n_capped} acted={n_acted} dry_run={DRY_RUN}")


### PR DESCRIPTION
Neither auto-resume path recognized Claude Code’s real hard-cap, which arrives as the banner **"You’ve hit your session limit · resets 6pm (Europe/Paris)"** — caps went undetected and sessions sat stalled past reset (e.g. the `airtrail` bridge session on the rpi5).

## Root cause
- **mac** (`claude-auto-retry`, pinned 0.2.2): its `LIMIT_PATTERNS` required `your`/`the` *adjacent* to `limit`, so "your **session** limit" never matched and the tmux monitor never entered its wait/resume state.
- **rpi5** (`rpi5/claude-rc-autoresume.py`): only scanned for a structured `rate_limit_event`, but those records only ever carry **warnings** (`allowed_warning`/`seven_day`). The real cap is an `isApiErrorMessage` assistant banner — invisible to the detector (every tick logged `capped=0`).

## Fix
- **mac**: bump the pin **0.2.2 → 0.5.1**. Upstream already fixed the wording (allows a qualifier word between `your` and `limit`, with tests for session/weekly), so no local override is needed — the earlier `customPatterns` workaround is dropped.
- **rpi5**: `detect_cap()` now matches the banner in addition to structured events, and `parse_reset_epoch()` extracts the reset time — timezone-aware, anchored to the cap message’s own timestamp so a late detection still resolves same-day 6pm. Unparseable reset → skip (never resume blind).

## Verification
- Local unit tests for `parse_reset_epoch`/`detect_cap` (incl. the exact airtrail banner) — pass.
- Upstream 0.5.1 `patterns.js` tests (47) pass, incl. the session/weekly cases; verified 0.5.1 keeps the `bin/cli.js` + `src/launcher.js` entrypoints the derivation wraps; tarball hash from `nix-prefetch-url`.
- Dry-run of the fixed rpi5 script against **live data**: `session 911748ee: cap detected [banner:…] resetsAt=1783353600` → `capped=1 acted=1` (was `capped=0`).

## Deploy note
Takes effect after `home-manager switch` (mac) and a NixOS rebuild on the rpi5. Already-running mac monitors pick up the new binary only on a fresh `claude` launch.