### PR TITLE
feat(beast): PoE2 price-check overlays (Sidekick, Exiled Exchange 2, Waystone)

### DIFF
--- a/nixos/dotfiles/hypr/hyprland.conf
+++ b/nixos/dotfiles/hypr/hyprland.conf
@@ -197,6 +197,16 @@ windowrule = workspace 1, title:^(Zen Twilight)$
 windowrule = workspace 2, class:^(steam)$
 windowrule = workspace 2, class:^(steam_app_default)$
 
+# Path of Exile 2 + Sidekick companion overlay → workspace 3 (primary ultrawide).
+# Sidekick (native Wayland, class "Sidekick") must float so it isn't tiled beside
+# the game and can sit over it. For the overlay to draw on top, run PoE in
+# "Windowed Fullscreen", not exclusive fullscreen.
+windowrule = workspace 3, class:^(steam_app_2694490)$   # Path of Exile 2
+# windowrule = workspace 3, class:^(steam_app_238960)$  # Path of Exile 1 (uncomment if you play PoE1)
+windowrule = workspace 3, class:^(Sidekick)$
+windowrule = float,       class:^(Sidekick)$
+windowrule = pin,         class:^(Sidekick)$   # keep overlay always above PoE (pin = on top; also shows on all workspaces)
+
 windowrulev2 = suppressevent fullscreen maximize, class:^(rsi launcher\.exe)$
 windowrulev2 = workspace 2, class:^(rsi launcher\.exe)$
 # windowrule = workspace 2, class:^(rsi launcher)

--- a/nixos/packages.nix
+++ b/nixos/packages.nix
@@ -88,6 +88,13 @@ in
     })
     
     inputs.nix-citizen.packages.${pkgs.stdenv.hostPlatform.system}.rsi-launcher
+
+    # Path of Exile companion trade tool (wrapped AppImage — see ../pkgs/sidekick.nix)
+    (pkgs.callPackage ../pkgs/sidekick.nix { })
+    # PoE2 price-check overlay, alternative to Sidekick (../pkgs/exiled-exchange-2.nix)
+    (pkgs.callPackage ../pkgs/exiled-exchange-2.nix { })
+    # Wayland-native PoE2 price-check overlay for Hyprland (../pkgs/waystone.nix)
+    (pkgs.callPackage ../pkgs/waystone.nix { })
   ];
 
 }

--- a/pkgs/exiled-exchange-2.nix
+++ b/pkgs/exiled-exchange-2.nix
@@ -1,0 +1,53 @@
+# Exiled Exchange 2 — a Path of Exile 2 price-check / trade overlay
+# (Kvan7/Exiled-Exchange-2), the community fork of Awakened PoE Trade.
+#
+# Electron app shipped only as a prebuilt AppImage → wrapped with
+# appimageTools.wrapType2, like sidekick.nix / opentrack-tobii.
+#
+# appimageTools' default FHS already covers Chromium/Electron's big dependency
+# set. The extras it does NOT cover are the X11 libs the global-hotkey addon
+# (uiohook-napi → node.napi.node) links against — libXtst (XTEST) and libXt —
+# without which the hook can't attach and no keystroke is ever caught (same
+# failure mode we hit with Sidekick's libuiohook).
+{
+  appimageTools,
+  fetchurl,
+}:
+let
+  pname = "exiled-exchange-2";
+  version = "0.15.8"; # upstream tag is v${version}
+
+  src = fetchurl {
+    url = "https://github.com/Kvan7/Exiled-Exchange-2/releases/download/v${version}/Exiled-Exchange-2-${version}.AppImage";
+    hash = "sha256-xmEvKJkRFJokzOa/6qRqT4+QKfnfjIoAfqP+oDqyxH8=";
+  };
+
+  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  extraPkgs = pkgs: [
+    pkgs.xorg.libXtst
+    pkgs.xorg.libXt
+  ];
+
+  # Desktop entry + icon from the AppImage, Exec rewritten to the wrapped binary.
+  # StartupWMClass stays "Exiled Exchange 2" so Hyprland rules can match it.
+  extraInstallCommands = ''
+    install -Dm444 ${appimageContents}/${pname}.png \
+      "$out/share/icons/hicolor/512x512/apps/${pname}.png"
+    install -Dm444 ${appimageContents}/${pname}.desktop \
+      "$out/share/applications/${pname}.desktop"
+    substituteInPlace "$out/share/applications/${pname}.desktop" \
+      --replace-fail "Exec=AppRun --sandbox %U" "Exec=${pname} %U" \
+      --replace-fail "Icon=exiled-exchange-2" "Icon=${pname}"
+  '';
+
+  meta = {
+    description = "Path of Exile 2 price-check overlay (fork of Awakened PoE Trade)";
+    homepage = "https://github.com/Kvan7/Exiled-Exchange-2";
+    mainProgram = "exiled-exchange-2";
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/sidekick.nix
+++ b/pkgs/sidekick.nix
@@ -1,0 +1,80 @@
+# Sidekick — a companion trade tool for Path of Exile 1 & 2 (Sidekick-Poe/Sidekick).
+# Price-checks items, checks map modifiers, cheat sheets, etc.
+#
+# Upstream ships only a prebuilt AppImage (not in nixpkgs, no source build), so
+# we wrap it with appimageTools.wrapType2 — same approach as opentrack-tobii in
+# nixos/tobii-native.nix.
+#
+# It's a framework-dependent .NET app (a Photino/webview UI), so unlike a
+# self-contained AppImage it needs its runtime libs injected via extraPkgs:
+#   - dotnet-runtime_8  → the .NET 8 shared framework the app is published against
+#   - webkitgtk_4_1     → the WebKitGTK 4.1 webview the UI renders in
+#   - libnotify         → libnotify.so.4, a hard DT_NEEDED of Photino.Native.so
+#                         (dlopen fails without it even with notifications disabled)
+#   - xsel              → clipboard access used for in-game item price checks
+# (mirrors upstream's documented deps: dotnet-runtime-8.0, webkit2gtk-4.1, xsel;
+#  libnotify is implied by the Photino native lib but undocumented upstream.)
+{
+  appimageTools,
+  fetchurl,
+}:
+let
+  pname = "sidekick-poe";
+  version = "2026.7.1"; # upstream tag is v${version}
+
+  src = fetchurl {
+    url = "https://github.com/Sidekick-Poe/Sidekick/releases/download/v${version}/Sidekick-linux-stable.AppImage";
+    hash = "sha256-7W+9179+ILBDfqgFuP6+SwvBpwIjTpEEwkZpwputEVU=";
+  };
+
+  # Extracted AppImage tree — used only to lift out the bundled .desktop + icon
+  # so the app shows up in rofi/dmenu (wrapType2 alone installs just the binary).
+  appimageContents = appimageTools.extractType2 { inherit pname version src; };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  extraPkgs = pkgs: [
+    pkgs.dotnet-runtime_8
+    pkgs.webkitgtk_4_1
+    pkgs.libnotify
+    pkgs.xsel
+
+    # Global hotkey capture: SharpHook ships libuiohook.so, which is X11-only on
+    # Linux (XRecord to listen, XTest to inject). Without these its dlopen fails
+    # silently — the C# keybind handlers still "initialize" but the native hook
+    # attaches to nothing, so no keystroke is ever caught. On Wayland it hooks
+    # the shared Xwayland, so it only sees keys while an XWayland window (the
+    # game, under Proton) is focused — which is fine for the in-game use case.
+    pkgs.xorg.libX11
+    pkgs.xorg.libXtst
+    pkgs.xorg.libXt
+    pkgs.xorg.libXinerama
+    pkgs.libxkbcommon
+
+    # Tray icon: NotificationIcon.NET ships libnotification_icon.so, which needs
+    # libappindicator3 (+ gtk3, pulled in via webkitgtk). Missing it only trips
+    # an ErrorBoundary for the tray, not the whole app — but this clears it.
+    pkgs.libappindicator-gtk3
+  ];
+
+  # Ship a desktop entry pointing at the wrapped binary (Exec/Icon rewritten from
+  # the AppImage's own Sidekick.desktop). Keep StartupWMClass=Sidekick so Wayland
+  # window rules can still match it.
+  extraInstallCommands = ''
+    install -Dm444 ${appimageContents}/Sidekick.png \
+      "$out/share/icons/hicolor/256x256/apps/${pname}.png"
+    install -Dm444 ${appimageContents}/Sidekick.desktop \
+      "$out/share/applications/${pname}.desktop"
+    substituteInPlace "$out/share/applications/${pname}.desktop" \
+      --replace-fail "Exec=Sidekick" "Exec=${pname}" \
+      --replace-fail "Icon=Sidekick" "Icon=${pname}"
+  '';
+
+  meta = {
+    description = "Companion trade tool for Path of Exile 1 & 2";
+    homepage = "https://sidekick-poe.github.io/";
+    mainProgram = "sidekick-poe";
+    platforms = [ "x86_64-linux" ];
+  };
+}

--- a/pkgs/waystone.nix
+++ b/pkgs/waystone.nix
@@ -1,0 +1,139 @@
+# Waystone — a Wayland-native Path of Exile 2 price-check overlay (kriskruse/Waystone).
+#
+# Unlike the Electron tools (Exiled Exchange 2, Awakened PoE Trade), Waystone is
+# built for Hyprland/wlroots: it renders through gtk4-layer-shell and binds its
+# global hotkeys via the xdg-desktop-portal GlobalShortcuts API — the two things
+# Electron refuses to do on Wayland. So it needs NO XWayland hacks or `pass` binds.
+#
+# Two processes over a Unix socket:
+#   - poed  (Python 3.12 + GTK4/gtk4-layer-shell) — overlay, portal hotkeys,
+#            wl-clipboard, xdotool Ctrl+C injection into the (XWayland) game.
+#   - brain (Node/TS, esbuild-bundled) — item parser + trade2/poe2scout pricing.
+#            poed spawns it as `node dist/server.mjs`; parser/data vendored from
+#            Exiled Exchange 2 under brain/vendor/ee2/public.
+#
+# Two NixOS-specific fixes vs upstream's Arch PKGBUILD:
+#   1. poed/__main__.py hardcodes LD_PRELOAD=/usr/lib/libgtk4-layer-shell.so
+#      (absent on NixOS) — the wrapper sets LD_PRELOAD to the Nix store path, so
+#      poed's own re-exec is skipped.
+#   2. __main__.py calls GLibUnix.signal_add(), which doesn't exist in nixpkgs'
+#      pygobject; the classic GLib.unix_signal_add() does — patched below.
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  buildNpmPackage,
+  python312,
+  wrapGAppsHook4,
+  gobject-introspection,
+  makeWrapper,
+  gtk4,
+  gtk4-layer-shell,
+  glib,
+  gdk-pixbuf,
+  pango,
+  graphene,
+  librsvg,
+  gsettings-desktop-schemas,
+  nodejs,
+  xdotool,
+  wl-clipboard,
+}:
+let
+  version = "0.1.1";
+
+  src = fetchFromGitHub {
+    owner = "kriskruse";
+    repo = "Waystone";
+    rev = "v${version}";
+    hash = "sha256-Vc18ROvsjH7i4yIfD5Pm7ewkko1rmRoeg4eZU0BXCCw=";
+  };
+
+  # Node "brain": esbuild bundle (self-contained, no runtime node_modules) plus
+  # the vendored EE2 game data the bundle resolves at ../vendor/ee2/public.
+  brain = buildNpmPackage {
+    pname = "waystone-brain";
+    inherit version src;
+    sourceRoot = "${src.name}/brain";
+    npmDepsHash = "sha256-AxaolaQHkRIVOozvlPmOSkFfcuSRuPZ76/aTgPSTPBQ=";
+    # `npm run build` (esbuild) is the default npmBuildScript; keep it.
+    installPhase = ''
+      runHook preInstall
+      mkdir -p "$out/dist" "$out/vendor/ee2"
+      cp dist/server.mjs "$out/dist/"
+      cp -r vendor/ee2/public "$out/vendor/ee2/public"
+      runHook postInstall
+    '';
+  };
+
+  # Python "poed" library (installed into a python env below).
+  poed = python312.pkgs.buildPythonPackage {
+    pname = "waystone-poed";
+    inherit version src;
+    pyproject = true;
+    sourceRoot = "${src.name}/poed";
+    build-system = [ python312.pkgs.setuptools ];
+    dependencies = with python312.pkgs; [
+      pygobject3
+      numpy
+      opencv4
+      pycairo
+    ];
+    # Fix #2: GLibUnix.signal_add → GLib.unix_signal_add (GLib is already imported).
+    postPatch = ''
+      substituteInPlace poed/__main__.py \
+        --replace-fail "GLibUnix.signal_add(" "GLib.unix_signal_add("
+    '';
+    # Importing poed pulls in GTK/GI + a display; can't run in the sandbox.
+    doCheck = false;
+    pythonImportsCheck = [ ];
+    # pyproject declares "opencv-python"; nixpkgs provides the same cv2 module as
+    # `opencv4` (dist name "opencv"), so the runtime-deps name check misfires.
+    dontCheckRuntimeDeps = true;
+  };
+
+  pythonEnv = python312.withPackages (_: [ poed ]);
+in
+stdenvNoCC.mkDerivation {
+  pname = "waystone";
+  inherit version;
+
+  dontUnpack = true;
+
+  # wrapGAppsHook4 + gobject-introspection populate GI_TYPELIB_PATH (Gtk-4.0,
+  # Gtk4LayerShell-1.0, GLibUnix-2.0, …), XDG_DATA_DIRS (gsettings schemas) and
+  # the gdk-pixbuf loaders onto the launcher.
+  nativeBuildInputs = [
+    wrapGAppsHook4
+    gobject-introspection
+    makeWrapper
+  ];
+  buildInputs = [
+    gtk4
+    gtk4-layer-shell
+    glib
+    gdk-pixbuf
+    pango
+    graphene
+    librsvg
+    gsettings-desktop-schemas
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    makeWrapper ${pythonEnv}/bin/python "$out/bin/waystone" \
+      --add-flags "-m poed" \
+      --set LD_PRELOAD ${gtk4-layer-shell}/lib/libgtk4-layer-shell.so \
+      --set WAYSTONE_BRAIN_DIR ${brain} \
+      --prefix PATH : ${lib.makeBinPath [ nodejs xdotool wl-clipboard ]}
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Wayland-native Path of Exile 2 price-check overlay (Hyprland, gtk4-layer-shell + portal hotkeys)";
+    homepage = "https://github.com/kriskruse/Waystone";
+    license = with lib.licenses; [ agpl3Plus mit ]; # project AGPL; vendored EE2 data MIT
+    mainProgram = "waystone";
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
Adds three Path of Exile 1/2 trade / price-check companion tools as wrapped packages on beast, plus Hyprland window rules.

## Packages (repo-root `pkgs/`, wired into `nixos/packages.nix`)
- **`sidekick.nix`** — .NET/Photino AppImage (`wrapType2` + `dotnet-runtime_8` / `webkitgtk_4_1` / `libnotify` / `xsel`).
- **`exiled-exchange-2.nix`** — Electron AppImage overlay; adds `libXtst`/`libXt` so the global-hotkey addon (`uiohook-napi`) can attach.
- **`waystone.nix`** — Wayland-native overlay via `gtk4-layer-shell` + the xdg-desktop-portal GlobalShortcuts API (no XWayland hacks).

## Hyprland (`nixos/dotfiles/hypr/hyprland.conf`)
- PoE2 → workspace 3; Sidekick overlay set to `float` + `pin` so it draws over the game (run PoE in windowed-fullscreen).

Captured from beast's working tree.