### PR TITLE
feat(home-assistant): add ha-intratone custom component

### DIFF
--- a/rpi5/home-assistant.nix
+++ b/rpi5/home-assistant.nix
@@ -21,6 +21,28 @@ let
     };
   };
 
+  # ha-intratone: reverse-engineered integration for the Intratone (Cogelec)
+  # cloud intercom. Goal here is on-demand remote door open via the "Clé mobile"
+  # / mobipass access locks (pure REST, POST /api/access/open/clemobil) — the
+  # visiophone audio/video path (go2rtc + ffmpeg) is left off (video opt-in,
+  # default false). Python deps are pulled from HA's own (unstable-overridden)
+  # python set so they match the ABI of the HA binary.
+  haIntratone = pkgs.buildHomeAssistantComponent rec {
+    owner = "GuiHash";
+    domain = "intratone";
+    version = "0.3.2";
+    src = pkgs.fetchFromGitHub {
+      owner = "GuiHash";
+      repo = "ha-intratone";
+      rev = "v${version}";
+      hash = "sha256-BkvdaY1oacmZM+bqTzxBf36G1jTkYK0wbxJRb4oIonY=";
+    };
+    dependencies = with config.services.home-assistant.package.python3Packages; [
+      firebase-messaging
+      voip-utils
+    ];
+  };
+
   # ha-linky: TypeScript/Node.js Linky → Home Assistant bridge.
   # config.ts hardcodes /data/options.json; the service uses BindReadOnlyPaths
   # to mount /etc/home-assistant/ha-linky at /data inside the unit's namespace.
@@ -59,7 +81,7 @@ in
     enable = true;
     # null = leave configuration.yaml unmanaged; HA (and the user) owns it directly
     config = null;
-    customComponents = [ haVoltalis ];
+    customComponents = [ haVoltalis haIntratone ];
     extraComponents = [
       # Already in the module's aarch64 defaults: default_config, met, esphome, rpi_power
       "homekit"    # HomeKit bridge — uses zeroconf/mDNS


### PR DESCRIPTION
## What

Wires [`GuiHash/ha-intratone`](https://github.com/GuiHash/ha-intratone) v0.3.2 into the native Home Assistant service as a custom component, following the existing `haVoltalis` pattern.

The Intratone (Cogelec) intercom is a GSM/cloud system with no local wiring into the flat and no official API — this integration is reverse-engineered (`sip.intratone.info` REST + FCM push + SIP). Target use here is **on-demand remote door open** via the *Clé mobile* / **mobipass** access locks (`POST /api/access/open/clemobil`, pure REST). The visiophone audio/video path (go2rtc + ffmpeg) is left **opt-in / off** (video defaults `false`), so no go2rtc stream slot is required.

## How

- New `haIntratone = pkgs.buildHomeAssistantComponent` pinned to tag `v0.3.2`.
- Python deps (`firebase-messaging` ≥0.4.0, `voip-utils` ≥0.3.0 — both already in nixpkgs) are pulled from `config.services.home-assistant.package.python3Packages` so they match the ABI of the unstable-overridden HA binary (Python 3.14).
- Added to `services.home-assistant.customComponents`.

## Verification

- Rebuilt on rpi5 (`nixos-rebuild-safe switch`) — exit 0.
- HA restarts cleanly on :8123; journal shows `intratone` imported with only the standard "custom integration not tested by Home Assistant" warning — **no `ModuleNotFoundError` for `intratone`/`firebase`/`voip`**, confirming deps resolved.

## Pending (post-merge, manual)

Pairing requires an invite code from the official Intratone app (*Mes infos → Ajouter un appareil*) entered via Settings → Devices & Services → Add Integration → Intratone. Whether on-demand open is available depends on the building's access mode (`data`/`ble` → works; legacy `clemobil` → call-gated only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)