### PR TITLE
feat(claude): idle+PushNotification Telegram gate; fix immich caption year order

### DIFF
--- a/home/claude.nix
+++ b/home/claude.nix
@@ -42,10 +42,6 @@ let
     value.source = "${sharedSkillsDir}/${name}/SKILL.md";
   }) claudeSlashCommandSkills);
 
-  notifyScript = (import ../shared/telegram-notify.nix { inherit pkgs; }) {
-    name = "claude";
-    source = "Claude Code";
-  };
   claudeCodePkg = unstablePkgs.claude-code.overrideAttrs (old: {
     nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ pkgs.makeWrapper ];
     # The vendored vendor/ripgrep/arm64-linux/rg in claude-code's npm package
@@ -141,10 +137,13 @@ in
     "MyDocuments/TRUSK/CLAUDE.md".source =
       config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/nic-os/home/dotfiles/trusk-CLAUDE.md";
 
-    # Stable path for the Telegram notify hook so settings.json doesn't
-    # need to embed a Nix store path that changes on rebuild.
-    ".claude/hooks/telegram-notify" = {
-      source = notifyScript;
+    # Unified Telegram notify gate (see home/scripts/claude-notify.sh). Wired
+    # under three hook events in claude-settings.json: UserPromptSubmit
+    # (`activity`), Notification (`notification`, idle-gated), and
+    # PostToolUse/PushNotification (`push`, always through). Shared with the
+    # remote-control bridge via the ~/.claude-rc/hooks symlink.
+    ".claude/hooks/claude-notify" = {
+      source = ./scripts/claude-notify.sh;
       executable = true;
     };
 

--- a/home/dotfiles/claude-settings.json
+++ b/home/dotfiles/claude-settings.json
@@ -144,13 +144,35 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$HOME/.claude/hooks/telegram-notify",
+            "command": "$HOME/.claude/hooks/claude-notify notification",
             "timeout": 10
           }
         ]
       }
     ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/claude-notify activity",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
+      {
+        "matcher": "PushNotification",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/hooks/claude-notify push",
+            "timeout": 10
+          }
+        ]
+      },
       {
         "matcher": "Write|Edit",
         "hooks": [

--- a/home/scripts/claude-notify.sh
+++ b/home/scripts/claude-notify.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Unified Claude Code -> Telegram notification gate. One script, three modes
+# (passed as $1) so the POST-to-aggregator logic lives in exactly one place:
+#
+#   activity      UserPromptSubmit hook. Stamps "the user is present right now"
+#                 into ~/.claude/state/last-activity. No forward.
+#   notification  Notification hook. Forwards to the central Telegram aggregator
+#                 (rpi5/claude-notify-aggregator.py) ONLY if the user has been
+#                 idle for >= CLAUDE_IDLE_NOTIFY_SECONDS. While the user is
+#                 actively working these are dropped, killing routine spam.
+#   push          PostToolUse(PushNotification) hook. Always forwards, flagged
+#                 immediate so the aggregator flushes at once — this is the
+#                 channel Claude uses when it decides an interruption is worth it.
+#
+# State (~/.claude/state) and this hooks dir are shared with the remote-control
+# bridge (~/.claude-rc symlinks both back here), so interactive and remote
+# sessions gate off the same activity clock.
+#
+# Always exits 0 — a hook must never block the agent.
+set +e
+
+STATE_DIR="${HOME}/.claude/state"
+ACTIVITY_FILE="${STATE_DIR}/last-activity"
+# "super idle" threshold; override with CLAUDE_IDLE_NOTIFY_SECONDS. Default 15m.
+IDLE_THRESHOLD="${CLAUDE_IDLE_NOTIFY_SECONDS:-900}"
+
+mode="$1"
+now=$(date +%s)
+
+if [ "$mode" = "activity" ]; then
+  mkdir -p "$STATE_DIR" 2>/dev/null
+  printf '%s' "$now" > "$ACTIVITY_FILE" 2>/dev/null
+  exit 0
+fi
+
+payload=$(cat 2>/dev/null)
+
+if [ "$mode" = "notification" ]; then
+  # Idle gate. A missing stamp (no prompt yet on this host) fails open so we
+  # never silently lose the first notification of a fresh session.
+  if [ -f "$ACTIVITY_FILE" ]; then
+    last=$(cat "$ACTIVITY_FILE" 2>/dev/null)
+    [ -z "$last" ] && last=0
+    if [ "$(( now - last ))" -lt "$IDLE_THRESHOLD" ]; then
+      exit 0
+    fi
+  fi
+  message=$(printf '%s' "$payload" | jq -r '.message // empty' 2>/dev/null)
+  source="Claude Code"
+  immediate="false"
+elif [ "$mode" = "push" ]; then
+  message=$(printf '%s' "$payload" | jq -r '.tool_input.message // empty' 2>/dev/null)
+  source="Claude PushNotification"
+  immediate="true"
+else
+  exit 0
+fi
+
+cwd=$(printf '%s' "$payload" | jq -r '.cwd // ""' 2>/dev/null)
+project=$(basename "${cwd:-unknown}")
+host=$(uname -n)
+
+body=$(jq -nc \
+  --arg host "$host" \
+  --arg project "$project" \
+  --arg message "$message" \
+  --arg source "$source" \
+  --argjson immediate "$immediate" \
+  '{host:$host, project:$project, message:$message, source:$source, immediate:$immediate}')
+
+# rpi5 hits the aggregator on loopback; other hosts fall back to the tailnet
+# FQDN. -m 4 bounds the wait so the hook can't hang the agent.
+for url in "http://127.0.0.1:8088/notify" "https://rpi5.gate-mintaka.ts.net:8088/notify"; do
+  if curl -fsS -m 4 -X POST "$url" \
+       -H 'Content-Type: application/json' \
+       --data-raw "$body" >/dev/null 2>&1; then
+    break
+  fi
+done
+exit 0

--- a/rpi5/claude-notify-aggregator.py
+++ b/rpi5/claude-notify-aggregator.py
@@ -61,15 +61,24 @@ def _format_line(host, project, message):
     return f"📁 {label}: {message or 'waiting for input'}"
 
 
-def add_event(host, project, message):
+def add_event(host, project, message, immediate=False):
     global _first_ts, _last_ts
     line = _format_line(host, project, message)
     now = time.time()
+    snapshot = None
     with _lock:
         if not _pending:
             _first_ts = now
         _pending[line] = _pending.get(line, 0) + 1
         _last_ts = now
+        # A PushNotification is an explicit "interrupt me now" from the agent,
+        # so flush the whole pending batch immediately instead of waiting out
+        # the quiet window. Snapshot under the lock, send outside it.
+        if immediate:
+            snapshot = dict(_pending)
+            _pending.clear()
+    if snapshot is not None:
+        _send(_build_text(snapshot))
 
 
 def _send(text):
@@ -141,6 +150,7 @@ class Handler(BaseHTTPRequestHandler):
             str(payload.get("host", "")),
             str(payload.get("project", "")),
             str(payload.get("message", "")),
+            immediate=bool(payload.get("immediate", False)),
         )
         self._respond()
 

--- a/rpi5/picoclaw/skills/immich-memories/scripts/immich-on-this-day.py
+++ b/rpi5/picoclaw/skills/immich-memories/scripts/immich-on-this-day.py
@@ -216,7 +216,8 @@ def run_download(memories, base, api_key, out_dir, top, per_memory, max_total):
     if total_memories:
         caption = f"📸 {french_date(datetime.now())}"
         if per_year:
-            caption += "\n" + ", ".join(f"{y} ({per_year[y]})" for y in sorted(per_year))
+            # Newest year first — most recent memories read at the top.
+            caption += "\n" + ", ".join(f"{y} ({per_year[y]})" for y in sorted(per_year, reverse=True))
     else:
         caption = ""
 


### PR DESCRIPTION
Two Telegram-scope changes.

## 1. Notification gate (main)

Cuts Claude Code → Telegram noise to two channels:
- **Super idle** — the `Notification` hook forwards only after **≥ `CLAUDE_IDLE_NOTIFY_SECONDS` (default 900s / 15 min)** of no prompt activity. A new `UserPromptSubmit` hook stamps `~/.claude/state/last-activity`. While you're actively prompting, routine notifications are dropped.
- **PushNotification** — a `PostToolUse(PushNotification)` hook always forwards, flagged `immediate`, so the aggregator flushes it at once instead of waiting out the 300s quiet window.

One script, three modes: `home/scripts/claude-notify.sh` (`activity` | `notification` | `push`). State + hooks dir are shared with the remote-control bridge via `~/.claude-rc` symlinks and the bridge derives its settings from `~/.claude/settings.json`, so interactive + remote sessions gate off the same clock. `shared/telegram-notify.nix` is untouched (still serves Pi).

`rpi5/claude-notify-aggregator.py` honors an `immediate` field that flushes the pending batch inline.

## 2. Immich caption year order

`rpi5/picoclaw/skills/immich-memories/…/immich-on-this-day.py`: the "on this day" caption listed per-year counts oldest→newest; inverted to newest→oldest (`2020 (1), 2018 (3), 2015 (2)`).

## Verified

- Notification gate tested against the **deployed** hook: active→suppressed, idle(16m)→POST `immediate:false`, push→POST `immediate:true` (2 POSTs from 3 events).
- Aggregator unit test: normal events pool; `immediate` flushes the batch inline.
- Caption reorder demonstrated; `py_compile` clean.
- `nix eval` green for `nsimon@rpi5` and `rpi5`. Home-manager already switched (hooks live).

## Deploy (needs sudo)

`~/nic-os` is checked out (detached) at this branch tip. Home-manager is already switched. Remaining:

```
sudo nixos-rebuild-safe switch --flake /home/nsimon/nic-os#rpi5   # aggregator immediate flush + immich caption
sudo systemctl restart claude-remote-control.service              # regenerate bridge settings (no auto-restart)
```

Tune with `CLAUDE_IDLE_NOTIFY_SECONDS` if 15 min isn't "super idle" enough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)