### PR TITLE
fix(claude): /run/wrappers/bin on wrapper PATH so bridge sessions can sudo

### DIFF
--- a/home/claude.nix
+++ b/home/claude.nix
@@ -50,6 +50,7 @@ let
     # system rg via USE_BUILTIN_RIPGREP=0 + PATH prefix.
     postFixup = (old.postFixup or "") + ''
       wrapProgram $out/bin/claude \
+        --prefix PATH : /run/wrappers/bin \
         --prefix PATH : ${pkgs.ripgrep}/bin \
         --set USE_BUILTIN_RIPGREP 0 \
         --set GIT_SSH_COMMAND "ssh -i ~/.ssh/ai_id_ed25519 -o IdentityAgent=none" \


### PR DESCRIPTION
## Problem
`claude-remote-control` worker sessions inherit the service's PATH, which has `/run/current-system/sw/bin` but **not** `/run/wrappers/bin`. On NixOS the *setuid* `sudo` lives only in `/run/wrappers/bin`; the copy in `sw/bin` isn't setuid. So `sudo` in a bridge session resolved to the non-setuid binary and failed:

```
sudo: /run/current-system/sw/bin/sudo must be owned by uid 0 and have the setuid bit set
```

A normal login shell has `/run/wrappers/bin` (via PAM), which is why `sudo` works in your terminal but not for bridge-spawned Claude sessions.

## Fix
Prepend `/run/wrappers/bin` in the `claude` `wrapProgram` so every Claude process (interactive **and** bridge, since `~/.claude/bin/claude-rc` execs the wrapped binary) resolves setuid wrappers like a login shell.

Verified the setuid wrapper works fine under the agent sandbox — only the PATH ordering was wrong.

## Takes effect
- New interactive `claude` sessions after deploy.
- Bridge worker sessions after the next `claude-remote-control` restart (not restarting it now, per request).
- Current running sessions keep their old PATH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)