### PR TITLE
feat(claude-rc): re-gate remote-control worker sessions through Aperture

### DIFF
--- a/rpi5/claude-rc-worktree-gate.sh
+++ b/rpi5/claude-rc-worktree-gate.sh
@@ -1,0 +1,36 @@
+# post-checkout hook (managed by claude-remote-control.nix, symlinked into
+# .git/hooks/post-checkout at bridge start).
+#
+# When the Remote Control bridge spawns an isolated worktree for a mobile /
+# claude.ai session, that worker inherits the bridge's isolated CLAUDE_CONFIG_DIR
+# (~/.claude-rc), whose settings.json forces ANTHROPIC_BASE_URL=api.anthropic.com
+# to satisfy the Remote Control guard. Workers themselves do NOT run that guard,
+# so we re-gate them here: drop a project-level settings.json in the new worktree
+# pointing the base URL back at the Aperture gate, restoring observability for
+# remote-control session traffic. (The bridge's own control-plane stays direct.)
+#
+# Guarded by CLAUDE_CONFIG_DIR so it is a fast no-op for the user's normal
+# checkouts and for other agents' worktrees. Never overwrites an existing
+# settings.json.
+
+case "${CLAUDE_CONFIG_DIR:-}" in
+  */.claude-rc) ;;
+  *) exit 0 ;;
+esac
+
+top=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+case "$top" in
+  */.claude/worktrees/*) ;;
+  *) exit 0 ;;
+esac
+
+[ -f "$top/.claude/settings.json" ] && exit 0
+
+# Single source of truth = the real user settings' gate URL; fall back to the
+# known gate host if jq or the file is unavailable.
+gate=$(jq -r '.env.ANTHROPIC_BASE_URL // empty' "$HOME/.claude/settings.json" 2>/dev/null || true)
+[ -n "$gate" ] || gate="https://ai.gate-mintaka.ts.net"
+
+mkdir -p "$top/.claude"
+printf '{"env":{"ANTHROPIC_BASE_URL":"%s"}}\n' "$gate" > "$top/.claude/settings.json"
+exit 0

--- a/rpi5/claude-remote-control.nix
+++ b/rpi5/claude-remote-control.nix
@@ -90,6 +90,15 @@ let
     ${pkgs.tmux}/bin/tmux kill-session -t ${sessionName} 2>/dev/null || true
   '';
 
+  # post-checkout hook that re-gates RC bridge worker sessions to Aperture.
+  # The bridge's isolated config forces direct Anthropic (to pass the Remote
+  # Control guard), so worker sessions spawned into worktrees would bypass the
+  # gate. This hook drops a project-level settings.json (base URL = gate) into
+  # each bridge-created worktree; workers don't run the guard, so they're free
+  # to use the gate. Guarded by CLAUDE_CONFIG_DIR → no-op for normal checkouts.
+  worktreeGateHook = pkgs.writeShellScript "claude-rc-worktree-gate"
+    (builtins.readFile ./claude-rc-worktree-gate.sh);
+
   # Build the isolated bridge config dir (see configDir note above) before each
   # start, refreshing symlinks and regenerating settings.json so it tracks any
   # change to the real ~/.claude/settings.json.
@@ -114,6 +123,15 @@ let
     # settings.json = real settings with the one key the guard checks overridden.
     jq '.env.ANTHROPIC_BASE_URL = "https://api.anthropic.com"' \
       "$src/settings.json" > "$dst/settings.json"
+
+    # Install the worktree-gate post-checkout hook (symlink to the versioned
+    # script). Only if absent or already a symlink — never clobber a foreign hook.
+    hook="/home/${username}/nic-os/.git/hooks/post-checkout"
+    if [ ! -e "$hook" ] || [ -L "$hook" ]; then
+      ln -sfn ${worktreeGateHook} "$hook"
+    else
+      echo "post-checkout hook exists and is not ours; skipping worktree-gate install" >&2
+    fi
   '';
 
   startScript = pkgs.writeShellScript "claude-remote-control-start" ''


### PR DESCRIPTION
Stacked on #339 (needs the bridge's isolated `CLAUDE_CONFIG_DIR` from that PR).

## Problem

#339 makes the Remote Control bridge run against `api.anthropic.com` (the guard rejects any other endpoint). Worker sessions the bridge spawns into worktrees **inherit** that isolated config, so their LLM traffic bypasses the Aperture gate. Verified live — running workers had `ANTHROPIC_BASE_URL=api.anthropic.com`.

## Fix

Worker sessions don't run the Remote Control guard, so they're free to use the gate. Add a `post-checkout` git hook (`rpi5/claude-rc-worktree-gate.sh`), symlinked into `.git/hooks/` by the bridge's `ExecStartPre`, that seeds a project-level `.claude/settings.json` (base URL = the gate, read from the real user settings) into each bridge-created worktree. Project settings outrank the shadow user settings, so the worker routes through Aperture; the bridge control-plane stays direct (nothing to observe there).

Guarded by `CLAUDE_CONFIG_DIR=*/.claude-rc` → strict no-op for normal `git checkout`s and other agents' worktrees; never clobbers an existing hook.

## Verification (no rebuild — all read-only on live rpi5)

- Worktree project settings override the shadow config at the **transport level** (a worker-style `claude` connected to the override URL).
- `git worktree add` fires `post-checkout` with the worktree as toplevel; no existing hook present.
- Hook validated in all 3 cases: seeds in bridge context ✓, no-op without `CLAUDE_CONFIG_DIR` ✓, no-op outside `worktrees/` ✓.

Note: only worktrees created **after** deploy take effect; already-running workers age out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)