### PR TITLE
fix(claude-rc): isolated CLAUDE_CONFIG_DIR to clear the api.anthropic.com Remote Control guard

### DIFF
--- a/rpi5/claude-rc-worktree-gate.sh
+++ b/rpi5/claude-rc-worktree-gate.sh
@@ -1,0 +1,36 @@
+# post-checkout hook (managed by claude-remote-control.nix, symlinked into
+# .git/hooks/post-checkout at bridge start).
+#
+# When the Remote Control bridge spawns an isolated worktree for a mobile /
+# claude.ai session, that worker inherits the bridge's isolated CLAUDE_CONFIG_DIR
+# (~/.claude-rc), whose settings.json forces ANTHROPIC_BASE_URL=api.anthropic.com
+# to satisfy the Remote Control guard. Workers themselves do NOT run that guard,
+# so we re-gate them here: drop a project-level settings.json in the new worktree
+# pointing the base URL back at the Aperture gate, restoring observability for
+# remote-control session traffic. (The bridge's own control-plane stays direct.)
+#
+# Guarded by CLAUDE_CONFIG_DIR so it is a fast no-op for the user's normal
+# checkouts and for other agents' worktrees. Never overwrites an existing
+# settings.json.
+
+case "${CLAUDE_CONFIG_DIR:-}" in
+  */.claude-rc) ;;
+  *) exit 0 ;;
+esac
+
+top=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+case "$top" in
+  */.claude/worktrees/*) ;;
+  *) exit 0 ;;
+esac
+
+[ -f "$top/.claude/settings.json" ] && exit 0
+
+# Single source of truth = the real user settings' gate URL; fall back to the
+# known gate host if jq or the file is unavailable.
+gate=$(jq -r '.env.ANTHROPIC_BASE_URL // empty' "$HOME/.claude/settings.json" 2>/dev/null || true)
+[ -n "$gate" ] || gate="https://ai.gate-mintaka.ts.net"
+
+mkdir -p "$top/.claude"
+printf '{"env":{"ANTHROPIC_BASE_URL":"%s"}}\n' "$gate" > "$top/.claude/settings.json"
+exit 0

--- a/rpi5/claude-remote-control.nix
+++ b/rpi5/claude-remote-control.nix
@@ -21,6 +21,21 @@ let
   projectsDir = "/home/${username}/.claude/projects";
   worktreesDir = "/home/${username}/nic-os/.claude/worktrees";
 
+  # Isolated CLAUDE_CONFIG_DIR for the bridge only. Remote Control in
+  # claude-code >= 2.1.x hard-refuses any API endpoint other than
+  # api.anthropic.com — the guard's bypass hook is compiled to always-false, so
+  # there is no env escape. But ~/.claude/settings.json forces the Aperture gate
+  # URL globally, and settings.json `env` outranks process env, so the bridge
+  # tripped the guard and exited 0 on every start (masked as active by
+  # RemainAfterExit; respawned every 5min by the watchdog). We shadow the real
+  # config here: symlink all state so OAuth, sessions/projects, skills, and the
+  # credentials.json that claude-oauth-extract watches stay authoritative in
+  # ~/.claude, and generate a settings.json whose only change is the base URL
+  # forced to direct Anthropic — the same escape the `claude-direct` shell alias
+  # already uses. Sessions the bridge spawns inherit this dir (direct Anthropic,
+  # bypassing the gate) which matches that established choice.
+  configDir = "/home/${username}/.claude-rc";
+
   # Extracts the current OAuth access token from ~/.claude/.credentials.json
   # and writes it atomically to /run/claude-oauth/token. The long-running
   # claude-remote-control process keeps credentials.json fresh by refreshing
@@ -75,10 +90,36 @@ let
     ${pkgs.tmux}/bin/tmux kill-session -t ${sessionName} 2>/dev/null || true
   '';
 
+  # Build the isolated bridge config dir (see configDir note above) before each
+  # start, refreshing symlinks and regenerating settings.json so it tracks any
+  # change to the real ~/.claude/settings.json.
+  prepConfigScript = pkgs.writeShellScript "claude-rc-prep-config" ''
+    set -eu
+    export PATH="${pkgs.jq}/bin:${pkgs.coreutils}/bin:$PATH"
+    src="/home/${username}/.claude"
+    dst="${configDir}"
+    mkdir -p "$dst"
+    # Mirror every real config entry as a symlink (credentials, sessions,
+    # projects, skills, plugins, settings.local.json, ...) except settings.json,
+    # which is generated below. Keeps all state authoritative in ~/.claude.
+    for entry in "$src"/* "$src"/.[!.]*; do
+      [ -e "$entry" ] || continue
+      name="$(basename "$entry")"
+      [ "$name" = "settings.json" ] && continue
+      ln -sfn "$entry" "$dst/$name"
+    done
+    # Account/org state lives at $HOME/.claude.json (outside .claude); Remote
+    # Control needs it to resolve org eligibility.
+    ln -sfn "/home/${username}/.claude.json" "$dst/.claude.json"
+    # settings.json = real settings with the one key the guard checks overridden.
+    jq '.env.ANTHROPIC_BASE_URL = "https://api.anthropic.com"' \
+      "$src/settings.json" > "$dst/settings.json"
+  '';
+
   startScript = pkgs.writeShellScript "claude-remote-control-start" ''
     ${pkgs.tmux}/bin/tmux kill-session -t ${sessionName} 2>/dev/null || true
     ${pkgs.tmux}/bin/tmux new-session -d -s ${sessionName} \
-      "${claudeRc} \
+      "CLAUDE_CONFIG_DIR=${configDir} ${claudeRc} \
         --spawn worktree \
         --no-create-session-in-dir \
         --capacity 8 \
@@ -195,6 +236,7 @@ in
       User = username;
       Group = "users";
       WorkingDirectory = "/home/${username}/nic-os";
+      ExecStartPre = prepConfigScript;
       ExecStart = startScript;
       ExecStop = stopScript;
       TimeoutStopSec = "10s";

--- a/rpi5/claude-remote-control.nix
+++ b/rpi5/claude-remote-control.nix
@@ -90,6 +90,15 @@ let
     ${pkgs.tmux}/bin/tmux kill-session -t ${sessionName} 2>/dev/null || true
   '';
 
+  # post-checkout hook that re-gates RC bridge worker sessions to Aperture.
+  # The bridge's isolated config forces direct Anthropic (to pass the Remote
+  # Control guard), so worker sessions spawned into worktrees would bypass the
+  # gate. This hook drops a project-level settings.json (base URL = gate) into
+  # each bridge-created worktree; workers don't run the guard, so they're free
+  # to use the gate. Guarded by CLAUDE_CONFIG_DIR → no-op for normal checkouts.
+  worktreeGateHook = pkgs.writeShellScript "claude-rc-worktree-gate"
+    (builtins.readFile ./claude-rc-worktree-gate.sh);
+
   # Build the isolated bridge config dir (see configDir note above) before each
   # start, refreshing symlinks and regenerating settings.json so it tracks any
   # change to the real ~/.claude/settings.json.
@@ -114,6 +123,15 @@ let
     # settings.json = real settings with the one key the guard checks overridden.
     jq '.env.ANTHROPIC_BASE_URL = "https://api.anthropic.com"' \
       "$src/settings.json" > "$dst/settings.json"
+
+    # Install the worktree-gate post-checkout hook (symlink to the versioned
+    # script). Only if absent or already a symlink — never clobber a foreign hook.
+    hook="/home/${username}/nic-os/.git/hooks/post-checkout"
+    if [ ! -e "$hook" ] || [ -L "$hook" ]; then
+      ln -sfn ${worktreeGateHook} "$hook"
+    else
+      echo "post-checkout hook exists and is not ours; skipping worktree-gate install" >&2
+    fi
   '';
 
   startScript = pkgs.writeShellScript "claude-remote-control-start" ''


### PR DESCRIPTION
## Problem

`claude-remote-control.service` reported a **false** `active (exited)` (`Type=oneshot`+`RemainAfterExit=true`), while the bridge actually died on every start and `claude-remote-control-watchdog.timer` respawned it every 5 min.

Root cause: claude-code ≥ 2.1.x hard-guards Remote Control — it refuses any endpoint other than `api.anthropic.com` (the bypass hook is compiled to always-false, so there's no env escape). Our global `~/.claude/settings.json` forces the Aperture gate URL (`https://ai.gate-mintaka.ts.net`), and `settings.json` `env` **outranks process env**, so `claude remote-control` printed `Error: Remote Control is only available when using Claude via api.anthropic.com.` and exited 0.

Notes from the investigation:
- The bridge options (`--spawn`, `--capacity`, `--no-create-session-in-dir`, …) are **not** removed in 2.1.x — just hidden from `--help`. They still work.
- `--settings` can't fix this: as a global option it clears the guard but breaks the hidden subcommand options' parsing; after the subcommand it doesn't clear the guard.

## Fix

Give **only the bridge** an isolated `CLAUDE_CONFIG_DIR=~/.claude-rc`, built by an `ExecStartPre`:
- Symlinks every real `~/.claude` entry (+ `$HOME/.claude.json` for org eligibility), so OAuth, sessions/projects, skills, and the `credentials.json` that `claude-oauth-extract` watches stay authoritative in `~/.claude`.
- Generates a `settings.json` = real settings with only `ANTHROPIC_BASE_URL` jq-forced to `https://api.anthropic.com` — the same escape the `claude-direct` shell alias already uses.
- `CLAUDE_CONFIG_DIR` is set inline in the tmux launch command.

Trade-off: the bridge and mobile-spawned sessions bypass the Aperture gate (consistent with the existing `claude-direct` alias); all other claude usage keeps the gate. `tiny-llm-gate`/OAuth-extract are unaffected.

## Verification (rebuilt on rpi5, live)

- `ExecStartPre` built `~/.claude-rc/` with `ANTHROPIC_BASE_URL": "https://api.anthropic.com"`.
- `claude-rc` tmux session now **persists** (stable across the watchdog window — no respawn); bridge process runs the full flag set.
- Pane: `·✔︎· Ready · nic-os`, `Capacity: 0/8`, environment registered for mobile/claude.ai. No guard error.
- Confirmed the credential-refresh preserves the `.credentials.json` symlink, so the `tiny-llm-gate` token path is intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)