### PR TITLE
fix(backups): dump airtrail, ghostfolio, paperless, reactive-resume to Storj

### DIFF
--- a/rpi5/backups.nix
+++ b/rpi5/backups.nix
@@ -6,7 +6,19 @@
   services.postgresqlBackup = {
     enable = true;
     location = "/mnt/data/backups/postgresql";
-    databases = [ "affine" "dawarich" "sure_production" "nextcloud_production" ];
+    # forgejo adds itself in forgejo.nix; immich dumps its own DB to
+    # /mnt/data/immich/backups. Everything else with a Postgres DB is listed
+    # here so the nightly dump lands on /mnt/data and reaches Storj via restic.
+    databases = [
+      "affine"
+      "dawarich"
+      "sure_production"
+      "nextcloud_production"
+      "airtrail"
+      "ghostfolio"
+      "paperless_production"
+      "reactive_resume"
+    ];
     compression = "gzip";
     startAt = "*-*-* 03:00:00";
   };


### PR DESCRIPTION
## Problem
Audit of Postgres backup coverage found that **restic → Storj only backs up `/mnt/data`**, but the live PG cluster lives at `/var/lib/postgresql/17` — outside that path. A database only reaches Storj if something dumps it into `/mnt/data/backups/` first.

Four of the eleven Postgres databases had **no dump job**, so they were absent from off-site backup entirely:

| DB | Was in Storj? |
|----|---------------|
| airtrail | ❌ |
| ghostfolio | ❌ |
| paperless_production | ❌ |
| reactive_resume | ❌ |

(affine, dawarich, sure_production, nextcloud_production dumped here; forgejo via `forgejo.nix`; immich via its own dump. SQLite hass/open-webui/vaultwarden/wakapi already covered.)

## Fix
Add the four uncovered DBs to `services.postgresqlBackup.databases`.

## Verify after rebuild
```
systemctl start postgresqlBackup-airtrail.service   # + ghostfolio/paperless_production/reactive_resume
ls -la /mnt/data/backups/postgresql/   # airtrail.sql.gz etc. present
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)